### PR TITLE
test(KEN-1241): kendex-core refusal families as tables [no-changelog]

### DIFF
--- a/crates/core/src/apply/tests.rs
+++ b/crates/core/src/apply/tests.rs
@@ -27,6 +27,18 @@ fn plan(scope: Scope, ops: Vec<PlannedOp>) -> Plan {
     Plan::landed(scope, ops).expect("a plan whose targets stay in their scope")
 }
 
+/// The rollback a precondition that no longer holds produces, its cause
+/// the stale path.
+fn assert_stale(error: &CoreError, at: &Path) {
+    match error {
+        CoreError::RolledBack { cause, .. } => match &**cause {
+            CoreError::PlanStale { path } => assert_eq!(path, at),
+            other => panic!("expected a stale plan, got {other:?}"),
+        },
+        other => panic!("expected a rollback, got {other:?}"),
+    }
+}
+
 /// A refusal part-way through takes the ops before it back with it: the
 /// first op's bytes are restored, and the bytes the refusal protected are
 /// left exactly as the outside writer left them.
@@ -67,7 +79,7 @@ fn a_refusal_part_way_through_rolls_back_what_ran_before_it() {
     fs::write(&second, "not kendex's").unwrap();
 
     let error = execute(&env, &plan).unwrap_err();
-    assert!(matches!(error, CoreError::RolledBack { .. }));
+    assert_stale(&error, &second);
     assert_eq!(fs::read_to_string(&target).unwrap(), "before");
     assert_eq!(fs::read_to_string(&second).unwrap(), "not kendex's");
 
@@ -111,40 +123,191 @@ fn an_edit_over_bytes_that_are_not_utf8_refuses_and_leaves_them() {
     assert_eq!(fs::read(&path).unwrap(), held, "the bytes are as they were");
 }
 
-/// A refused write makes nothing on its way to refusing.
-///
-/// The order is load-bearing, not tidy: `mutated_before_failure` reads a
-/// `PlanStale` as proof the op ran nothing, so a directory chain the op
-/// created before refusing is journaled absent, left out of the restore
-/// set, and survives the rollback. What is left is the empty `.claude/`
-/// that harness and project detection read as an installation.
-#[test]
-fn a_refused_write_makes_no_directory_and_a_passing_one_does() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = env_in(tmp.path());
-    let root = tmp.path().join(".claude");
-    let target = root.join("skills/ship/SKILL.md");
+/// Why one op was refused: its precondition no longer held at the path,
+/// or the path could not be read at all.
+enum Cause {
+    Stale,
+    #[cfg_attr(
+        not(unix),
+        allow(dead_code, reason = "built only by the permission-bit row")
+    )]
+    Unreadable,
+}
 
-    // Nothing is at the path, so a precondition binding to bytes refuses.
-    let refused = execute(
-        &env,
-        &write_plan(
-            Scope::Global,
-            target.clone(),
-            "body",
-            Pre::HashIs {
-                hash: "not the bytes at that path".to_owned(),
+/// One row per op the transaction refuses and rolls back, the cause named
+/// and the bytes at the path left as the outside writer left them. A
+/// write binding to bytes that are not there, a write over a file that
+/// arrived since the plan, and a removal of a copy whose bytes are not
+/// the ones the plan proved it could take are each a stale plan. A path
+/// the apply cannot read is not a path it may call removed: the record
+/// would go while the files stayed installed, and only absence the stat
+/// proves is the end state a removal asked for; that row runs where
+/// permission bits are the access control and steps aside for root, whom
+/// they do not bind.
+///
+/// A refused write also makes nothing on its way to refusing. The order
+/// is load-bearing, not tidy: `mutated_before_failure` reads a `PlanStale`
+/// as proof the op ran nothing, so a directory chain the op created
+/// before refusing is journaled absent, left out of the restore set, and
+/// survives the rollback. What is left is the empty `.claude/` that
+/// harness and project detection read as an installation. The passing
+/// half of that row, the same write with a precondition that holds, is
+/// `a_write_whose_precondition_holds_makes_its_chain`.
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one table: four refused ops rolled back by one transaction, each row an op of its own"
+)]
+fn a_refused_op_rolls_back_naming_its_cause_and_leaves_the_bytes() {
+    /// The op, the path whose bytes must survive with what they were (or
+    /// an absent path whose chain must stay absent), and a directory
+    /// whose mode is put back after the call.
+    struct Planted {
+        op: Op,
+        at: PathBuf,
+        left: Option<&'static str>,
+        #[cfg_attr(
+            not(unix),
+            allow(dead_code, reason = "set only by the permission-bit row")
+        )]
+        restore: Option<PathBuf>,
+    }
+    type Plant = fn(&Path) -> Option<Planted>;
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, Cause, Plant)> = vec![
+        (
+            "a write binding to bytes that are not there",
+            Cause::Stale,
+            |tmp| {
+                let target = tmp.join(".claude/skills/ship/SKILL.md");
+                Some(Planted {
+                    op: Op::WriteFile {
+                        path: target.clone(),
+                        bytes: b"body".to_vec(),
+                        pre: Pre::HashIs {
+                            hash: "not the bytes at that path".to_owned(),
+                        },
+                    },
+                    at: target,
+                    left: None,
+                    restore: None,
+                })
             },
         ),
-    )
-    .unwrap_err();
-    assert!(matches!(refused, CoreError::RolledBack { .. }));
-    assert!(
-        !root.exists(),
-        "a refused write left the chain it would have needed"
-    );
+        (
+            "a write over a file that arrived since the plan",
+            Cause::Stale,
+            |tmp| {
+                let target = tmp.join("file.md");
+                fs::write(&target, "changed since plan").unwrap();
+                Some(Planted {
+                    op: Op::WriteFile {
+                        path: target.clone(),
+                        bytes: b"overwrite".to_vec(),
+                        pre: Pre::Absent,
+                    },
+                    at: target,
+                    left: Some("changed since plan"),
+                    restore: None,
+                })
+            },
+        ),
+        ("a removal of a copy that changed", Cause::Stale, |tmp| {
+            let edited = tmp.join("edited.md");
+            fs::write(&edited, "not what the plan read").unwrap();
+            Some(Planted {
+                op: Op::Trash {
+                    absent_is_done: true,
+                    path: edited.clone(),
+                    pre: Pre::HashIs {
+                        hash: "what the plan read".into(),
+                    },
+                },
+                at: edited,
+                left: Some("not what the plan read"),
+                restore: None,
+            })
+        }),
+    ];
+    #[cfg(unix)]
+    rows.push((
+        "a removal of a copy nothing can read",
+        Cause::Unreadable,
+        |tmp| {
+            use std::os::unix::fs::PermissionsExt as _;
+            let sealed = tmp.join("sealed");
+            let victim = sealed.join("SKILL.md");
+            fs::create_dir_all(&sealed).unwrap();
+            fs::write(&victim, "content").unwrap();
+            fs::set_permissions(&sealed, fs::Permissions::from_mode(0o000)).unwrap();
+            if fs::symlink_metadata(&victim).is_ok() {
+                // Permissions do not bind this user (root): the read cannot be
+                // made to fail here.
+                fs::set_permissions(&sealed, fs::Permissions::from_mode(0o700)).unwrap();
+                return None;
+            }
+            Some(Planted {
+                op: Op::Trash {
+                    absent_is_done: true,
+                    path: victim.clone(),
+                    pre: Pre::Any,
+                },
+                at: victim,
+                left: Some("content"),
+                restore: Some(sealed),
+            })
+        },
+    ));
 
-    // The same write with a precondition that holds does make it.
+    for (label, cause, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let Some(planted) = plant(tmp.path()) else {
+            continue;
+        };
+        let plan = plan(
+            Scope::Global,
+            vec![PlannedOp {
+                description: label.into(),
+                op: planted.op,
+            }],
+        );
+
+        // Unlocked before anything can panic: a sealed directory outlives
+        // the TempDir that cannot remove it.
+        let outcome = execute(&env, &plan);
+        #[cfg(unix)]
+        if let Some(dir) = &planted.restore {
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(dir, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let error = outcome.unwrap_err();
+
+        match (&cause, &error) {
+            (Cause::Stale, _) => assert_stale(&error, &planted.at),
+            (Cause::Unreadable, CoreError::RolledBack { cause, .. }) => match &**cause {
+                CoreError::Io { path, .. } => assert_eq!(path, &planted.at, "{label}"),
+                other => panic!("{label}: expected the unreadable copy, got {other:?}"),
+            },
+            (Cause::Unreadable, other) => panic!("{label}: expected a rollback, got {other:?}"),
+        }
+        match planted.left {
+            Some(bytes) => assert_eq!(fs::read_to_string(&planted.at).unwrap(), bytes, "{label}"),
+            None => assert!(
+                !tmp.path().join(".claude").exists(),
+                "{label}: a refused write left the chain it would have needed"
+            ),
+        }
+    }
+}
+
+/// The same write the first row above refuses, with a precondition that
+/// holds, does make its chain.
+#[test]
+fn a_write_whose_precondition_holds_makes_its_chain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = env_in(tmp.path());
+    let target = tmp.path().join(".claude/skills/ship/SKILL.md");
     let outcome = execute(
         &env,
         &write_plan(Scope::Global, target.clone(), "body", Pre::Absent),
@@ -152,19 +315,6 @@ fn a_refused_write_makes_no_directory_and_a_passing_one_does() {
     .unwrap();
     assert_eq!(outcome.applied, 1);
     assert_eq!(fs::read_to_string(&target).unwrap(), "body");
-}
-
-#[test]
-fn stale_precondition_aborts_and_rolls_back() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = env_in(tmp.path());
-    let target = tmp.path().join("file.md");
-    fs::write(&target, "changed since plan").unwrap();
-
-    let plan = write_plan(Scope::Global, target.clone(), "overwrite", Pre::Absent);
-    let error = execute(&env, &plan).unwrap_err();
-    assert!(matches!(error, CoreError::RolledBack { .. }));
-    assert_eq!(fs::read_to_string(&target).unwrap(), "changed since plan");
 }
 
 #[test]
@@ -380,77 +530,4 @@ fn a_link_crosses_a_filesystem_boundary_into_the_trash() {
     assert!(!link.is_symlink());
     let held = fs::read_dir(env.trash_dir()).unwrap().flatten().next();
     assert_eq!(fs::read_link(held.unwrap().path()).unwrap(), gone);
-}
-
-/// A path the apply cannot read is not a path it may call removed: the
-/// record would go while the files stayed installed. Only absence the
-/// stat proves is the end state a removal asked for.
-#[cfg(unix)]
-#[test]
-fn a_copy_that_cannot_be_read_stops_the_removal() {
-    use std::os::unix::fs::PermissionsExt as _;
-    let tmp = tempfile::tempdir().unwrap();
-    let env = env_in(tmp.path());
-    let sealed = tmp.path().join("sealed");
-    let victim = sealed.join("SKILL.md");
-    fs::create_dir_all(&sealed).unwrap();
-    fs::write(&victim, "content").unwrap();
-    fs::set_permissions(&sealed, fs::Permissions::from_mode(0o000)).unwrap();
-    let unlock = || fs::set_permissions(&sealed, fs::Permissions::from_mode(0o700)).unwrap();
-    if fs::symlink_metadata(&victim).is_ok() {
-        // Permissions do not bind this user (root): the read cannot be
-        // made to fail here.
-        unlock();
-        return;
-    }
-
-    let plan = plan(
-        Scope::Global,
-        vec![PlannedOp {
-            description: "remove the copy nothing can read".into(),
-            op: Op::Trash {
-                absent_is_done: true,
-                path: victim.clone(),
-                pre: Pre::Any,
-            },
-        }],
-    );
-
-    // Unlocked before anything can panic: a sealed directory outlives the
-    // TempDir that cannot remove it.
-    let outcome = execute(&env, &plan);
-    unlock();
-    assert!(matches!(outcome.unwrap_err(), CoreError::RolledBack { .. }));
-    assert_eq!(fs::read_to_string(&victim).unwrap(), "content");
-}
-
-/// The other half of the same rule: a copy that is still there, and
-/// not the bytes the plan proved it could take, stops the apply.
-#[test]
-fn a_copy_that_changed_still_stops_the_removal() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = env_in(tmp.path());
-    let edited = tmp.path().join("edited.md");
-    fs::write(&edited, "not what the plan read").unwrap();
-
-    let plan = plan(
-        Scope::Global,
-        vec![PlannedOp {
-            description: "remove the edited copy".into(),
-            op: Op::Trash {
-                absent_is_done: true,
-                path: edited.clone(),
-                pre: Pre::HashIs {
-                    hash: "what the plan read".into(),
-                },
-            },
-        }],
-    );
-
-    let error = execute(&env, &plan).unwrap_err();
-    assert!(matches!(error, CoreError::RolledBack { .. }));
-    assert_eq!(
-        fs::read_to_string(&edited).unwrap(),
-        "not what the plan read"
-    );
 }

--- a/crates/core/src/apply/tests.rs
+++ b/crates/core/src/apply/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::env::FakeOs;
+use crate::test_util::rooted;
 use std::path::{Path, PathBuf};
 
 fn env_in(dir: &Path) -> Env {
@@ -44,12 +45,15 @@ fn assert_stale(error: &CoreError, at: &Path) {
 /// left exactly as the outside writer left them.
 #[test]
 fn a_refusal_part_way_through_rolls_back_what_ran_before_it() {
+    // Rooted: the stale path a refusal names is the canonical one, and a
+    // temp path on macOS is spelled through /var.
     let tmp = tempfile::tempdir().unwrap();
-    let env = env_in(tmp.path());
-    let target = tmp.path().join("a/file.md");
+    let root = rooted(&tmp);
+    let env = env_in(&root);
+    let target = root.join("a/file.md");
     fs::create_dir_all(target.parent().unwrap()).unwrap();
     fs::write(&target, "before").unwrap();
-    let second = tmp.path().join("b/new.md");
+    let second = root.join("b/new.md");
 
     let plan = plan(
         Scope::Global,
@@ -261,8 +265,9 @@ fn a_refused_op_rolls_back_naming_its_cause_and_leaves_the_bytes() {
 
     for (label, cause, plant) in rows {
         let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        let Some(planted) = plant(tmp.path()) else {
+        let root = rooted(&tmp);
+        let env = env_in(&root);
+        let Some(planted) = plant(&root) else {
             continue;
         };
         let plan = plan(
@@ -294,7 +299,7 @@ fn a_refused_op_rolls_back_naming_its_cause_and_leaves_the_bytes() {
         match planted.left {
             Some(bytes) => assert_eq!(fs::read_to_string(&planted.at).unwrap(), bytes, "{label}"),
             None => assert!(
-                !tmp.path().join(".claude").exists(),
+                !root.join(".claude").exists(),
                 "{label}: a refused write left the chain it would have needed"
             ),
         }

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -94,30 +94,108 @@ fn a_release_under_a_name_a_url_reserves_is_still_fetched() {
     assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
 }
 
-/// Skew, driven from both sides: the app installing a release the feed is
-/// behind, and one the feed is ahead of. Either way the pair would come out
-/// split by version rather than by failure, so nothing is written and the
-/// app's own version stays behind, which is what brings the card back to
-/// try both halves again. Build metadata is not skew — SemVer keeps it out
-/// of precedence, and the release job stamps one version into both.
+/// One row per reason the command half refuses, each moving neither half:
+/// nothing is written, the command already installed is exactly as it
+/// was, and no staged file is left. Skew, driven from both sides — the app
+/// installing a release the feed is behind, and one the feed is ahead of:
+/// either way the pair would come out split by version rather than by
+/// failure, and the app's own version staying behind is what brings the
+/// card back to try both halves again. A release that publishes no
+/// command for this machine cannot move the command installed on it, and
+/// the refusal names the target because that is the only part a person
+/// can act on. A download that fails verification, in both shapes a bad
+/// download takes, is named as the command half's: read off a card that
+/// has just been pressed, a bare signature error says nothing about which
+/// of the two halves it came from.
 #[test]
-fn a_feed_on_another_release_moves_neither_half() {
-    for offered in ["9.9.8", "10.0.0"] {
+fn the_command_half_refuses_by_name_and_moves_neither_half() {
+    /// A change to the machine the release is out on, the target and
+    /// release the app asks for, and the refusal: the whole message, or
+    /// everything of it up to the verifier's or decoder's own words.
+    type Plant = fn(&Path) -> (&'static str, &'static str);
+    type Row = (&'static str, Plant, fn() -> String, bool);
+    let rows: [Row; 5] = [
+        (
+            "the feed behind the app",
+            |_| (TARGET, "9.9.8"),
+            || {
+                format!(
+                    "the desktop app installs 9.9.8 and the release feed offers the kendex command at {RELEASE}; nothing was updated"
+                )
+            },
+            true,
+        ),
+        (
+            "the feed ahead of the app",
+            |_| (TARGET, "10.0.0"),
+            || {
+                format!(
+                    "the desktop app installs 10.0.0 and the release feed offers the kendex command at {RELEASE}; nothing was updated"
+                )
+            },
+            true,
+        ),
+        (
+            "no command for this target",
+            |_| ("sparc-unknown-none-elf", RELEASE),
+            || {
+                format!(
+                    "release {RELEASE} publishes no kendex command for sparc-unknown-none-elf, so the command installed here would be left behind; nothing was updated"
+                )
+            },
+            true,
+        ),
+        (
+            "bytes the signature does not cover",
+            |home| {
+                std::fs::write(home.join("new-command"), b"kendex AppImage bytes, and more")
+                    .unwrap();
+                (TARGET, RELEASE)
+            },
+            || {
+                "the kendex command could not be updated: the download does not verify under the pinned release key: ".to_owned()
+            },
+            false,
+        ),
+        (
+            "a body that is no signature at all",
+            |home| {
+                std::fs::write(home.join("new-command.sig"), b"not a signature").unwrap();
+                (TARGET, RELEASE)
+            },
+            || {
+                "the kendex command could not be updated: the download does not verify under the pinned release key: the signature is not base64: ".to_owned()
+            },
+            false,
+        ),
+    ];
+    for (label, plant, refusal, whole) in rows {
         let dir = tempfile::tempdir().unwrap();
         let (feed_url, installed) = a_release_is_out(&dir);
+        let (target, release) = plant(dir.path());
 
-        let refused =
-            across(&CommandBeside::Ours(installed.clone()), &feed_url, offered).unwrap_err();
+        let refused = bring_command_across(
+            &CommandBeside::Ours(installed.clone()),
+            &feed_url,
+            release,
+            target,
+            TEST_KEY,
+        )
+        .unwrap_err();
 
-        assert!(refused.contains(offered), "{offered}: {refused}");
-        assert!(refused.contains(RELEASE), "{offered}: {refused}");
-        assert!(
-            refused.contains("nothing was updated"),
-            "{offered}: {refused}"
-        );
-        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{offered}");
+        match whole {
+            true => assert_eq!(refused, refusal(), "{label}"),
+            false => assert!(refused.starts_with(&refusal()), "{label}: {refused}"),
+        }
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{label}");
+        assert!(!staged_path(&installed).exists(), "{label}");
     }
+}
 
+/// Build metadata is not skew — SemVer keeps it out of precedence, and the
+/// release job stamps one version into both.
+#[test]
+fn build_metadata_on_the_release_is_not_skew() {
     let dir = tempfile::tempdir().unwrap();
     let (feed_url, installed) = a_release_is_out(&dir);
     let build_metadata = format!("{RELEASE}+ci");
@@ -125,29 +203,6 @@ fn a_feed_on_another_release_moves_neither_half() {
         across(&CommandBeside::Ours(installed), &feed_url, &build_metadata).unwrap(),
         CommandHalf::Moved
     );
-}
-
-/// A release that publishes no command for this machine cannot move the
-/// command that is installed on it, so it moves neither half rather than
-/// leaving one behind. The refusal names the target, because that is the
-/// only part a person can act on.
-#[test]
-fn a_release_with_no_command_for_this_target_stops_the_family() {
-    let dir = tempfile::tempdir().unwrap();
-    let (feed_url, installed) = a_release_is_out(&dir);
-
-    let refused = bring_command_across(
-        &CommandBeside::Ours(installed.clone()),
-        &feed_url,
-        RELEASE,
-        "sparc-unknown-none-elf",
-        TEST_KEY,
-    )
-    .unwrap_err();
-
-    assert!(refused.contains("sparc-unknown-none-elf"), "{refused}");
-    assert!(refused.contains("nothing was updated"), "{refused}");
-    assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
 }
 
 /// Absence is not failure. A dmg or msi with no command beside it is the
@@ -168,32 +223,6 @@ fn no_command_or_one_another_installer_owns_lets_the_app_go_alone() {
             "{beside:?}"
         );
         assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{beside:?}");
-    }
-}
-
-/// The command half is signed for the same reason the app half is: the feed
-/// names a host, so a run has to be able to be handed bytes and refuse them.
-/// Driven by both shapes a bad download takes, and either way the command
-/// already installed is exactly as it was.
-#[test]
-fn a_command_binary_that_fails_verification_is_never_written() {
-    for (file, corrupt) in [
-        ("new-command", b"kendex AppImage bytes, and more".as_slice()),
-        ("new-command.sig", b"not a signature".as_slice()),
-    ] {
-        let dir = tempfile::tempdir().unwrap();
-        let (feed_url, installed) = a_release_is_out(&dir);
-        std::fs::write(dir.path().join(file), corrupt).unwrap();
-
-        let refused =
-            across(&CommandBeside::Ours(installed.clone()), &feed_url, RELEASE).unwrap_err();
-
-        assert!(
-            refused.contains("the kendex command could not be updated"),
-            "{file}: {refused}"
-        );
-        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{file}");
-        assert!(!staged_path(&installed).exists(), "{file}");
     }
 }
 

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -70,70 +70,6 @@ fn a_shared_skill_folder_adopts_the_target_and_keeps_every_tool_reading() {
     assert_eq!(after.drift, vec![]);
 }
 
-/// "Somewhere kendex has no business touching": a folder that is not a
-/// skill at all. The marker is the boundary — no SKILL.md, no adopt.
-#[cfg(unix)]
-#[test]
-fn a_link_at_a_folder_without_the_marker_still_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
-    let scope = Scope::Project {
-        root: project.clone(),
-    };
-    let elsewhere = tmp.path().join("documents");
-    fs::create_dir_all(&elsewhere).unwrap();
-    fs::write(elsewhere.join("notes.txt"), "private").unwrap();
-    fs::create_dir_all(project.join(".claude/skills")).unwrap();
-    std::os::unix::fs::symlink(&elsewhere, project.join(".claude/skills/documents")).unwrap();
-
-    let error = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "documents",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-    assert!(matches!(error, CoreError::ForeignSymlink { .. }));
-    assert!(project.join(".claude/skills/documents").is_symlink());
-    assert!(elsewhere.join("notes.txt").is_file());
-}
-
-/// A project link reaching the global shared tree is not this scope's to
-/// adopt: what sits there is a global install, which the project's lock
-/// cannot see, and capturing it under another name would steal it.
-#[cfg(unix)]
-#[test]
-fn a_project_link_into_the_global_tree_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
-    let scope = Scope::Project {
-        root: project.clone(),
-    };
-    let managed = env.global_skills_dir().join("other");
-    fs::create_dir_all(&managed).unwrap();
-    fs::write(
-        managed.join("SKILL.md"),
-        "---\nname: other\ndescription: managed elsewhere\n---\nManaged.\n",
-    )
-    .unwrap();
-    fs::create_dir_all(project.join(".claude/skills")).unwrap();
-    std::os::unix::fs::symlink(&managed, project.join(".claude/skills/stolen")).unwrap();
-
-    let error = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "stolen",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-    assert!(matches!(error, CoreError::ForeignSymlink { .. }));
-    assert!(managed.join("SKILL.md").is_file());
-}
-
 /// The same folder at the scope it belongs to is a sharing layout, not a
 /// refusal. `~/.agents/skills/<name>` is where a global install lands and
 /// where a person building this by hand puts the real folder, because
@@ -184,38 +120,6 @@ fn a_global_link_into_the_shared_tree_adopts() {
     );
 }
 
-/// Only this skill's own place in the shared tree is the finished shape.
-/// A link at one name pointing at another name's folder there would have
-/// adoption capture that folder under this name and move the original,
-/// taking a second skill's content with it.
-#[cfg(unix)]
-#[test]
-fn a_global_link_across_names_in_the_shared_tree_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let other = env.global_skills_dir().join("other");
-    fs::create_dir_all(&other).unwrap();
-    fs::write(
-        other.join("SKILL.md"),
-        "---\nname: other\ndescription: a second skill\n---\nTheirs.\n",
-    )
-    .unwrap();
-    fs::create_dir_all(env.home.join(".claude/skills")).unwrap();
-    std::os::unix::fs::symlink(&other, env.home.join(".claude/skills/alias")).unwrap();
-
-    let error = adopt(
-        &env,
-        &Scope::Global,
-        ItemKind::Skill,
-        "alias",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-    assert!(matches!(error, CoreError::ForeignSymlink { .. }));
-    assert!(other.join("SKILL.md").is_file());
-}
-
 /// The folder changing between the plan and the apply aborts the whole
 /// transaction: the trash op is bound to the bytes that were captured,
 /// so a stale snapshot can never become "the backup".
@@ -248,7 +152,15 @@ fn a_target_that_changed_after_planning_fails_the_apply() {
     .unwrap();
     fs::write(shared.join("SKILL.md"), "changed under the plan").unwrap();
 
-    assert!(crate::apply::execute(&env, &plan).is_err());
+    let failed = crate::apply::execute(&env, &plan).unwrap_err();
+    assert!(
+        matches!(
+            &failed,
+            CoreError::RolledBack { cause, .. }
+                if matches!(&**cause, CoreError::PlanStale { path } if path == &shared)
+        ),
+        "{failed:?}"
+    );
     assert!(
         shared.join("SKILL.md").is_file(),
         "the folder stays where it was"
@@ -256,88 +168,169 @@ fn a_target_that_changed_after_planning_fails_the_apply() {
     assert!(project.join(".claude/skills/browser").is_symlink());
 }
 
-/// An absolute name is not a name. `PathBuf::join` throws away the root it
-/// is joined onto, so the position adoption reads becomes the absolute
-/// path itself — a directory outside every kendex root, captured into the
-/// local source and then trashed. Refused before a path is derived.
+/// One row per link adoption may not follow, each leaving the link and
+/// what it points at exactly where they were and nothing in the trash. A
+/// folder that is not a skill at all: the marker is the boundary — no
+/// SKILL.md, no adopt. A project link reaching the global shared tree:
+/// what sits there is a global install, which the project's lock cannot
+/// see, and capturing it under another name would steal it. A global link
+/// at one name pointing at another name's folder in the shared tree, and
+/// a project link at one name into its shared tree at another: each names
+/// a second skill that already has a home, and adopting through it would
+/// capture that folder under this name and move the original, taking the
+/// second skill's content with it. Only this skill's own place in the
+/// shared tree is the finished shape, which
+/// `a_global_link_into_the_shared_tree_adopts` and
+/// `a_link_at_this_items_own_home_is_adopted` keep.
+#[cfg(unix)]
 #[test]
-fn an_absolute_name_captures_and_trashes_nothing() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
-    let scope = Scope::Project {
-        root: project.clone(),
-    };
-    let outside = tmp.path().join("elsewhere/notes");
-    fs::create_dir_all(&outside).unwrap();
-    fs::write(outside.join("SKILL.md"), "somebody else's files").unwrap();
-    fs::create_dir_all(project.join(".claude/skills")).unwrap();
+fn a_link_into_a_folder_that_is_not_this_skills_own_refuses() {
+    /// The link a tool holds, the folder it points at, and a file in
+    /// that folder with the bytes it must still hold.
+    type Plant = fn(&Env, &Path) -> (PathBuf, PathBuf, PathBuf, &'static str);
+    let rows: [(&str, bool, Plant); 4] = [
+        ("a folder without the marker", false, |_, project| {
+            let elsewhere = project.parent().unwrap().join("documents");
+            fs::create_dir_all(&elsewhere).unwrap();
+            fs::write(elsewhere.join("notes.txt"), "private").unwrap();
+            let link = project.join(".claude/skills/documents");
+            (
+                link,
+                elsewhere.clone(),
+                elsewhere.join("notes.txt"),
+                "private",
+            )
+        }),
+        (
+            "a project link into the global tree",
+            false,
+            |env, project| {
+                let managed = env.global_skills_dir().join("other");
+                fs::create_dir_all(&managed).unwrap();
+                fs::write(managed.join("SKILL.md"), "Managed.\n").unwrap();
+                let link = project.join(".claude/skills/stolen");
+                (
+                    link,
+                    managed.clone(),
+                    managed.join("SKILL.md"),
+                    "Managed.\n",
+                )
+            },
+        ),
+        (
+            "a global link across names in the shared tree",
+            true,
+            |env, home| {
+                let other = env.global_skills_dir().join("other");
+                fs::create_dir_all(&other).unwrap();
+                fs::write(other.join("SKILL.md"), "Theirs.\n").unwrap();
+                let link = home.join(".claude/skills/alias");
+                (link, other.clone(), other.join("SKILL.md"), "Theirs.\n")
+            },
+        ),
+        (
+            "a project link into its shared tree at another name",
+            false,
+            |_, project| {
+                let other = project.join(".agents/skills/browser");
+                fs::create_dir_all(&other).unwrap();
+                fs::write(other.join("SKILL.md"), "Theirs.\n").unwrap();
+                let link = project.join(".claude/skills/handmade");
+                (link, other.clone(), other.join("SKILL.md"), "Theirs.\n")
+            },
+        ),
+    ];
+    for (label, global, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = rooted(&tmp);
+        let env = Env::fake(&home, FakeOs::Linux);
+        let (scope, root) = match global {
+            true => (Scope::Global, home.clone()),
+            false => {
+                let project = home.join("app");
+                (
+                    Scope::Project {
+                        root: project.clone(),
+                    },
+                    project,
+                )
+            }
+        };
+        let (link, target, kept, body) = plant(&env, &root);
+        fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let name = link.file_name().unwrap().to_str().unwrap();
 
-    let refused = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        outside.to_str().unwrap(),
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
+        let refused = adopt(&env, &scope, ItemKind::Skill, name, &[HarnessId::Claude]).unwrap_err();
 
-    assert!(
-        matches!(refused, CoreError::AdoptNameUnusable { .. }),
-        "{refused:?}"
-    );
-    assert!(outside.join("SKILL.md").is_file());
-    assert!(!project.join(".kendex-local").exists());
-    assert!(trash_is_empty(&env));
-    // The offer a surface would draw says the same thing.
-    assert!(!can_keep_for(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        outside.to_str().unwrap(),
-        HarnessId::Claude
-    ));
+        match &refused {
+            CoreError::ForeignSymlink {
+                target: at,
+                points_to,
+            } => {
+                assert_eq!(at, &link, "{label}");
+                assert_eq!(points_to, &target, "{label}");
+            }
+            other => panic!("{label}: expected the foreign-symlink refusal, got {other:?}"),
+        }
+        assert!(link.is_symlink(), "{label}");
+        assert_eq!(fs::read_to_string(&kept).unwrap(), body, "{label}");
+        assert!(trash_is_empty(&env), "{label}");
+    }
 }
 
-/// A `..`-shaped name climbs out of the tool's skills directory: the old
+/// One row per name that is not a name, refused before a path is derived
+/// and captured and trashed nothing, with the offer a surface would draw
+/// saying the same thing. An absolute name: `PathBuf::join` throws away
+/// the root it is joined onto, so the position adoption reads becomes the
+/// absolute path itself — a directory outside every kendex root. A
+/// `..`-shaped name climbs out of the tool's skills directory: the old
 /// join put the position at `.claude/notes`, one step above where skills
-/// live, and the capture would have moved and trashed it.
+/// live. The refusal carries the name and the reason `names::item_problem`
+/// gives, whose rows are pinned in `names.rs`.
 #[test]
-fn a_traversal_name_captures_and_trashes_nothing() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
-    let scope = Scope::Project {
-        root: project.clone(),
-    };
-    let climbed = project.join(".claude/notes");
-    fs::create_dir_all(&climbed).unwrap();
-    fs::write(climbed.join("SKILL.md"), "not an item kendex was given").unwrap();
-    fs::create_dir_all(project.join(".claude/skills")).unwrap();
+fn a_name_that_is_not_a_name_captures_and_trashes_nothing() {
+    /// The folder the name would have reached, and the name as asked.
+    type Plant = fn(&Path, &Path) -> (PathBuf, String);
+    let rows: [(&str, Plant); 2] = [
+        ("an absolute name", |tmp, _| {
+            let outside = tmp.join("elsewhere/notes");
+            (outside.clone(), outside.to_str().unwrap().to_owned())
+        }),
+        ("a traversal name", |_, project| {
+            (project.join(".claude/notes"), "../notes".to_owned())
+        }),
+    ];
+    for (label, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = rooted(&tmp);
+        let env = Env::fake(&home, FakeOs::Linux);
+        let project = home.join("app");
+        let scope = Scope::Project {
+            root: project.clone(),
+        };
+        let (reached, name) = plant(&home, &project);
+        fs::create_dir_all(&reached).unwrap();
+        fs::write(reached.join("SKILL.md"), "not an item kendex was given").unwrap();
+        fs::create_dir_all(project.join(".claude/skills")).unwrap();
 
-    let refused = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "../notes",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
+        let refused =
+            adopt(&env, &scope, ItemKind::Skill, &name, &[HarnessId::Claude]).unwrap_err();
 
-    assert!(
-        matches!(refused, CoreError::AdoptNameUnusable { .. }),
-        "{refused:?}"
-    );
-    assert!(climbed.join("SKILL.md").is_file());
-    assert!(!project.join(".kendex-local").exists());
-    assert!(trash_is_empty(&env));
-    assert!(!can_keep_for(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "../notes",
-        HarnessId::Claude
-    ));
+        match &refused {
+            CoreError::AdoptNameUnusable { name: shown, .. } => {
+                assert_eq!(shown, &crate::names::shown(&name), "{label}");
+            }
+            other => panic!("{label}: expected the unusable-name refusal, got {other:?}"),
+        }
+        assert!(reached.join("SKILL.md").is_file(), "{label}");
+        assert!(!project.join(".kendex-local").exists(), "{label}");
+        assert!(trash_is_empty(&env), "{label}");
+        assert!(
+            !can_keep_for(&env, &scope, ItemKind::Skill, &name, HarnessId::Claude),
+            "{label}"
+        );
+    }
 }
 
 /// A namespaced skill sits at the tool's rendered spelling — one directory
@@ -398,44 +391,6 @@ fn a_namespaced_skill_is_adopted_at_its_rendered_position() {
     assert!(!project.join(".claude/skills/data-science").exists());
     let after = audit(&env, &scope).unwrap();
     assert_eq!(after.drift, vec![]);
-}
-
-/// A link at one name pointing into the shared tree at another names a
-/// second skill that already has a home. Adopting through it would rename
-/// that one under this name, taking its content with it.
-#[cfg(unix)]
-#[test]
-fn a_link_into_the_shared_tree_at_another_name_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
-    let scope = Scope::Project {
-        root: project.clone(),
-    };
-    let other = project.join(".agents/skills/browser");
-    fs::create_dir_all(&other).unwrap();
-    fs::write(other.join("SKILL.md"), "---\nname: browser\n---\nTheirs.\n").unwrap();
-    fs::create_dir_all(project.join(".claude/skills")).unwrap();
-    std::os::unix::fs::symlink(&other, project.join(".claude/skills/handmade")).unwrap();
-
-    let refused = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "handmade",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-
-    assert!(
-        matches!(refused, CoreError::ForeignSymlink { .. }),
-        "{refused:?}"
-    );
-    assert_eq!(
-        fs::read_to_string(other.join("SKILL.md")).unwrap(),
-        "---\nname: browser\n---\nTheirs.\n"
-    );
-    assert!(trash_is_empty(&env));
 }
 
 /// The same link pointing at this item's own home is the finished shape —

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -126,13 +126,15 @@ fn a_global_link_into_the_shared_tree_adopts() {
 #[cfg(unix)]
 #[test]
 fn a_target_that_changed_after_planning_fails_the_apply() {
+    // Rooted: the stale path the rollback names is the canonical one.
     let tmp = tempfile::tempdir().unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("app");
     let scope = Scope::Project {
         root: project.clone(),
     };
-    let shared = tmp.path().join("shared/browser");
+    let shared = home.join("shared/browser");
     fs::create_dir_all(&shared).unwrap();
     fs::write(
         shared.join("SKILL.md"),

--- a/crates/core/src/engine/adopt/tests/slots.rs
+++ b/crates/core/src/engine/adopt/tests/slots.rs
@@ -10,215 +10,6 @@ use std::fs;
 
 use crate::test_util::rooted;
 
-use super::trash_is_empty;
-
-/// The same nesting from the other side, and the direction that would
-/// delete. `data-science/eda` is stored at `<local>/skills/data-science`,
-/// so the slot a plain `data-science` asks for is the directory holding
-/// it — and the slot existing is not a previous copy of `data-science`,
-/// a name the local source lists nowhere. A project's plain skill is its
-/// own source in `.agents`, so the local source is a plain skill's
-/// destination only at the global scope.
-#[test]
-fn a_plain_skill_over_the_namespaced_one_stored_there_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let scope = Scope::Global;
-    let held = home.join(".claude/skills");
-    fs::create_dir_all(held.join("data-science__eda")).unwrap();
-    fs::write(
-        held.join("data-science__eda/SKILL.md"),
-        "the namespaced one",
-    )
-    .unwrap();
-    let plan = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "data-science/eda",
-        &[HarnessId::Claude],
-    )
-    .unwrap();
-    crate::apply::execute(&env, &plan).unwrap();
-
-    fs::create_dir_all(held.join("data-science")).unwrap();
-    fs::write(held.join("data-science/SKILL.md"), "the plain one").unwrap();
-    let trashed = || fs::read_dir(env.trash_dir()).map_or(0, Iterator::count);
-    let before = trashed();
-    let refused = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "data-science",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err()
-    .to_string();
-
-    assert!(refused.contains("data-science/eda"), "{refused:?}");
-    // The local source still offers the namespaced skill under its own
-    // name, and the declaration still resolves to content that is there.
-    let root = crate::source::local_source_root(&env, &scope);
-    let sealed = crate::source_read::SealedSource::open(&root).unwrap();
-    let config = crate::source::source_config_for(&sealed, LOCAL_SOURCE_NAME).unwrap();
-    assert_eq!(
-        crate::source::list_items(&sealed, &config, ItemKind::Skill),
-        ["data-science/eda"]
-    );
-    let manifest =
-        crate::manifest::load_for_mutation(&crate::manifest::manifest_path(&env, &scope))
-            .unwrap()
-            .unwrap();
-    assert_eq!(
-        manifest.declared(ItemKind::Skill)["data-science/eda"].source,
-        LOCAL_SOURCE_NAME
-    );
-    assert_eq!(
-        crate::source::find_item(&sealed, &config, ItemKind::Skill, "data-science/eda"),
-        Some(root.join("skills/data-science/eda"))
-    );
-    assert_eq!(
-        fs::read_to_string(root.join("skills/data-science/eda/SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert_eq!(trashed(), before);
-
-    // The refusal is the collision's, not a refusal of every plain name:
-    // one whose slot holds nothing is still kept.
-    fs::create_dir_all(held.join("handmade")).unwrap();
-    fs::write(held.join("handmade/SKILL.md"), "mine").unwrap();
-    let plan = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "handmade",
-        &[HarnessId::Claude],
-    )
-    .unwrap();
-    crate::apply::execute(&env, &plan).unwrap();
-    assert!(root.join("skills/handmade/SKILL.md").is_file());
-}
-
-/// The spelling half of the same collision. A macOS or Windows volume
-/// hands `Data-Science` and `data-science` to one directory, so the stored
-/// `Data-Science/eda` sits in the slot a plain `data-science` asks for even
-/// though the two names differ character by character. The refusal reads
-/// both sides under `names::fold`, which is a fact about the names rather
-/// than about the host running the test, so it holds here too.
-#[test]
-fn a_plain_skill_over_a_differently_cased_namespaced_one_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let scope = Scope::Global;
-    let held = home.join(".claude/skills");
-    fs::create_dir_all(held.join("Data-Science__eda")).unwrap();
-    fs::write(
-        held.join("Data-Science__eda/SKILL.md"),
-        "the namespaced one",
-    )
-    .unwrap();
-    let plan = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "Data-Science/eda",
-        &[HarnessId::Claude],
-    )
-    .unwrap();
-    crate::apply::execute(&env, &plan).unwrap();
-
-    fs::create_dir_all(held.join("data-science")).unwrap();
-    fs::write(held.join("data-science/SKILL.md"), "the plain one").unwrap();
-    let trashed = || fs::read_dir(env.trash_dir()).map_or(0, Iterator::count);
-    let before = trashed();
-    let refused = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "data-science",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err()
-    .to_string();
-
-    assert!(refused.contains("Data-Science/eda"), "{refused:?}");
-    let root = crate::source::local_source_root(&env, &scope);
-    let sealed = crate::source_read::SealedSource::open(&root).unwrap();
-    let config = crate::source::source_config_for(&sealed, LOCAL_SOURCE_NAME).unwrap();
-    assert_eq!(
-        crate::source::list_items(&sealed, &config, ItemKind::Skill),
-        ["Data-Science/eda"]
-    );
-    assert_eq!(
-        fs::read_to_string(root.join("skills/Data-Science/eda/SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert_eq!(trashed(), before);
-}
-
-/// The occupancy read is a read, and a read that fails is not an answer of
-/// "the slot is free". Here the directory holding `data-science/eda` is
-/// past the bound the sealed reader lists within, so the listing the guard
-/// asks for cannot be made — and adoption refuses instead of trashing what
-/// the plain name would land on top of. A local source that declares its
-/// own layout is the shape that reaches this: without a control file the
-/// search table walks the same directory first and refuses there.
-#[test]
-fn a_plain_skill_over_a_slot_whose_listing_fails_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let scope = Scope::Global;
-    let held = home.join(".claude/skills");
-    fs::create_dir_all(held.join("data-science__eda")).unwrap();
-    fs::write(
-        held.join("data-science__eda/SKILL.md"),
-        "the namespaced one",
-    )
-    .unwrap();
-    let plan = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "data-science/eda",
-        &[HarnessId::Claude],
-    )
-    .unwrap();
-    crate::apply::execute(&env, &plan).unwrap();
-
-    let root = crate::source::local_source_root(&env, &scope);
-    fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
-    let stored = root.join("skills/data-science");
-    for n in 0..4_096 {
-        fs::create_dir(stored.join(format!("filler-{n:04}"))).unwrap();
-    }
-
-    fs::create_dir_all(held.join("data-science")).unwrap();
-    fs::write(held.join("data-science/SKILL.md"), "the plain one").unwrap();
-    let trashed = || fs::read_dir(env.trash_dir()).map_or(0, Iterator::count);
-    let before = trashed();
-    let refused = adopt(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "data-science",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-
-    assert!(
-        matches!(refused, CoreError::SourceEscape { .. }),
-        "{refused:?}"
-    );
-    assert_eq!(
-        fs::read_to_string(root.join("skills/data-science/eda/SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert_eq!(trashed(), before);
-}
-
 /// A skill written straight into the global scope's local source. These
 /// controls ask what the slot HOLDS, and how it came to hold it is not part
 /// of that question.
@@ -231,112 +22,442 @@ fn store_local_skill(env: &Env, rel: &str, body: &str) -> PathBuf {
     dir
 }
 
-/// The refusal a plain `name` gets at the global scope, with Claude holding
-/// a skill of that name for the capture to take.
-fn refuse_plain_skill(env: &Env, home: &Path, name: &str) -> String {
+/// A skill Claude holds at the global scope, for a capture to take.
+fn hold_claude_skill(home: &Path, name: &str, body: &str) -> PathBuf {
     let held = home.join(".claude/skills").join(name);
     fs::create_dir_all(&held).unwrap();
-    fs::write(held.join("SKILL.md"), "the plain one").unwrap();
-    adopt(
+    fs::write(held.join("SKILL.md"), body).unwrap();
+    held
+}
+
+/// A skill adopted into the global scope's local source from Claude's
+/// tree, the way a stored namespaced item usually came to be there.
+fn adopt_claude_skill(env: &Env, home: &Path, held_as: &str, name: &str, body: &str) {
+    hold_claude_skill(home, held_as, body);
+    let plan = adopt(
         env,
         &Scope::Global,
         ItemKind::Skill,
         name,
         &[HarnessId::Claude],
     )
-    .unwrap_err()
-    .to_string()
-}
-
-/// A local source whose own config will not parse offers nothing at all —
-/// every listing of it is empty, and an empty listing is not an empty
-/// directory. The skill stored in the slot is stored there either way.
-#[test]
-fn a_plain_skill_over_a_slot_in_an_unreadable_local_source_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let stored = store_local_skill(&env, "data-science/eda", "the namespaced one");
-    let root = crate::source::local_source_root(&env, &Scope::Global);
-    fs::write(root.join("kendex.toml"), "schema = [").unwrap();
-
-    let refused = refuse_plain_skill(&env, &home, "data-science");
-
-    assert!(refused.contains("data-science/eda"), "{refused:?}");
-    assert_eq!(
-        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert!(trash_is_empty(&env));
-}
-
-/// A catalog that declares where its skills live: `skills/data-science` is
-/// this source's skill directory, so what it stores is listed as `foo/eda`
-/// — a name whose plugin half is not the slot's, and whose path is inside
-/// the slot regardless.
-#[test]
-fn a_plain_skill_over_a_slot_holding_a_differently_named_item_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let stored = store_local_skill(&env, "data-science/foo/eda", "the stored one");
-    let root = crate::source::local_source_root(&env, &Scope::Global);
-    fs::write(
-        root.join("kendex.toml"),
-        "[catalog]\nskills = [\"skills/data-science\"]\n",
-    )
     .unwrap();
-
-    let refused = refuse_plain_skill(&env, &home, "data-science");
-
-    assert!(refused.contains("data-science/foo"), "{refused:?}");
-    assert_eq!(
-        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
-        "the stored one"
-    );
-    assert!(trash_is_empty(&env));
+    crate::apply::execute(env, &plan).unwrap();
 }
 
-/// The same catalog with the slot holding a plain skill of its own, which
-/// makes the slot replaceable rather than empty. Its one immediate child,
-/// `foo`, is no item — the item is `foo/eda`, a level further down, which
-/// is where a declared catalog directory legitimately keeps it. A search
-/// that stops at the children reports the slot free and the capture takes
-/// the stored item with the directory.
-#[test]
-fn a_plain_skill_over_an_item_stored_deeper_in_its_slot_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let stored = store_local_skill(&env, "data-science/foo/eda", "the stored one");
-    store_local_skill(&env, "data-science", "the earlier plain one");
-    let root = crate::source::local_source_root(&env, &Scope::Global);
-    fs::write(
-        root.join("kendex.toml"),
-        "[catalog]\nskills = [\"skills/data-science\"]\n",
-    )
-    .unwrap();
-
-    let refused = refuse_plain_skill(&env, &home, "data-science");
-
-    assert!(refused.contains("data-science/foo/eda"), "{refused:?}");
-    assert_eq!(
-        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
-        "the stored one"
-    );
-    // The source still offers the stored item under its own name, so a
-    // declaration naming it still resolves to content that is there.
+/// The listing the local source gives of its skills.
+fn listed_skills(env: &Env) -> Vec<String> {
+    let root = crate::source::local_source_root(env, &Scope::Global);
     let sealed = crate::source_read::SealedSource::open(&root).unwrap();
     let config = crate::source::source_config_for(&sealed, LOCAL_SOURCE_NAME).unwrap();
-    assert_eq!(
-        crate::source::list_items(&sealed, &config, ItemKind::Skill),
-        ["foo/eda"]
-    );
-    assert_eq!(
-        crate::source::find_item(&sealed, &config, ItemKind::Skill, "foo/eda"),
-        Some(stored)
-    );
-    assert!(trash_is_empty(&env));
+    crate::source::list_items(&sealed, &config, ItemKind::Skill)
+}
+
+/// Where the local source resolves a skill name to.
+fn found_skill(env: &Env, name: &str) -> Option<PathBuf> {
+    let root = crate::source::local_source_root(env, &Scope::Global);
+    let sealed = crate::source_read::SealedSource::open(&root).unwrap();
+    let config = crate::source::source_config_for(&sealed, LOCAL_SOURCE_NAME).unwrap();
+    crate::source::find_item(&sealed, &config, ItemKind::Skill, name)
+}
+
+/// Why the plain name was refused.
+#[derive(Debug)]
+enum Refusal {
+    /// The slot holds this item, which the capture would be written over:
+    /// `AdoptNameUnusable` naming the plain name and the occupant.
+    Occupant(&'static str),
+    /// The slot or its parent is past the reader's bound: `SourceEscape`
+    /// at this path, for this reason.
+    Bound(PathBuf, String),
+    /// The occupancy read itself failed at this path: `Io`.
+    #[cfg_attr(
+        not(unix),
+        allow(dead_code, reason = "built only by the permission-bit rows")
+    )]
+    Unreadable(PathBuf),
+}
+
+/// One slot layout: what was planted, the plain name asked for, the
+/// refusal it gets, the stored files that must survive untouched with
+/// their bytes, a path whose mode is put back after the call, and where
+/// that is the point what the local source still lists afterwards and
+/// where it resolves the first listed name to.
+struct Planted {
+    name: &'static str,
+    refusal: Refusal,
+    kept: Vec<(PathBuf, &'static str)>,
+    #[cfg_attr(
+        not(unix),
+        allow(dead_code, reason = "set only by the permission-bit rows")
+    )]
+    restore: Option<PathBuf>,
+    listed: Option<(Vec<&'static str>, PathBuf)>,
+}
+
+/// One row per shape a plain skill's slot can already be in, at the global
+/// scope, where the local source is a plain skill's destination (a
+/// project's plain skill is its own source in `.agents`). Every row plants
+/// one layout, has Claude hold a plain skill of the name, and asks
+/// adoption to keep it; the refusal is the collision's or the read's, the
+/// stored bytes are still there, nothing reached the trash, and where the
+/// source is asked afterwards it still offers the stored item under its
+/// own name.
+///
+/// The rows that fail the occupancy READ are as much the point as the
+/// rows that find an occupant: a read that fails is not an answer of "the
+/// slot is free". A slot past the sealed reader's listing bound, a slot
+/// wider than the descendant search's entry budget, and a kind directory
+/// past the bound are refused as the bound's, since nothing else in those
+/// rows would refuse. A POSIX directory can be searchable and writable
+/// without being listable (mode 0311, or an ACL), and a child can be
+/// listable but not traversable (mode 000): both keep the nested skill
+/// reachable while the scan sees nothing, and read as empty they would
+/// hand the capture the occupied slot. Root reads and traverses any
+/// directory whatever its mode, so there the denial does not exist and
+/// those two rows expect the ordinary collision instead.
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one table: twelve slot layouts refused by one adopt call, each row a layout of its own"
+)]
+fn a_plain_skill_over_an_occupied_or_unreadable_slot_refuses() {
+    type Plant = fn(&Env, &Path) -> Planted;
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, Plant)> = vec![
+        // `data-science/eda` is stored at `<local>/skills/data-science`, so
+        // the slot a plain `data-science` asks for is the directory
+        // holding it — and the slot existing is not a previous copy of
+        // `data-science`, a name the local source lists nowhere. The
+        // declaration still resolves to content that is there.
+        ("the namespaced one stored there", |env, home| {
+            adopt_claude_skill(
+                env,
+                home,
+                "data-science__eda",
+                "data-science/eda",
+                "the namespaced one",
+            );
+            let root = crate::source::local_source_root(env, &Scope::Global);
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Occupant("skills/data-science/eda"),
+                kept: vec![(
+                    root.join("skills/data-science/eda/SKILL.md"),
+                    "the namespaced one",
+                )],
+                restore: None,
+                listed: Some((
+                    vec!["data-science/eda"],
+                    root.join("skills/data-science/eda"),
+                )),
+            }
+        }),
+        // The spelling half of the same collision. A macOS or Windows
+        // volume hands `Data-Science` and `data-science` to one directory,
+        // so the stored `Data-Science/eda` sits in the slot a plain
+        // `data-science` asks for even though the two names differ
+        // character by character. The refusal reads both sides under
+        // `names::fold`, a fact about the names rather than about the host
+        // running the test, so it holds here too.
+        ("a differently cased namespaced one", |env, home| {
+            adopt_claude_skill(
+                env,
+                home,
+                "Data-Science__eda",
+                "Data-Science/eda",
+                "the namespaced one",
+            );
+            let root = crate::source::local_source_root(env, &Scope::Global);
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Occupant("skills/Data-Science/eda"),
+                kept: vec![(
+                    root.join("skills/Data-Science/eda/SKILL.md"),
+                    "the namespaced one",
+                )],
+                restore: None,
+                listed: Some((
+                    vec!["Data-Science/eda"],
+                    root.join("skills/Data-Science/eda"),
+                )),
+            }
+        }),
+        // The directory holding `data-science/eda` is past the bound the
+        // sealed reader lists within, so the listing the guard asks for
+        // cannot be made. A local source that declares its own layout is
+        // the shape that reaches this: without a control file the search
+        // table walks the same directory first and refuses there.
+        ("a slot whose listing fails", |env, home| {
+            adopt_claude_skill(
+                env,
+                home,
+                "data-science__eda",
+                "data-science/eda",
+                "the namespaced one",
+            );
+            let root = crate::source::local_source_root(env, &Scope::Global);
+            fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
+            let stored = root.join("skills/data-science");
+            for n in 0..4_096 {
+                fs::create_dir(stored.join(format!("filler-{n:04}"))).unwrap();
+            }
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Bound(
+                    stored.clone(),
+                    "more than 4096 entries in one catalog directory".to_owned(),
+                ),
+                kept: vec![(stored.join("eda/SKILL.md"), "the namespaced one")],
+                restore: None,
+                listed: None,
+            }
+        }),
+        // A local source whose own config will not parse offers nothing
+        // at all — every listing of it is empty, and an empty listing is
+        // not an empty directory. The skill stored in the slot is stored
+        // there either way.
+        ("a slot in an unreadable local source", |env, _| {
+            let stored = store_local_skill(env, "data-science/eda", "the namespaced one");
+            let root = crate::source::local_source_root(env, &Scope::Global);
+            fs::write(root.join("kendex.toml"), "schema = [").unwrap();
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Occupant("skills/data-science/eda"),
+                kept: vec![(stored.join("SKILL.md"), "the namespaced one")],
+                restore: None,
+                listed: None,
+            }
+        }),
+        // A catalog that declares where its skills live: `skills/data-science`
+        // is this source's skill directory, so what it stores is listed as
+        // `foo/eda` — a name whose plugin half is not the slot's, and whose
+        // path is inside the slot regardless.
+        ("a slot holding a differently named item", |env, _| {
+            let stored = store_local_skill(env, "data-science/foo/eda", "the stored one");
+            let root = crate::source::local_source_root(env, &Scope::Global);
+            fs::write(
+                root.join("kendex.toml"),
+                "[catalog]\nskills = [\"skills/data-science\"]\n",
+            )
+            .unwrap();
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Occupant("skills/data-science/foo"),
+                kept: vec![(stored.join("SKILL.md"), "the stored one")],
+                restore: None,
+                listed: None,
+            }
+        }),
+        // The same catalog with the slot holding a plain skill of its own,
+        // which makes the slot replaceable rather than empty. Its one
+        // immediate child, `foo`, is no item — the item is `foo/eda`, a
+        // level further down, which is where a declared catalog directory
+        // legitimately keeps it. A search that stops at the children
+        // reports the slot free and the capture takes the stored item with
+        // the directory.
+        ("an item stored deeper in its slot", |env, _| {
+            let stored = store_local_skill(env, "data-science/foo/eda", "the stored one");
+            store_local_skill(env, "data-science", "the earlier plain one");
+            let root = crate::source::local_source_root(env, &Scope::Global);
+            fs::write(
+                root.join("kendex.toml"),
+                "[catalog]\nskills = [\"skills/data-science\"]\n",
+            )
+            .unwrap();
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Occupant("skills/data-science/foo/eda"),
+                kept: vec![(stored.join("SKILL.md"), "the stored one")],
+                restore: None,
+                listed: Some((vec!["foo/eda"], stored)),
+            }
+        }),
+        // The descendant search looks at a bounded number of entries, and
+        // a slot wider than that bound is one it has not finished looking
+        // at. Nothing is stored under this slot but the earlier copy's own
+        // filler, one entry past the budget counting its SKILL.md.
+        ("a slot too wide to search", |env, _| {
+            let stored = store_local_skill(env, "data-science", "the earlier plain one");
+            for n in 0..crate::source_read::TREE_BOUND.files {
+                fs::create_dir(stored.join(format!("filler-{n:04}"))).unwrap();
+            }
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Bound(
+                    stored.clone(),
+                    format!(
+                        "more than {} entries under one slot — cannot tell what is stored there",
+                        crate::source_read::TREE_BOUND.files
+                    ),
+                ),
+                kept: vec![(stored.join("SKILL.md"), "the earlier plain one")],
+                restore: None,
+                listed: None,
+            }
+        }),
+        // A listing skips a `tests` directory wherever it finds one — the
+        // support vocabulary a browse row is drawn through, since files
+        // there are about the items rather than items. A legal `tests/foo`
+        // is therefore a skill no listing names, and it occupies the plain
+        // `tests` slot all the same.
+        ("a slot no listing names", |env, _| {
+            let stored = store_local_skill(env, "tests/foo", "the namespaced one");
+            Planted {
+                name: "tests",
+                refusal: Refusal::Occupant("skills/tests/foo"),
+                kept: vec![(stored.join("SKILL.md"), "the namespaced one")],
+                restore: None,
+                listed: None,
+            }
+        }),
+        // A plain item and a namespaced one legitimately share one
+        // directory: `skills/plugin/SKILL.md` beside
+        // `skills/plugin/item/SKILL.md`, both listed and both resolved. So
+        // the slot being the plain item makes it replaceable, not empty —
+        // the capture replaces the plain item's own files, and
+        // `plugin/item` is a second item it would take with it.
+        ("itself beside a namespaced one", |env, _| {
+            let plain = store_local_skill(env, "plugin", "the earlier plain one");
+            let nested = store_local_skill(env, "plugin/item", "the namespaced one");
+            Planted {
+                name: "plugin",
+                refusal: Refusal::Occupant("skills/plugin/item"),
+                kept: vec![
+                    (nested.join("SKILL.md"), "the namespaced one"),
+                    (plain.join("SKILL.md"), "the earlier plain one"),
+                ],
+                restore: None,
+                listed: None,
+            }
+        }),
+        // The parent scan is a read of a source, so it carries the reader's
+        // work bound like every other one. A kind directory past the bound
+        // is refused rather than scanned, which also keeps adoption from
+        // writing into a source that discovery will later refuse to read
+        // back. Nothing here is stored in the slot.
+        ("a parent past the entry bound", |env, _| {
+            let unrelated = store_local_skill(env, "unrelated", "somebody else's");
+            let kind_dir = crate::source::local_source_root(env, &Scope::Global).join("skills");
+            for n in 0..4_096 {
+                fs::create_dir(kind_dir.join(format!("filler-{n:04}"))).unwrap();
+            }
+            assert!(!kind_dir.join("data-science").exists());
+            Planted {
+                name: "data-science",
+                refusal: Refusal::Bound(
+                    kind_dir,
+                    "more than 4096 entries in one catalog directory".to_owned(),
+                ),
+                kept: vec![(unrelated.join("SKILL.md"), "somebody else's")],
+                restore: None,
+                listed: None,
+            }
+        }),
+    ];
+    #[cfg(unix)]
+    rows.extend([
+        // The parent is searchable and writable but not listable.
+        (
+            "a parent that will not enumerate",
+            (|env, _| {
+                use std::os::unix::fs::PermissionsExt;
+                let stored = store_local_skill(env, "data-science/eda", "the namespaced one");
+                let root = crate::source::local_source_root(env, &Scope::Global);
+                fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
+                let kind_dir = root.join("skills");
+                fs::set_permissions(&kind_dir, fs::Permissions::from_mode(0o311)).unwrap();
+                let refusal = match fs::read_dir(&kind_dir).is_err() {
+                    true => Refusal::Unreadable(kind_dir.clone()),
+                    false => Refusal::Occupant("skills/data-science/eda"),
+                };
+                Planted {
+                    name: "data-science",
+                    refusal,
+                    kept: vec![(stored.join("SKILL.md"), "the namespaced one")],
+                    restore: Some(kind_dir),
+                    listed: None,
+                }
+            }) as Plant,
+        ),
+        // `plugin/item` sits beside the plain `plugin`, and its directory
+        // can be listed but not traversed, so the `SKILL.md` probe into it
+        // fails; the refusal names the probe it could not make, not the
+        // slot.
+        (
+            "a child that cannot be probed",
+            (|env, _| {
+                use std::os::unix::fs::PermissionsExt;
+                store_local_skill(env, "plugin", "the earlier plain one");
+                let nested = store_local_skill(env, "plugin/item", "the namespaced one");
+                fs::set_permissions(&nested, fs::Permissions::from_mode(0o000)).unwrap();
+                let refusal = match fs::metadata(nested.join("SKILL.md")).is_err() {
+                    true => Refusal::Unreadable(nested.join("SKILL.md")),
+                    false => Refusal::Occupant("skills/plugin/item"),
+                };
+                Planted {
+                    name: "plugin",
+                    refusal,
+                    kept: vec![(nested.join("SKILL.md"), "the namespaced one")],
+                    restore: Some(nested),
+                    listed: None,
+                }
+            }) as Plant,
+        ),
+    ]);
+
+    for (label, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = rooted(&tmp);
+        let env = Env::fake(&home, FakeOs::Linux);
+        let planted = plant(&env, &home);
+        hold_claude_skill(&home, planted.name, "the plain one");
+        let trashed = || fs::read_dir(env.trash_dir()).map_or(0, Iterator::count);
+        let before = trashed();
+
+        // The mode goes back before anything can panic: a directory left
+        // unreadable outlives the TempDir that cannot remove it.
+        let outcome = adopt(
+            &env,
+            &Scope::Global,
+            ItemKind::Skill,
+            planted.name,
+            &[HarnessId::Claude],
+        );
+        #[cfg(unix)]
+        if let Some(path) = &planted.restore {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let refused = outcome.unwrap_err();
+
+        match (&planted.refusal, &refused) {
+            (Refusal::Occupant(held), CoreError::AdoptNameUnusable { name, problem }) => {
+                assert_eq!(name, planted.name, "{label}");
+                assert_eq!(
+                    problem,
+                    &format!("`{held}` is stored here, and this name would be written over it"),
+                    "{label}"
+                );
+            }
+            (Refusal::Bound(at, why), CoreError::SourceEscape { path, reason }) => {
+                assert_eq!(path, at, "{label}");
+                assert_eq!(reason, why, "{label}");
+            }
+            (Refusal::Unreadable(at), CoreError::Io { path, .. }) => {
+                assert_eq!(path, at, "{label}");
+            }
+            (expected, got) => panic!("{label}: expected {expected:?}, got {got:?}"),
+        }
+        for (path, body) in &planted.kept {
+            assert_eq!(&fs::read_to_string(path).unwrap(), body, "{label}");
+        }
+        assert_eq!(trashed(), before, "{label}");
+        if let Some((listed, at)) = &planted.listed {
+            assert_eq!(&listed_skills(&env), listed, "{label}");
+            assert_eq!(found_skill(&env, listed[0]).as_ref(), Some(at), "{label}");
+        }
+    }
 }
 
 /// The must-fail half: what the descendant search must NOT call an
@@ -359,18 +480,7 @@ fn a_plain_skill_over_a_slot_holding_nothing_of_its_own_lands() {
     fs::create_dir_all(&vacant).unwrap();
 
     for (name, body) in [("handmade", "the newer one"), ("vacant", "a first copy")] {
-        let held = home.join(".claude/skills").join(name);
-        fs::create_dir_all(&held).unwrap();
-        fs::write(held.join("SKILL.md"), body).unwrap();
-        let plan = adopt(
-            &env,
-            &Scope::Global,
-            ItemKind::Skill,
-            name,
-            &[HarnessId::Claude],
-        )
-        .unwrap();
-        crate::apply::execute(&env, &plan).unwrap();
+        adopt_claude_skill(&env, &home, name, name, body);
     }
 
     assert_eq!(
@@ -383,66 +493,6 @@ fn a_plain_skill_over_a_slot_holding_nothing_of_its_own_lands() {
     );
 }
 
-/// The descendant search looks at a bounded number of entries, and a slot
-/// wider than that bound is one it has not finished looking at. Not
-/// finished is not empty, so adoption refuses. Nothing is stored under this
-/// slot but the earlier copy's own filler: the bound is the only reason to
-/// refuse, so the refusal is the bound's or it is nobody's.
-#[test]
-fn a_plain_skill_over_a_slot_too_wide_to_search_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let stored = store_local_skill(&env, "data-science", "the earlier plain one");
-    // One entry past the budget, counting the earlier copy's own SKILL.md.
-    for n in 0..crate::source_read::TREE_BOUND.files {
-        fs::create_dir(stored.join(format!("filler-{n:04}"))).unwrap();
-    }
-
-    let held = home.join(".claude/skills/data-science");
-    fs::create_dir_all(&held).unwrap();
-    fs::write(held.join("SKILL.md"), "the plain one").unwrap();
-    let refused = adopt(
-        &env,
-        &Scope::Global,
-        ItemKind::Skill,
-        "data-science",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-
-    assert!(
-        matches!(refused, CoreError::SourceEscape { .. }),
-        "{refused:?}"
-    );
-    assert_eq!(
-        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
-        "the earlier plain one"
-    );
-    assert!(trash_is_empty(&env));
-}
-
-/// A listing skips a `tests` directory wherever it finds one — the support
-/// vocabulary a browse row is drawn through, since files there are about the
-/// items rather than items. A legal `tests/foo` is therefore a skill no
-/// listing names, and it occupies the plain `tests` slot all the same.
-#[test]
-fn a_plain_skill_over_a_slot_no_listing_names_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let stored = store_local_skill(&env, "tests/foo", "the namespaced one");
-
-    let refused = refuse_plain_skill(&env, &home, "tests");
-
-    assert!(refused.contains("tests/foo"), "{refused:?}");
-    assert_eq!(
-        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert!(trash_is_empty(&env));
-}
-
 /// A slot holding this very name is not a collision. The plain item stored
 /// there is a previous copy of the name being kept, and replacing it is
 /// what a capture over it is for — the refusal above is the collision's,
@@ -453,187 +503,11 @@ fn a_plain_skill_over_an_earlier_copy_of_itself_lands() {
     let home = rooted(&tmp);
     let env = Env::fake(&home, FakeOs::Linux);
     let stored = store_local_skill(&env, "handmade", "the earlier one");
-    let held = home.join(".claude/skills/handmade");
-    fs::create_dir_all(&held).unwrap();
-    fs::write(held.join("SKILL.md"), "the newer one").unwrap();
 
-    let plan = adopt(
-        &env,
-        &Scope::Global,
-        ItemKind::Skill,
-        "handmade",
-        &[HarnessId::Claude],
-    )
-    .unwrap();
-    crate::apply::execute(&env, &plan).unwrap();
+    adopt_claude_skill(&env, &home, "handmade", "handmade", "the newer one");
 
     assert_eq!(
         fs::read_to_string(stored.join("SKILL.md")).unwrap(),
         "the newer one"
     );
-}
-
-/// A plain item and a namespaced one legitimately share one directory:
-/// `skills/plugin/SKILL.md` beside `skills/plugin/item/SKILL.md`, both
-/// listed and both resolved. So the slot being the plain item makes it
-/// replaceable, not empty — the capture replaces the plain item's own
-/// files, and `plugin/item` is a second item it would take with it.
-#[test]
-fn a_plain_skill_over_itself_beside_a_namespaced_one_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let plain = store_local_skill(&env, "plugin", "the earlier plain one");
-    let nested = store_local_skill(&env, "plugin/item", "the namespaced one");
-
-    let refused = refuse_plain_skill(&env, &home, "plugin");
-
-    assert!(refused.contains("plugin/item"), "{refused:?}");
-    assert_eq!(
-        fs::read_to_string(nested.join("SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert_eq!(
-        fs::read_to_string(plain.join("SKILL.md")).unwrap(),
-        "the earlier plain one"
-    );
-    assert!(trash_is_empty(&env));
-}
-
-/// The occupancy read is a read, and the other way it fails. A POSIX
-/// directory can be searchable and writable without being listable — mode
-/// 0311, or an ACL — so the slot and the skill nested in it stay reachable
-/// while the scan of the parent returns nothing. Reading that nothing as an
-/// empty parent reports the occupied slot free, and the capture hashes and
-/// trashes what is in it.
-#[cfg(unix)]
-#[test]
-fn a_plain_skill_whose_parent_will_not_enumerate_refuses() {
-    use std::os::unix::fs::PermissionsExt;
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let stored = store_local_skill(&env, "data-science/eda", "the namespaced one");
-    let root = crate::source::local_source_root(&env, &Scope::Global);
-    fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
-    let kind_dir = root.join("skills");
-    fs::set_permissions(&kind_dir, fs::Permissions::from_mode(0o311)).unwrap();
-    // Root reads any directory whatever its mode, so there the denial under
-    // test does not exist and the adoption is the ordinary refusal.
-    let denied = fs::read_dir(&kind_dir).is_err();
-
-    let held = home.join(".claude/skills/data-science");
-    fs::create_dir_all(&held).unwrap();
-    fs::write(held.join("SKILL.md"), "the plain one").unwrap();
-    let refused = adopt(
-        &env,
-        &Scope::Global,
-        ItemKind::Skill,
-        "data-science",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-    fs::set_permissions(&kind_dir, fs::Permissions::from_mode(0o755)).unwrap();
-
-    match denied {
-        true => assert!(matches!(refused, CoreError::Io { .. }), "{refused:?}"),
-        false => assert!(
-            refused.to_string().contains("data-science/eda"),
-            "{refused}"
-        ),
-    }
-    assert_eq!(
-        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert!(trash_is_empty(&env));
-}
-
-/// The third shape of the same failure, and the one a boolean probe hides.
-/// `plugin/item` sits beside the plain `plugin`, and its directory can be
-/// listed but not traversed — mode 000, or an ACL. The `SKILL.md` probe
-/// into it fails, and answered as "no item here" the slot reads as holding
-/// only the plain skill the capture replaces, so the trash takes the
-/// namespaced one with it and leaves its declaration pointing at nothing.
-#[cfg(unix)]
-#[test]
-fn a_plain_skill_over_a_child_that_cannot_be_probed_refuses() {
-    use std::os::unix::fs::PermissionsExt;
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    store_local_skill(&env, "plugin", "the earlier plain one");
-    let nested = store_local_skill(&env, "plugin/item", "the namespaced one");
-    fs::set_permissions(&nested, fs::Permissions::from_mode(0o000)).unwrap();
-    // Root traverses any directory whatever its mode, so there the denial
-    // under test does not exist and the refusal is the ordinary one.
-    let denied = fs::metadata(nested.join("SKILL.md")).is_err();
-
-    let held = home.join(".claude/skills/plugin");
-    fs::create_dir_all(&held).unwrap();
-    fs::write(held.join("SKILL.md"), "the plain one").unwrap();
-    let refused = adopt(
-        &env,
-        &Scope::Global,
-        ItemKind::Skill,
-        "plugin",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-    fs::set_permissions(&nested, fs::Permissions::from_mode(0o755)).unwrap();
-
-    match denied {
-        // The refusal names the probe it could not make, not the slot.
-        true => match &refused {
-            CoreError::Io { path, .. } => assert_eq!(path, &nested.join("SKILL.md")),
-            other => panic!("expected the unreadable probe, got {other:?}"),
-        },
-        false => assert!(refused.to_string().contains("plugin/item"), "{refused}"),
-    }
-    assert_eq!(
-        fs::read_to_string(nested.join("SKILL.md")).unwrap(),
-        "the namespaced one"
-    );
-    assert!(trash_is_empty(&env));
-}
-
-/// The parent scan is a read of a source, so it carries the reader's work
-/// bound like every other one. A kind directory past the bound is refused
-/// rather than scanned, which also keeps adoption from writing into a
-/// source that discovery will later refuse to read back. Nothing here is
-/// stored in the slot: the bound is the only reason to refuse, so the
-/// refusal is the bound's or it is nobody's.
-#[test]
-fn a_plain_skill_whose_parent_is_past_the_entry_bound_refuses() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = Env::fake(&home, FakeOs::Linux);
-    let unrelated = store_local_skill(&env, "unrelated", "somebody else's");
-    let kind_dir = crate::source::local_source_root(&env, &Scope::Global).join("skills");
-    for n in 0..4_096 {
-        fs::create_dir(kind_dir.join(format!("filler-{n:04}"))).unwrap();
-    }
-    assert!(!kind_dir.join("data-science").exists());
-
-    let held = home.join(".claude/skills/data-science");
-    fs::create_dir_all(&held).unwrap();
-    fs::write(held.join("SKILL.md"), "the plain one").unwrap();
-    let refused = adopt(
-        &env,
-        &Scope::Global,
-        ItemKind::Skill,
-        "data-science",
-        &[HarnessId::Claude],
-    )
-    .unwrap_err();
-
-    assert!(
-        matches!(refused, CoreError::SourceEscape { .. }),
-        "{refused:?}"
-    );
-    assert_eq!(
-        fs::read_to_string(unrelated.join("SKILL.md")).unwrap(),
-        "somebody else's"
-    );
-    assert!(trash_is_empty(&env));
 }

--- a/crates/core/src/engine/compared/tests.rs
+++ b/crates/core/src/engine/compared/tests.rs
@@ -24,29 +24,6 @@ fn identical_bytes_compare_equal_and_a_changed_byte_does_not() {
     assert_eq!(changed.differing_total, 1);
 }
 
-/// Anything that is not a plain readable file of its own is no answer.
-/// An "identical" claim off an unread side is what this arm prevents.
-#[test]
-#[allow(clippy::expect_used)]
-fn of_file_refuses_a_link_a_directory_and_an_absent_path() {
-    let dir = tmp();
-    let real = dir.path().join("real.md");
-    std::fs::write(&real, b"body\n").expect("write");
-    // The link arm needs a link, and only a platform that hands them out
-    // without a privilege can make one in a test. The directory and absent
-    // arms are the same everywhere and stay.
-    #[cfg(unix)]
-    {
-        let link = dir.path().join("link.md");
-        std::os::unix::fs::symlink(&real, &link).expect("symlink");
-        assert!(of_file(&link, b"body\n").is_none(), "a link is not read");
-    }
-    let folder = dir.path().join("folder");
-    std::fs::create_dir(&folder).expect("mkdir");
-    assert!(of_file(&folder, b"body\n").is_none());
-    assert!(of_file(&dir.path().join("gone.md"), b"body\n").is_none());
-}
-
 #[test]
 #[allow(clippy::expect_used)]
 fn a_tree_names_every_side_that_only_one_holds() {
@@ -92,148 +69,230 @@ fn two_names_that_render_alike_stay_two_files() {
     assert_eq!(compared.differing.len(), 2, "{:?}", compared.differing);
 }
 
-/// Both bounds hold on their own, and they multiply: five hundred files at
-/// eight megabytes each is four gigabytes of reading for one position.
+/// One row per path `of_file` gives no answer for. Anything that is not
+/// a plain readable file of its own is no answer, and an "identical" claim
+/// off an unread side is what this arm prevents: a link, a directory, an
+/// absent path, and a file bigger than the bound. The link row needs a
+/// link, and only a platform that hands them out without a privilege can
+/// make one in a test.
 #[test]
 #[allow(clippy::expect_used)]
-fn a_tree_past_the_cumulative_budget_gives_no_answer() {
-    let dir = tmp();
-    let root = dir.path().join("wide");
-    std::fs::create_dir_all(&root).expect("mkdir");
-    // Each file is well under MAX_BYTES and the count is well under
-    // MAX_ENTRIES; together they cross the budget.
-    let chunk = vec![b'x'; usize::try_from(MAX_BYTES).expect("bound fits")];
-    let each = MAX_TOTAL_BYTES / MAX_BYTES;
-    for n in 0..each {
-        std::fs::write(root.join(format!("f{n}")), &chunk).expect("write");
+fn of_file_gives_no_answer_off_anything_but_a_plain_readable_file() {
+    /// The path to read and the bytes to compare it against.
+    type Plant = fn(&Path) -> (PathBuf, Vec<u8>);
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, Plant)> = vec![
+        ("a directory", |dir| {
+            let folder = dir.join("folder");
+            std::fs::create_dir(&folder).expect("mkdir");
+            (folder, b"body\n".to_vec())
+        }),
+        ("an absent path", |dir| {
+            (dir.join("gone.md"), b"body\n".to_vec())
+        }),
+        ("a file bigger than the bound", |dir| {
+            let bytes = vec![b'x'; usize::try_from(MAX_BYTES).expect("bound fits") + 1];
+            let path = dir.join("big.bin");
+            std::fs::write(&path, &bytes).expect("write");
+            (path, bytes)
+        }),
+    ];
+    #[cfg(unix)]
+    rows.push(("a link", |dir| {
+        let real = dir.join("real.md");
+        std::fs::write(&real, b"body\n").expect("write");
+        let link = dir.join("link.md");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        (link, b"body\n".to_vec())
+    }));
+    for (label, plant) in rows {
+        let dir = tmp();
+        let (path, bytes) = plant(dir.path());
+        assert!(of_file(&path, &bytes).is_none(), "{label}");
     }
-    assert!(
-        of_tree(&root, &[]).is_some(),
-        "the budget itself still reads"
-    );
-    std::fs::write(root.join("one-more"), b"x").expect("write");
-    assert!(of_tree(&root, &[]).is_none(), "past the budget, no answer");
 }
 
-/// The position belongs to somebody else. A link inside it would aim the
-/// read at a file nothing about this item chose, so the tree is refused
-/// whole rather than read through it.
-///
-/// Proven where a test can make a link without a privilege.
-#[cfg(unix)]
-#[test]
-#[allow(clippy::expect_used)]
-fn a_link_inside_the_tree_refuses_the_whole_comparison() {
-    let dir = tmp();
-    let outside = dir.path().join("outside.md");
-    std::fs::write(&outside, b"elsewhere\n").expect("write");
-    let root = dir.path().join("skill");
-    std::fs::create_dir_all(&root).expect("mkdir");
-    std::fs::write(root.join("SKILL.md"), b"same\n").expect("write");
-    let wanted = vec![(PathBuf::from("SKILL.md"), b"same\n".to_vec())];
-    assert!(of_tree(&root, &wanted).is_some(), "the plain tree compares");
-    std::os::unix::fs::symlink(&outside, root.join("linked.md")).expect("symlink");
-    assert!(of_tree(&root, &wanted).is_none(), "a link stops the answer");
+/// A directory a row's tree needs put back after the read.
+#[derive(Default)]
+struct Held {
+    #[cfg_attr(
+        not(unix),
+        allow(dead_code, reason = "set only by the permission-bit row")
+    )]
+    restore: Option<PathBuf>,
 }
 
-/// A folder the walk cannot enumerate must refuse the answer. Skipped, it
-/// would leave a partial tree comparing as whole, which is what "identical
-/// to the catalog" is printed from.
-///
-/// The unreadable folder is made with permission bits, so this runs where
-/// permission bits are the access control.
-#[cfg(unix)]
+/// One row per tree `of_tree` gives no answer for, each with the tree at
+/// the bound still reading where the bound is the point. Neither bound is
+/// a rendered item's shape, and a position past one is unread rather than
+/// assumed equal: the entry bound counts folders too, the per-file bound
+/// holds inside a tree as well, and the two multiply into a cumulative
+/// budget (five hundred files at eight megabytes each is four gigabytes
+/// of reading for one position). A link that loops back into its own tree
+/// stops at the same depth `hash_tree` uses rather than running until the
+/// stack does. The position belongs to somebody else, so a link inside it
+/// would aim the read at a file nothing about this item chose, and the
+/// tree is refused whole rather than read through it. A folder the walk
+/// cannot enumerate must refuse the answer: skipped, it would leave a
+/// partial tree comparing as whole, which is what "identical to the
+/// catalog" is printed from. Something that is neither file nor directory
+/// is nobody's to read; the third thing an entry can be here is a Unix
+/// socket. The link, permission-bit and socket rows run where a test can
+/// make those without a privilege.
 #[test]
-#[allow(clippy::expect_used)]
-fn a_folder_that_will_not_enumerate_refuses_rather_than_dropping_out() {
-    let dir = tmp();
-    let root = dir.path().join("skill");
-    let hidden = root.join("locked");
-    std::fs::create_dir_all(&hidden).expect("mkdir");
-    std::fs::write(root.join("SKILL.md"), b"same\n").expect("write");
-    std::fs::write(hidden.join("inner.md"), b"same\n").expect("write");
-    let wanted = vec![(PathBuf::from("SKILL.md"), b"same\n".to_vec())];
-    assert!(
-        of_tree(&root, &wanted).is_some(),
-        "readable, so it compares"
-    );
-
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&hidden, std::fs::Permissions::from_mode(0o000)).expect("chmod");
-    let refused = of_tree(&root, &wanted).is_none();
-    std::fs::set_permissions(&hidden, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-    assert!(
-        refused,
-        "a folder that will not enumerate compared as whole"
-    );
-}
-
-/// Neither bound is a rendered item's shape, and a position past one is
-/// unread rather than assumed equal. Folders count too: a tree wide in
-/// directories is as much of a read as one wide in files.
-#[test]
-#[allow(clippy::expect_used)]
-fn a_tree_with_more_entries_than_the_bound_gives_no_answer() {
-    let dir = tmp();
-    let root = dir.path().join("wide");
-    std::fs::create_dir_all(&root).expect("mkdir");
-    for n in 0..MAX_ENTRIES - 1 {
-        std::fs::write(root.join(format!("f{n}")), b"x").expect("write");
+#[allow(clippy::expect_used, clippy::too_many_lines)]
+fn of_tree_gives_no_answer_past_a_bound_or_off_an_entry_it_will_not_read() {
+    /// The tree at the bound, still readable, with the differing total
+    /// and shown-name count the at-bound read carries where a row pins
+    /// them; then the one step past it.
+    type Build = fn(&Path) -> Held;
+    struct Row {
+        label: &'static str,
+        wanted: Vec<(PathBuf, Vec<u8>)>,
+        at_bound: Option<Build>,
+        at_bound_counts: Option<(u32, usize)>,
+        past: Build,
     }
-    let compared = of_tree(&root, &[]).expect("the bound itself still reads");
-    assert_eq!(compared.differing_total, MAX_ENTRIES as u32 - 1);
-    assert_eq!(
-        compared.differing.len(),
-        SHOWN_DIFFERING,
-        "the row carries at most SHOWN_DIFFERING names"
-    );
+    #[cfg_attr(not(unix), allow(unused_variables))]
+    let skill = || vec![(PathBuf::from("SKILL.md"), b"same\n".to_vec())];
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows = vec![
+        Row {
+            label: "past the cumulative budget",
+            wanted: vec![],
+            at_bound: Some(|root| {
+                // Each file is well under MAX_BYTES and the count is well
+                // under MAX_ENTRIES; together they cross the budget.
+                let chunk = vec![b'x'; usize::try_from(MAX_BYTES).expect("bound fits")];
+                for n in 0..MAX_TOTAL_BYTES / MAX_BYTES {
+                    std::fs::write(root.join(format!("f{n}")), &chunk).expect("write");
+                }
+                Held::default()
+            }),
+            at_bound_counts: None,
+            past: |root| {
+                std::fs::write(root.join("one-more"), b"x").expect("write");
+                Held::default()
+            },
+        },
+        Row {
+            label: "more entries than the bound",
+            wanted: vec![],
+            at_bound: Some(|root| {
+                for n in 0..MAX_ENTRIES - 1 {
+                    std::fs::write(root.join(format!("f{n}")), b"x").expect("write");
+                }
+                Held::default()
+            }),
+            at_bound_counts: Some((MAX_ENTRIES as u32 - 1, SHOWN_DIFFERING)),
+            past: |root| {
+                std::fs::create_dir(root.join("one-more")).expect("mkdir");
+                Held::default()
+            },
+        },
+        Row {
+            label: "a file bigger than the bound inside the tree",
+            wanted: vec![],
+            at_bound: None,
+            at_bound_counts: None,
+            past: |root| {
+                let bytes = vec![b'x'; usize::try_from(MAX_BYTES).expect("bound fits") + 1];
+                std::fs::write(root.join("big.bin"), &bytes).expect("write");
+                Held::default()
+            },
+        },
+        Row {
+            label: "deeper than the bound",
+            wanted: vec![],
+            at_bound: None,
+            at_bound_counts: None,
+            past: |root| {
+                let mut at = root.to_path_buf();
+                for _ in 0..=crate::hash::MAX_DEPTH {
+                    at = at.join("d");
+                }
+                std::fs::create_dir_all(&at).expect("mkdir");
+                std::fs::write(at.join("SKILL.md"), b"deep\n").expect("write");
+                Held::default()
+            },
+        },
+    ];
+    #[cfg(unix)]
+    rows.extend([
+        Row {
+            label: "a link inside the tree",
+            wanted: skill(),
+            at_bound: Some(|root| {
+                std::fs::write(root.join("SKILL.md"), b"same\n").expect("write");
+                Held::default()
+            }),
+            at_bound_counts: None,
+            past: |root| {
+                let outside = root.parent().expect("parent").join("outside.md");
+                std::fs::write(&outside, b"elsewhere\n").expect("write");
+                std::os::unix::fs::symlink(&outside, root.join("linked.md")).expect("symlink");
+                Held::default()
+            },
+        },
+        Row {
+            label: "a folder that will not enumerate",
+            wanted: skill(),
+            at_bound: Some(|root| {
+                std::fs::create_dir_all(root.join("locked")).expect("mkdir");
+                std::fs::write(root.join("SKILL.md"), b"same\n").expect("write");
+                std::fs::write(root.join("locked/inner.md"), b"same\n").expect("write");
+                Held::default()
+            }),
+            at_bound_counts: None,
+            past: |root| {
+                use std::os::unix::fs::PermissionsExt;
+                let hidden = root.join("locked");
+                std::fs::set_permissions(&hidden, std::fs::Permissions::from_mode(0o000))
+                    .expect("chmod");
+                Held {
+                    restore: Some(hidden),
+                }
+            },
+        },
+        Row {
+            label: "an entry that is neither file nor directory",
+            wanted: vec![],
+            at_bound: None,
+            at_bound_counts: None,
+            past: |root| {
+                // The listener can go; its socket stays in the tree.
+                drop(std::os::unix::net::UnixListener::bind(root.join("sock")).expect("socket"));
+                Held::default()
+            },
+        },
+    ]);
 
-    std::fs::create_dir(root.join("one-more")).expect("mkdir");
-    assert!(of_tree(&root, &[]).is_none(), "a folder counts as an entry");
-}
-
-#[test]
-#[allow(clippy::expect_used)]
-fn a_file_bigger_than_the_bound_gives_no_answer() {
-    let dir = tmp();
-    let bytes = vec![b'x'; usize::try_from(MAX_BYTES).expect("bound fits") + 1];
-    let path = dir.path().join("big.bin");
-    std::fs::write(&path, &bytes).expect("write");
-    assert!(of_file(&path, &bytes).is_none(), "too large to read");
-
-    let root = dir.path().join("skill");
-    std::fs::create_dir_all(&root).expect("mkdir");
-    std::fs::write(root.join("big.bin"), &bytes).expect("write");
-    assert!(of_tree(&root, &[]).is_none(), "and inside a tree as well");
-}
-
-/// A link that loops back into its own tree stops at the same depth
-/// `hash_tree` uses rather than running until the stack does.
-#[test]
-#[allow(clippy::expect_used)]
-fn a_tree_deeper_than_the_bound_gives_no_answer() {
-    let dir = tmp();
-    let root = dir.path().join("deep");
-    let mut at = root.clone();
-    for _ in 0..=crate::hash::MAX_DEPTH {
-        at = at.join("d");
+    for row in rows {
+        let label = row.label;
+        let dir = tmp();
+        let root = dir.path().join("skill");
+        std::fs::create_dir_all(&root).expect("mkdir");
+        if let Some(at_bound) = row.at_bound {
+            let _held = at_bound(&root);
+            let compared = of_tree(&root, &row.wanted)
+                .unwrap_or_else(|| panic!("{label}: the bound itself still reads"));
+            if let Some((total, shown)) = row.at_bound_counts {
+                assert_eq!(compared.differing_total, total, "{label}");
+                assert_eq!(
+                    compared.differing.len(),
+                    shown,
+                    "{label}: the row carries at most SHOWN_DIFFERING names"
+                );
+            }
+        }
+        #[cfg_attr(not(unix), allow(unused_variables))]
+        let held = (row.past)(&root);
+        let answer = of_tree(&root, &row.wanted);
+        #[cfg(unix)]
+        if let Some(path) = &held.restore {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+        assert!(answer.is_none(), "{label}: past the bound, no answer");
     }
-    std::fs::create_dir_all(&at).expect("mkdir");
-    std::fs::write(at.join("SKILL.md"), b"deep\n").expect("write");
-    assert!(of_tree(&root, &[]).is_none());
-}
-
-/// Something that is neither file nor directory is nobody's to read. The
-/// third thing a filesystem entry can be here is a Unix socket, so this
-/// runs where sockets live in the filesystem.
-#[cfg(unix)]
-#[test]
-#[allow(clippy::expect_used)]
-fn an_entry_that_is_neither_file_nor_directory_stops_the_answer() {
-    let dir = tmp();
-    let root = dir.path().join("skill");
-    std::fs::create_dir_all(&root).expect("mkdir");
-    let socket = std::os::unix::net::UnixListener::bind(root.join("sock")).expect("socket");
-    assert!(of_tree(&root, &[]).is_none());
-    drop(socket);
 }

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -89,92 +89,96 @@ fn app_image(path: &str) -> AppInstall {
     AppInstall::AppImage(Some(PathBuf::from(path)))
 }
 
+/// One row per Linux AppImage the desktop shell can find itself in: the
+/// path it is judged by, the host facts the probe answers, and the channel.
+/// A file the person can replace updates in place; a system-owned one names
+/// the package that put it there, on every distro that reads as Arch (`ID`
+/// or `ID_LIKE`, unquoted and whole) and as unknown elsewhere, even where a
+/// root-owned machine could write the file; `/usr/local` is a hand install;
+/// with two helpers on `PATH` paru wins, and with none the command is
+/// helper-neutral prose. A process that is not running from an image has
+/// nothing to judge.
 #[test]
-fn an_appimage_the_person_owns_updates_in_place() {
+fn for_app_names_the_channel_of_each_appimage_layout() {
     let home = "/home/pat/.local/share/kendex/kendex.AppImage";
-    let probe = Fake::default().replaceable(home);
-    assert_eq!(for_app(&app_image(home), &probe), InstallChannel::Direct);
-}
-
-#[test]
-fn an_appimage_in_a_directory_that_refuses_writes_is_unknown() {
-    let elsewhere = "/opt/kendex/kendex.AppImage";
-    assert_eq!(
-        for_app(&app_image(elsewhere), &Fake::default()),
-        InstallChannel::Unknown
-    );
-}
-
-#[test]
-fn a_linux_app_launched_outside_an_appimage_is_unknown() {
-    assert_eq!(
-        for_app(&AppInstall::AppImage(None), &Fake::default()),
-        InstallChannel::Unknown
-    );
-}
-
-/// A root-owned machine can write anywhere; the package still owns the file.
-#[test]
-fn a_packaged_appimage_names_its_package_even_where_the_file_is_writable() {
-    let probe = Fake::default()
-        .replaceable(PACKAGED_APP_IMAGE)
-        .os_release(ARCH)
-        .on_path("paru");
-    assert_eq!(
-        for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        aur("paru -S kendex-bin")
-    );
-}
-
-#[test]
-fn usr_local_is_a_hand_install_not_a_package() {
     let local = "/usr/local/lib/kendex/kendex.AppImage";
-    let probe = Fake::default().replaceable(local).os_release(ARCH);
-    assert_eq!(for_app(&app_image(local), &probe), InstallChannel::Direct);
-}
-
-#[test]
-fn an_arch_derivative_naming_arch_in_id_like_is_recognised() {
-    let probe = Fake::default().os_release(CACHYOS).on_path("yay");
-    assert_eq!(
-        for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        aur("yay -S kendex-bin")
-    );
-}
-
-#[test]
-fn a_package_owned_path_on_an_unrecognised_distro_is_unknown() {
-    for probe in [
-        Fake::default().os_release(DEBIAN),
-        Fake::default(),
-        Fake::default().os_release("ID=archlinux\n"),
-    ] {
-        assert_eq!(
-            for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-            InstallChannel::Unknown
-        );
+    let rows: Vec<(&str, AppInstall, Fake, InstallChannel)> = vec![
+        (
+            "an image the person owns",
+            app_image(home),
+            Fake::default().replaceable(home),
+            InstallChannel::Direct,
+        ),
+        (
+            "an image in a directory that refuses writes",
+            app_image("/opt/kendex/kendex.AppImage"),
+            Fake::default(),
+            InstallChannel::Unknown,
+        ),
+        (
+            "launched outside an image",
+            AppInstall::AppImage(None),
+            Fake::default(),
+            InstallChannel::Unknown,
+        ),
+        (
+            "the packaged image on a root-writable machine",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default()
+                .replaceable(PACKAGED_APP_IMAGE)
+                .os_release(ARCH)
+                .on_path("paru"),
+            aur("paru -S kendex-bin"),
+        ),
+        (
+            "a hand install under /usr/local",
+            app_image(local),
+            Fake::default().replaceable(local).os_release(ARCH),
+            InstallChannel::Direct,
+        ),
+        (
+            "an Arch derivative naming arch in ID_LIKE",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default().os_release(CACHYOS).on_path("yay"),
+            aur("yay -S kendex-bin"),
+        ),
+        (
+            "the packaged path on Debian",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default().os_release(DEBIAN),
+            InstallChannel::Unknown,
+        ),
+        (
+            "the packaged path with no os-release",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default(),
+            InstallChannel::Unknown,
+        ),
+        (
+            "the packaged path where ID only starts with arch",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default().os_release("ID=archlinux\n"),
+            InstallChannel::Unknown,
+        ),
+        (
+            "Arch with no AUR helper on PATH",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default().os_release(ARCH),
+            aur("update kendex-bin with your AUR helper"),
+        ),
+        (
+            "Arch with both helpers on PATH",
+            app_image(PACKAGED_APP_IMAGE),
+            Fake::default()
+                .os_release(ARCH)
+                .on_path("yay")
+                .on_path("paru"),
+            aur("paru -S kendex-bin"),
+        ),
+    ];
+    for (label, install, probe, expected) in rows {
+        assert_eq!(for_app(&install, &probe), expected, "{label}");
     }
-}
-
-#[test]
-fn with_no_aur_helper_the_command_is_helper_neutral_prose() {
-    let probe = Fake::default().os_release(ARCH);
-    assert_eq!(
-        for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        aur("update kendex-bin with your AUR helper")
-    );
-}
-
-#[test]
-fn paru_wins_over_yay_when_both_are_installed() {
-    let probe = Fake::default()
-        .os_release(ARCH)
-        .on_path("yay")
-        .on_path("paru");
-    assert_eq!(
-        for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        aur("paru -S kendex-bin")
-    );
 }
 
 #[test]
@@ -256,15 +260,6 @@ fn a_brew_linked_cli_is_brews_to_upgrade_however_it_was_reached() {
     }
 }
 
-/// A real binary at the same place Homebrew would have linked one stays
-/// ours to replace: following the link is what decides, not the prefix.
-#[test]
-fn a_plain_binary_in_usr_local_bin_is_still_a_direct_install() {
-    let exe = "/usr/local/bin/kendex";
-    let probe = Fake::default().replaceable(exe);
-    assert_eq!(for_cli(Path::new(exe), &probe), InstallChannel::Direct);
-}
-
 /// The same name reached through a link into a package's tree belongs to
 /// that package, on the app side as much as the command's. The image is
 /// resolved as the variant is built, so what reaches `for_app` is the file.
@@ -289,29 +284,53 @@ fn an_appimage_reached_through_a_link_belongs_to_whatever_it_points_at() {
     assert_eq!(for_app(&install, &probe), aur("paru -S kendex-bin"));
 }
 
+/// One row per place the command can be found: a plain binary at the very
+/// place Homebrew would have linked one is still ours (following the link is
+/// what decides, not the prefix); a binary in a directory the person can
+/// write updates itself and one they cannot is unknown; a system-owned one
+/// names whichever AUR package put it there, `kendex-bin` where that
+/// package's image is on the machine and `kendex` where only the command is.
 #[test]
-fn a_cli_in_a_writable_user_directory_updates_itself() {
-    let exe = "/home/pat/.local/bin/kendex";
-    let probe = Fake::default().replaceable(exe);
-    assert_eq!(for_cli(Path::new(exe), &probe), InstallChannel::Direct);
-    assert_eq!(
-        for_cli(Path::new(exe), &Fake::default()),
-        InstallChannel::Unknown
-    );
-}
-
-/// The prebuilt package ships both halves, so a machine carrying its
-/// AppImage is told to update that package rather than the CLI-only one.
-#[test]
-fn the_packaged_cli_names_whichever_package_put_it_there() {
-    let exe = Path::new("/usr/bin/kendex");
-    let both = Fake::default()
-        .os_release(ARCH)
-        .on_path("paru")
-        .present(PACKAGED_APP_IMAGE);
-    assert_eq!(for_cli(exe, &both), aur("paru -S kendex-bin"));
-    let cli_only = Fake::default().os_release(ARCH).on_path("paru");
-    assert_eq!(for_cli(exe, &cli_only), aur("paru -S kendex"));
+fn for_cli_names_the_channel_of_each_binary_layout() {
+    let user = "/home/pat/.local/bin/kendex";
+    let rows: [(&str, &str, Fake, InstallChannel); 5] = [
+        (
+            "a plain binary in /usr/local/bin",
+            "/usr/local/bin/kendex",
+            Fake::default().replaceable("/usr/local/bin/kendex"),
+            InstallChannel::Direct,
+        ),
+        (
+            "a binary the person can replace",
+            user,
+            Fake::default().replaceable(user),
+            InstallChannel::Direct,
+        ),
+        (
+            "a binary the person cannot replace",
+            user,
+            Fake::default(),
+            InstallChannel::Unknown,
+        ),
+        (
+            "the packaged command beside the packaged image",
+            "/usr/bin/kendex",
+            Fake::default()
+                .os_release(ARCH)
+                .on_path("paru")
+                .present(PACKAGED_APP_IMAGE),
+            aur("paru -S kendex-bin"),
+        ),
+        (
+            "the packaged command alone",
+            "/usr/bin/kendex",
+            Fake::default().os_release(ARCH).on_path("paru"),
+            aur("paru -S kendex"),
+        ),
+    ];
+    for (label, exe, probe, expected) in rows {
+        assert_eq!(for_cli(Path::new(exe), &probe), expected, "{label}");
+    }
 }
 
 /// Anything a resolver read off the machine — a distro name, an os-release
@@ -353,99 +372,119 @@ fn in_place_replacement_is_refused_off_a_direct_install() {
             "this install came from {AUR_HELPER}; update it with: paru -S kendex-bin"
         ))
     );
-    assert!(InstallChannel::Unknown.allow_replacement().is_err());
+    assert_eq!(
+        InstallChannel::Unknown.allow_replacement(),
+        Err("kendex cannot tell how this copy was installed, so it will not replace it".to_owned())
+    );
 }
 
-/// A running AppImage: the runtime mounts it and both variables point at
-/// that mount, which is where the executable is.
+/// One row per environment the AppImage runtime can leave behind. Both
+/// `APPIMAGE` and `APPDIR` are exported into the environment every child
+/// gets, so a deb launched from a terminal that came out of an image
+/// carries a stranger's pair; only an executable living inside `APPDIR`
+/// says this process is the bundle. With no executable to place, a bare
+/// variable keeps a genuine bundle from being demoted. An exported-but-empty
+/// `APPDIR` is every path's prefix and reads as unset, blank as much as
+/// empty and with no executable to place as much as with one, and a
+/// prefix that matches as a string but not as a path is no prefix.
 #[test]
-fn a_mounted_appimage_is_recognised_by_where_it_runs_from() {
-    assert!(in_appimage(
-        Some(OsStr::new("/home/me/kendex.AppImage")),
-        Some(OsStr::new("/tmp/.mount_kendexAbc")),
-        Some(Path::new("/tmp/.mount_kendexAbc/usr/bin/kendex-app"))
-    ));
-    assert!(!in_appimage(
-        None,
-        None,
-        Some(Path::new("/usr/bin/kendex-app"))
-    ));
-}
-
-/// The other half of the inherited-variable problem: the runtime exports
-/// APPIMAGE into the same environment every child gets, so it says no more
-/// about this process than APPDIR does.
-#[test]
-fn a_stray_appimage_does_not_make_this_an_appimage() {
-    let installed = Path::new("/usr/bin/kendex-app");
-    assert!(!in_appimage(
-        Some(OsStr::new("/home/me/other.AppImage")),
-        None,
-        Some(installed)
-    ));
-    assert!(!in_appimage(
-        Some(OsStr::new("/home/me/other.AppImage")),
-        Some(OsStr::new("/tmp/.mount_otherXyz")),
-        Some(installed)
-    ));
-}
-
-/// Neither variable can be measured against a path we do not have, and a
-/// genuine bundle is not worth demoting to half size over it.
-#[test]
-fn a_bundle_that_cannot_read_its_own_path_is_still_a_bundle() {
-    assert!(in_appimage(
-        Some(OsStr::new("/home/me/kendex.AppImage")),
-        None,
-        None
-    ));
-    assert!(in_appimage(
-        None,
-        Some(OsStr::new("/home/me/kendex.AppDir")),
-        None
-    ));
-    assert!(!in_appimage(None, None, None));
-}
-
-/// An exported-but-empty APPDIR is every path's prefix, so it has to be
-/// read as unset rather than as a directory containing everything.
-#[test]
-fn an_empty_appdir_is_not_a_directory_this_lives_in() {
-    for empty in ["", "   "] {
-        assert!(
-            !in_appimage(
-                None,
-                Some(OsStr::new(empty)),
-                Some(Path::new("/usr/bin/kendex-app"))
+fn in_appimage_reads_the_pair_against_where_this_process_runs() {
+    let mounted = "/tmp/.mount_kendexAbc/usr/bin/kendex-app";
+    let installed = "/usr/bin/kendex-app";
+    let extracted = "/home/me/kendex.AppDir";
+    type Row = (
+        &'static str,
+        Option<&'static str>,
+        Option<&'static str>,
+        Option<&'static str>,
+        bool,
+    );
+    let rows: [Row; 13] = [
+        (
+            "running from the mount",
+            Some("/home/me/kendex.AppImage"),
+            Some("/tmp/.mount_kendexAbc"),
+            Some(mounted),
+            true,
+        ),
+        (
+            "no variables, an installed binary",
+            None,
+            None,
+            Some(installed),
+            false,
+        ),
+        (
+            "a stray image, no dir",
+            Some("/home/me/other.AppImage"),
+            None,
+            Some(installed),
+            false,
+        ),
+        (
+            "a stray pair around an installed binary",
+            Some("/home/me/other.AppImage"),
+            Some("/tmp/.mount_otherXyz"),
+            Some(installed),
+            false,
+        ),
+        (
+            "an image and no executable to place",
+            Some("/home/me/kendex.AppImage"),
+            None,
+            None,
+            true,
+        ),
+        (
+            "a dir and no executable to place",
+            None,
+            Some(extracted),
+            None,
+            true,
+        ),
+        ("nothing at all", None, None, None, false),
+        ("an empty dir", None, Some(""), Some(installed), false),
+        ("a blank dir", None, Some("   "), Some(installed), false),
+        (
+            "running inside the extracted dir",
+            None,
+            Some(extracted),
+            Some("/home/me/kendex.AppDir/usr/bin/kendex-app"),
+            true,
+        ),
+        (
+            "a stray dir around an installed binary",
+            None,
+            Some(extracted),
+            Some(installed),
+            false,
+        ),
+        (
+            "a dir that is only a string prefix",
+            None,
+            Some(extracted),
+            Some("/home/me/kendex.AppDirectory/usr/bin/kendex-app"),
+            false,
+        ),
+        (
+            "a blank dir and no executable to place",
+            None,
+            Some("   "),
+            None,
+            false,
+        ),
+    ];
+    for (label, appimage, appdir, exe, expected) in rows {
+        assert_eq!(
+            in_appimage(
+                appimage.map(OsStr::new),
+                appdir.map(OsStr::new),
+                exe.map(Path::new)
             ),
-            "{empty:?}"
+            expected,
+            "{label}"
         );
     }
-}
-
-/// Every AppImage's AppRun exports APPDIR and everything it starts
-/// inherits it, so a deb launched from a terminal that came out of one
-/// carries a stranger's APPDIR. It only speaks for this process when
-/// this process lives inside it.
-#[test]
-fn a_stray_appdir_does_not_make_this_an_appimage() {
-    let extracted = OsStr::new("/home/me/kendex.AppDir");
-    assert!(in_appimage(
-        None,
-        Some(extracted),
-        Some(Path::new("/home/me/kendex.AppDir/usr/bin/kendex-app"))
-    ));
-    assert!(!in_appimage(
-        None,
-        Some(extracted),
-        Some(Path::new("/usr/bin/kendex-app"))
-    ));
-    // A prefix that only matches as a string, not as a path.
-    assert!(!in_appimage(
-        None,
-        Some(extracted),
-        Some(Path::new("/home/me/kendex.AppDirectory/usr/bin/kendex-app"))
-    ));
 }
 
 /// The variable alone never names this process's own install: a deb or a

--- a/crates/core/src/pi_ext/tests.rs
+++ b/crates/core/src/pi_ext/tests.rs
@@ -256,96 +256,174 @@ fn a_package_without_an_append_system_file_writes_no_block() {
     assert!(!append_system_path(&f.scope).exists());
 }
 
-#[test]
-#[cfg(unix)]
-fn find_by_package_name_reads_sealed_and_skips_symlinked_metadata() {
-    let tmp = tempfile::tempdir().unwrap();
-    let base = tmp.path().canonicalize().unwrap().join("pi-extensions");
-    write(
-        &base.join("pi-hooks/package.json"),
-        "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
-    );
-    write(
-        &base.join("@scope/pi-deep/package.json"),
-        "{\"name\": \"@scope/pi-deep\", \"version\": \"1.0.0\"}",
-    );
-    // A hostile catalog linking metadata at host files must be skipped,
-    // not followed.
-    write(
-        &tmp.path().join("outside.json"),
-        "{\"name\": \"@vg/pi-evil\", \"version\": \"9.9.9\"}",
-    );
-    std::fs::create_dir_all(base.join("pi-evil")).unwrap();
-    std::os::unix::fs::symlink(
-        tmp.path().join("outside.json"),
-        base.join("pi-evil/package.json"),
-    )
-    .unwrap();
-
-    let sealed = crate::source_read::SealedSource::open(base.parent().unwrap()).unwrap();
-    assert_eq!(
-        find_by_package_name(&sealed, "@vg/pi-hooks").unwrap(),
-        Some(base.join("pi-hooks"))
-    );
-    assert_eq!(
-        find_by_package_name(&sealed, "@scope/pi-deep").unwrap(),
-        Some(base.join("@scope/pi-deep"))
-    );
-    assert_eq!(find_by_package_name(&sealed, "@vg/pi-evil").unwrap(), None);
+/// What a lookup by package name answers.
+#[derive(Debug)]
+#[cfg_attr(
+    not(unix),
+    allow(dead_code, reason = "Found and Absent are built only by the link rows")
+)]
+enum Answer {
+    /// The directory registering the name, under the catalog.
+    Found(&'static str),
+    Absent,
+    /// The `PiPackage` refusal, its message whole.
+    Refused(String),
 }
 
+/// One row per catalog shape a lookup by package name reads through the
+/// seal. A package at its plain directory and one under its npm scope are
+/// found. A hostile catalog linking metadata at host files must be
+/// skipped, not followed, with the scan going on to the real package
+/// beside it, and a catalog whose `pi-extensions` is itself a
+/// symlink out of the catalog must not have the escape laundered by
+/// sealing the folder as a root: the traversal stays beneath the catalog's
+/// own seal and refuses the link, so neither answers. Two directories
+/// registering one name is a refusal to pick one. The scan carries one
+/// aggregate budget across both levels — thousands of scope directories
+/// must not multiply into millions of candidates — and past it is a
+/// refusal to scan. The link rows run where a test can make a link
+/// without a privilege.
 #[test]
-fn find_by_package_name_refuses_an_ambiguous_registration() {
-    let tmp = tempfile::tempdir().unwrap();
-    let base = tmp.path().canonicalize().unwrap().join("pi-extensions");
-    for dir in ["first", "second"] {
-        write(
-            &base.join(dir).join("package.json"),
-            "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
-        );
-    }
-    let sealed = crate::source_read::SealedSource::open(base.parent().unwrap()).unwrap();
-    let error = find_by_package_name(&sealed, "@vg/pi-hooks").unwrap_err();
-    assert!(
-        error.to_string().contains("refusing to pick one"),
-        "{error}"
-    );
-}
+#[allow(
+    clippy::too_many_lines,
+    reason = "one table: seven catalog shapes read by one lookup, each row a layout of its own"
+)]
+fn find_by_package_name_answers_for_each_catalog_shape() {
+    /// The catalog laid out under the temp root, and the answer.
+    /// The catalog laid out under the temp root, the name looked up,
+    /// and the answer.
+    type Plant = fn(&Path) -> (PathBuf, &'static str, Answer);
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, Plant)> = vec![
+        ("two directories registering the name", |tmp| {
+            let catalog = tmp.join("catalog");
+            let base = catalog.join("pi-extensions");
+            for dir in ["first", "second"] {
+                write(
+                    &base.join(dir).join("package.json"),
+                    "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
+                );
+            }
+            let refused = format!(
+                "2 directories under {} register this package name — refusing to pick one",
+                base.display()
+            );
+            (catalog, "@vg/pi-hooks", Answer::Refused(refused))
+        }),
+        ("more candidates than the scan budget", |tmp| {
+            let catalog = tmp.join("catalog");
+            let base = catalog.join("pi-extensions");
+            for scope in 0..3 {
+                for pkg in 0..2000 {
+                    std::fs::create_dir_all(base.join(format!("@s{scope}/p{pkg}"))).unwrap();
+                }
+            }
+            let refused = format!(
+                "more than 4096 package directories under {} — refusing to scan them all",
+                base.display()
+            );
+            (catalog, "@vg/pi-hooks", Answer::Refused(refused))
+        }),
+    ];
+    #[cfg(unix)]
+    rows.extend([
+        (
+            "a package at its plain directory",
+            (|tmp| {
+                let catalog = tmp.join("catalog");
+                write(
+                    &catalog.join("pi-extensions/pi-hooks/package.json"),
+                    "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
+                );
+                (
+                    catalog,
+                    "@vg/pi-hooks",
+                    Answer::Found("pi-extensions/pi-hooks"),
+                )
+            }) as Plant,
+        ),
+        ("a package under its npm scope", |tmp| {
+            let catalog = tmp.join("catalog");
+            write(
+                &catalog.join("pi-extensions/@scope/pi-deep/package.json"),
+                "{\"name\": \"@scope/pi-deep\", \"version\": \"1.0.0\"}",
+            );
+            (
+                catalog,
+                "@scope/pi-deep",
+                Answer::Found("pi-extensions/@scope/pi-deep"),
+            )
+        }),
+        ("metadata linked at a host file", |tmp| {
+            let catalog = tmp.join("catalog");
+            write(
+                &tmp.join("outside.json"),
+                "{\"name\": \"@vg/pi-hooks\", \"version\": \"9.9.9\"}",
+            );
+            std::fs::create_dir_all(catalog.join("pi-extensions/pi-evil")).unwrap();
+            std::os::unix::fs::symlink(
+                tmp.join("outside.json"),
+                catalog.join("pi-extensions/pi-evil/package.json"),
+            )
+            .unwrap();
+            (catalog, "@vg/pi-hooks", Answer::Absent)
+        }),
+        // The hostile entry is skipped and the scan goes on to the real
+        // package beside it.
+        ("a hostile entry beside a real package", |tmp| {
+            let catalog = tmp.join("catalog");
+            write(
+                &catalog.join("pi-extensions/pi-hooks/package.json"),
+                "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
+            );
+            write(
+                &tmp.join("outside.json"),
+                "{\"name\": \"@vg/pi-hooks\", \"version\": \"9.9.9\"}",
+            );
+            std::fs::create_dir_all(catalog.join("pi-extensions/pi-evil")).unwrap();
+            std::os::unix::fs::symlink(
+                tmp.join("outside.json"),
+                catalog.join("pi-extensions/pi-evil/package.json"),
+            )
+            .unwrap();
+            (
+                catalog,
+                "@vg/pi-hooks",
+                Answer::Found("pi-extensions/pi-hooks"),
+            )
+        }),
+        ("an extensions folder linked out of the catalog", |tmp| {
+            let outside = tmp.join("outside");
+            write(
+                &outside.join("pi-hooks/package.json"),
+                "{\"name\": \"@vg/pi-hooks\", \"version\": \"9.9.9\"}",
+            );
+            let catalog = tmp.join("catalog");
+            std::fs::create_dir_all(&catalog).unwrap();
+            std::os::unix::fs::symlink(&outside, catalog.join("pi-extensions")).unwrap();
+            (catalog, "@vg/pi-hooks", Answer::Absent)
+        }),
+    ]);
 
-/// A catalog whose `pi-extensions` is itself a symlink out of the catalog
-/// must not have the escape laundered by sealing the folder as a root —
-/// the traversal stays beneath the catalog's own seal and refuses the
-/// link.
-#[test]
-#[cfg(unix)]
-fn find_by_package_name_refuses_a_symlinked_extensions_folder() {
-    let tmp = tempfile::tempdir().unwrap();
-    let outside = tmp.path().canonicalize().unwrap().join("outside");
-    write(
-        &outside.join("pi-hooks/package.json"),
-        "{\"name\": \"@vg/pi-hooks\", \"version\": \"9.9.9\"}",
-    );
-    let catalog = tmp.path().canonicalize().unwrap().join("catalog");
-    std::fs::create_dir_all(&catalog).unwrap();
-    std::os::unix::fs::symlink(&outside, catalog.join("pi-extensions")).unwrap();
-
-    let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
-    assert_eq!(find_by_package_name(&sealed, "@vg/pi-hooks").unwrap(), None);
-}
-
-/// The scan carries one aggregate budget across both levels — thousands
-/// of scope directories must not multiply into millions of candidates.
-#[test]
-fn find_by_package_name_bounds_the_aggregate_scan() {
-    let tmp = tempfile::tempdir().unwrap();
-    let catalog = tmp.path().canonicalize().unwrap().join("catalog");
-    let base = catalog.join("pi-extensions");
-    for scope in 0..3 {
-        for pkg in 0..2000 {
-            std::fs::create_dir_all(base.join(format!("@s{scope}/p{pkg}"))).unwrap();
+    for (label, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let (catalog, name, answer) = plant(&tmp.path().canonicalize().unwrap());
+        let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
+        let found = find_by_package_name(&sealed, name);
+        match (&answer, found) {
+            (Answer::Found(at), Ok(found)) => assert_eq!(found, Some(catalog.join(at)), "{label}"),
+            (Answer::Absent, Ok(found)) => assert_eq!(found, None, "{label}"),
+            (
+                Answer::Refused(why),
+                Err(CoreError::PiPackage {
+                    name: named,
+                    message,
+                }),
+            ) => {
+                assert_eq!(named, name, "{label}");
+                assert_eq!(&message, why, "{label}");
+            }
+            (expected, got) => panic!("{label}: expected {expected:?}, got {got:?}"),
         }
     }
-    let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
-    let error = find_by_package_name(&sealed, "@vg/pi-hooks").unwrap_err();
-    assert!(error.to_string().contains("refusing to scan"), "{error}");
 }

--- a/crates/core/src/pi_ext/tests.rs
+++ b/crates/core/src/pi_ext/tests.rs
@@ -407,7 +407,9 @@ fn find_by_package_name_answers_for_each_catalog_shape() {
 
     for (label, plant) in rows {
         let tmp = tempfile::tempdir().unwrap();
-        let (catalog, name, answer) = plant(&tmp.path().canonicalize().unwrap());
+        // The catalog's one spelling, which is what a refusal names the
+        // base by (no `\\?\` prefix on Windows).
+        let (catalog, name, answer) = plant(&crate::paths::canonical(tmp.path()).unwrap());
         let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
         let found = find_by_package_name(&sealed, name);
         match (&answer, found) {

--- a/crates/core/src/source_read/tests.rs
+++ b/crates/core/src/source_read/tests.rs
@@ -14,75 +14,19 @@ fn fixture() -> (tempfile::TempDir, SealedSource) {
 }
 
 #[test]
-fn reads_inside_the_root_and_refuses_escapes() {
-    let (tmp, sealed) = fixture();
+fn reads_inside_the_root() {
+    let (_tmp, sealed) = fixture();
     let inside = sealed.root().join("skills/gh/SKILL.md");
     assert!(sealed.is_file(&inside));
-    assert!(sealed.read_to_string(&inside).is_ok());
-
-    let outside = tmp.path().join("secret.txt");
-    assert!(!sealed.is_file(&outside));
-    assert!(matches!(
-        sealed.read(&outside),
-        Err(CoreError::SourceEscape { .. })
-    ));
-    let dotted = sealed.root().join("skills/../../secret.txt");
-    assert!(matches!(
-        sealed.read(&dotted),
-        Err(CoreError::SourceEscape { .. })
-    ));
-}
-
-#[cfg(unix)]
-#[test]
-fn symlinks_are_refused_through_every_read_path() {
-    let (tmp, sealed) = fixture();
-    let secret = tmp.path().join("secret.txt");
-    std::os::unix::fs::symlink(&secret, sealed.root().join("skills/gh/leak.md")).expect("symlink");
-    let leak = sealed.root().join("skills/gh/leak.md");
-    assert!(!sealed.is_file(&leak));
-    assert!(matches!(
-        sealed.read(&leak),
-        Err(CoreError::SourceEscape { .. })
-    ));
-    assert!(matches!(
-        sealed.collect_tree(&sealed.root().join("skills/gh"), &[]),
-        Err(CoreError::SourceEscape { .. })
-    ));
-    assert!(matches!(
-        sealed.hash_tree(&sealed.root().join("skills/gh")),
-        Err(CoreError::SourceEscape { .. })
-    ));
-
-    // A symlinked directory cannot recurse forever either.
-    std::fs::remove_file(&leak).expect("rm");
-    std::os::unix::fs::symlink(sealed.root(), sealed.root().join("skills/gh/loop"))
-        .expect("symlink");
-    assert!(matches!(
-        sealed.collect_tree(sealed.root(), &[]),
-        Err(CoreError::SourceEscape { .. })
-    ));
-}
-
-#[test]
-fn tree_budgets_bound_hostile_catalogs() {
-    let (_tmp, sealed) = fixture();
-    let mut nested = sealed.root().join("skills/deep");
-    for _ in 0..(MAX_TREE_DEPTH + 2) {
-        nested = nested.join("d");
-    }
-    std::fs::create_dir_all(&nested).expect("mkdir");
-    std::fs::write(nested.join("f"), "x").expect("write");
-    assert!(matches!(
-        sealed.collect_tree(&sealed.root().join("skills/deep"), &[]),
-        Err(CoreError::SourceEscape { .. })
-    ));
+    assert_eq!(
+        sealed.read_to_string(&inside).unwrap(),
+        "---\nname: gh\n---\n"
+    );
 }
 
 /// The bound is a ceiling, not a wall one short of it: a directory
-/// holding exactly the limit is inside it and must still read. The bound
-/// is a refusal to do the work, which is the whole answer, not one row a
-/// listing can go on without.
+/// holding exactly the limit is inside it and must still read. The entry
+/// after that is the row below.
 #[test]
 fn the_directory_bound_admits_exactly_the_limit() {
     let (_tmp, sealed) = fixture();
@@ -92,12 +36,141 @@ fn the_directory_bound_admits_exactly_the_limit() {
         std::fs::write(dir.join(format!("f{n}")), "x").expect("write");
     }
     assert_eq!(sealed.entries(&dir).expect("list").len(), MAX_DIR_ENTRIES);
+}
 
-    std::fs::write(dir.join("one-too-many"), "x").expect("write");
-    assert!(matches!(
-        sealed.entries(&dir),
-        Err(CoreError::SourceEscape { .. })
-    ));
+/// One row per read the sealed door refuses, each a `SourceEscape` naming
+/// the path it stopped at and the reason only that arm gives. A path
+/// outside the root and a dotted path climbing out of it; a link, through
+/// every read path (a file read, a collected tree, a hashed tree) and as a
+/// directory that would recurse forever; a tree nesting past the depth
+/// bound; and a directory one entry past the entry bound, which is a
+/// refusal to do the work — the whole answer, not one row a listing can
+/// go on without. Where the refused path is a file the collapsed reading
+/// answers no for it too. The link rows run where a test can make a link
+/// without a privilege.
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one table: eight escapes refused by one seal, each row a read of its own"
+)]
+fn every_escape_is_refused_naming_the_path_and_the_reason() {
+    /// The refused call, the path the refusal names, and its reason.
+    type Act = fn(&Path, &SealedSource) -> (Result<()>, PathBuf, String);
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, bool, Act)> = vec![
+        ("a path outside the root", true, |tmp, sealed| {
+            let outside = tmp.join("secret.txt");
+            (
+                sealed.read(&outside).map(drop),
+                outside,
+                "outside the source root".to_owned(),
+            )
+        }),
+        ("a dotted path climbing out", true, |_, sealed| {
+            let dotted = sealed.root().join("skills/../../secret.txt");
+            (
+                sealed.read(&dotted).map(drop),
+                dotted,
+                "path traversal in a catalog path".to_owned(),
+            )
+        }),
+        ("a tree deeper than the bound", false, |_, sealed| {
+            let deep = sealed.root().join("skills/deep");
+            let mut nested = deep.clone();
+            let mut past = deep.clone();
+            for level in 0..(MAX_TREE_DEPTH + 2) {
+                nested = nested.join("d");
+                if level <= MAX_TREE_DEPTH {
+                    past = past.join("d");
+                }
+            }
+            std::fs::create_dir_all(&nested).expect("mkdir");
+            std::fs::write(nested.join("f"), "x").expect("write");
+            (
+                sealed.collect_tree(&deep, &[]).map(drop),
+                past,
+                format!("catalog tree nests deeper than {MAX_TREE_DEPTH} levels"),
+            )
+        }),
+        (
+            "a directory one entry past the bound",
+            false,
+            |_, sealed| {
+                let dir = sealed.root().join("many");
+                std::fs::create_dir_all(&dir).expect("mkdir");
+                for n in 0..=MAX_DIR_ENTRIES {
+                    std::fs::write(dir.join(format!("f{n}")), "x").expect("write");
+                }
+                (
+                    sealed.entries(&dir).map(drop),
+                    dir,
+                    format!("more than {MAX_DIR_ENTRIES} entries in one catalog directory"),
+                )
+            },
+        ),
+    ];
+    #[cfg(unix)]
+    {
+        rows.extend([
+            (
+                "a link read as a file",
+                true,
+                (|tmp, sealed| {
+                    let leak = sealed.root().join("skills/gh/leak.md");
+                    std::os::unix::fs::symlink(tmp.join("secret.txt"), &leak).expect("symlink");
+                    (
+                        sealed.read(&leak).map(drop),
+                        leak,
+                        "symlink in a catalog — refusing to read through it".to_owned(),
+                    )
+                }) as Act,
+            ),
+            ("a link inside a collected tree", false, |tmp, sealed| {
+                let leak = sealed.root().join("skills/gh/leak.md");
+                std::os::unix::fs::symlink(tmp.join("secret.txt"), &leak).expect("symlink");
+                (
+                    sealed
+                        .collect_tree(&sealed.root().join("skills/gh"), &[])
+                        .map(drop),
+                    leak,
+                    "symlink in a catalog — refusing to read through it".to_owned(),
+                )
+            }),
+            ("a link inside a hashed tree", false, |tmp, sealed| {
+                let leak = sealed.root().join("skills/gh/leak.md");
+                std::os::unix::fs::symlink(tmp.join("secret.txt"), &leak).expect("symlink");
+                (
+                    sealed.hash_tree(&sealed.root().join("skills/gh")).map(drop),
+                    leak,
+                    "symlink in a catalog — refusing to read through it".to_owned(),
+                )
+            }),
+            ("a link that would recurse forever", false, |_, sealed| {
+                let looped = sealed.root().join("skills/gh/loop");
+                std::os::unix::fs::symlink(sealed.root(), &looped).expect("symlink");
+                (
+                    sealed.collect_tree(sealed.root(), &[]).map(drop),
+                    looped,
+                    "symlink in a catalog — refusing to read through it".to_owned(),
+                )
+            }),
+        ]);
+    }
+
+    for (label, not_a_file, act) in rows {
+        let (tmp, sealed) = fixture();
+        let (refused, at, why) = act(tmp.path(), &sealed);
+        match refused {
+            Err(CoreError::SourceEscape { path, reason }) => {
+                assert_eq!(path, at, "{label}");
+                assert_eq!(reason, why, "{label}");
+            }
+            other => panic!("{label}: expected a refused read, got {other:?}"),
+        }
+        if not_a_file {
+            assert!(!sealed.is_file(&at), "{label}");
+        }
+    }
 }
 
 /// A skill that is the whole repository excludes VCS internals and


### PR DESCRIPTION
The first of three `crates/core/src` PRs of the tests audit (the classification pass covered all 160 in-crate test modules; 44 carry findings). This one is the refusal families: eight modules whose cases each planted one layout, called one function and asserted a refusal, written as one `#[test]` per layout or read as `is_err()` / a substring of the Display string where the `CoreError` variant and its fields discriminate. Test code only; no production Rust changes; `[no-changelog]`.

## Folded or deleted cases, with the surviving row

| Former cases | Surviving table or case |
|---|---|
| `install_channel/tests.rs`: `an_appimage_the_person_owns_updates_in_place`, `an_appimage_in_a_directory_that_refuses_writes_is_unknown`, `a_linux_app_launched_outside_an_appimage_is_unknown`, `a_packaged_appimage_names_its_package_even_where_the_file_is_writable`, `usr_local_is_a_hand_install_not_a_package`, `an_arch_derivative_naming_arch_in_id_like_is_recognised`, `a_package_owned_path_on_an_unrecognised_distro_is_unknown` (three probes), `with_no_aur_helper_the_command_is_helper_neutral_prose`, `paru_wins_over_yay_when_both_are_installed` | `for_app_names_the_channel_of_each_appimage_layout`, 11 rows of (install, probe, channel) |
| `install_channel/tests.rs`: `a_mounted_appimage_is_recognised_by_where_it_runs_from`, `a_stray_appimage_does_not_make_this_an_appimage`, `a_bundle_that_cannot_read_its_own_path_is_still_a_bundle`, `an_empty_appdir_is_not_a_directory_this_lives_in`, `a_stray_appdir_does_not_make_this_an_appimage` | `in_appimage_reads_the_pair_against_where_this_process_runs`, 13 rows of (APPIMAGE, APPDIR, exe, answer): the twelve former asserts plus one the reviewer's mutation showed missing, a blank `APPDIR` with no executable to place (the only row that can fail when the whitespace trim goes) |
| `install_channel/tests.rs`: `a_plain_binary_in_usr_local_bin_is_still_a_direct_install`, `a_cli_in_a_writable_user_directory_updates_itself` (two asserts), `the_packaged_cli_names_whichever_package_put_it_there` (two asserts) | `for_cli_names_the_channel_of_each_binary_layout`, 5 rows |
| `engine/adopt/tests/slots.rs`: `a_plain_skill_over_the_namespaced_one_stored_there_refuses`, `_over_a_differently_cased_namespaced_one_refuses`, `_over_a_slot_whose_listing_fails_refuses`, `_over_a_slot_in_an_unreadable_local_source_refuses`, `_over_a_slot_holding_a_differently_named_item_refuses`, `_over_an_item_stored_deeper_in_its_slot_refuses`, `_over_a_slot_too_wide_to_search_refuses`, `_over_a_slot_no_listing_names_refuses`, `_over_itself_beside_a_namespaced_one_refuses`, `_whose_parent_is_past_the_entry_bound_refuses`, `_whose_parent_will_not_enumerate_refuses` (unix), `_over_a_child_that_cannot_be_probed_refuses` (unix); the `refuse_plain_skill` helper | `a_plain_skill_over_an_occupied_or_unreadable_slot_refuses`, 12 rows with a typed `Refusal` column: `Occupant(held)` asserts the `AdoptNameUnusable { name, problem }` fields whole (the occupant is spelled as the source-relative path, `skills/data-science/eda`), `Bound(path, reason)` asserts the `SourceEscape` fields, `Unreadable(path)` the `Io` path; the trash is counted before and after every row; the two unix rows keep the root fallback and put the mode back before the byte read. Losses: the first case's `manifest.declared(...)["data-science/eda"].source == LOCAL_SOURCE_NAME` assertion (the listing and the resolved path stay as the `listed` column); its trailing "handmade lands" control, a duplicate of `a_plain_skill_over_an_earlier_copy_of_itself_lands`. The two `lands` cases stay as the must-fail inverse |
| `engine/adopt/tests/links.rs`: `a_link_at_a_folder_without_the_marker_still_refuses`, `a_project_link_into_the_global_tree_refuses`, `a_global_link_across_names_in_the_shared_tree_refuses`, `a_link_into_the_shared_tree_at_another_name_refuses` | `a_link_into_a_folder_that_is_not_this_skills_own_refuses` (unix), 4 rows pinning `ForeignSymlink { target, points_to }`, the link still a link, the target's bytes and the trash empty on every row (only the first case asserted the link; only the last asserted the trash) |
| `engine/adopt/tests/links.rs`: `an_absolute_name_captures_and_trashes_nothing`, `a_traversal_name_captures_and_trashes_nothing` | `a_name_that_is_not_a_name_captures_and_trashes_nothing`, 2 rows pinning `AdoptNameUnusable.name` to `names::shown(name)`; the `problem` field is `names::item_problem`'s and its rows belong to `names.rs` (PR three of this series) |
| `engine/compared/tests.rs`: `of_file_refuses_a_link_a_directory_and_an_absent_path`, the `of_file` half of `a_file_bigger_than_the_bound_gives_no_answer` | `of_file_gives_no_answer_off_anything_but_a_plain_readable_file`, 4 rows (the link row under `cfg(unix)`) |
| `engine/compared/tests.rs`: `a_tree_past_the_cumulative_budget_gives_no_answer`, `a_link_inside_the_tree_refuses_the_whole_comparison`, `a_folder_that_will_not_enumerate_refuses_rather_than_dropping_out`, `a_tree_with_more_entries_than_the_bound_gives_no_answer`, the `of_tree` half of `a_file_bigger_than_the_bound_gives_no_answer`, `a_tree_deeper_than_the_bound_gives_no_answer`, `an_entry_that_is_neither_file_nor_directory_stops_the_answer` | `of_tree_gives_no_answer_past_a_bound_or_off_an_entry_it_will_not_read`, 7 rows; each at-bound control ("the budget itself still reads", "the plain tree compares", "readable, so it compares") is the row's `at_bound` build, and the entries row keeps its `differing_total` and `SHOWN_DIFFERING` counts |
| `apply/tests.rs`: `stale_precondition_aborts_and_rolls_back`, the refused half of `a_refused_write_makes_no_directory_and_a_passing_one_does`, `a_copy_that_changed_still_stops_the_removal`, `a_copy_that_cannot_be_read_stops_the_removal` (unix) | `a_refused_op_rolls_back_naming_its_cause_and_leaves_the_bytes`, 4 rows pinning the `RolledBack` cause as `PlanStale { path }` or `Io { path }` (every former case matched `RolledBack { .. }` alone); the passing half is `a_write_whose_precondition_holds_makes_its_chain`. `a_refusal_part_way_through_rolls_back_what_ran_before_it` stays a case and pins its cause too |
| `command_update/tests.rs`: `a_feed_on_another_release_moves_neither_half` (two skew rows), `a_release_with_no_command_for_this_target_stops_the_family`, `a_command_binary_that_fails_verification_is_never_written` (two rows) | `the_command_half_refuses_by_name_and_moves_neither_half`, 5 rows; the skew and no-target rows pin the arm's whole `String` message, the two bad-download rows pin everything up to the verifier's or decoder's own words ("nothing was updated" is every arm's clause and is never the pin by itself); `INSTALLED` intact and no staged file on every row. The build-metadata control is `build_metadata_on_the_release_is_not_skew` |
| `source_read/tests.rs`: the refused half of `reads_inside_the_root_and_refuses_escapes` (the positive half is `reads_inside_the_root`), `symlinks_are_refused_through_every_read_path`, `tree_budgets_bound_hostile_catalogs`, the refused half of `the_directory_bound_admits_exactly_the_limit` | `every_escape_is_refused_naming_the_path_and_the_reason`, 8 rows pinning `SourceEscape { path, reason }` whole; the two `!is_file` bits are the `not_a_file` column |
| `pi_ext/tests.rs`: `find_by_package_name_reads_sealed_and_skips_symlinked_metadata`, `find_by_package_name_refuses_an_ambiguous_registration`, `find_by_package_name_refuses_a_symlinked_extensions_folder`, `find_by_package_name_bounds_the_aggregate_scan` | `find_by_package_name_answers_for_each_catalog_shape`, 7 rows of (catalog, name, answer): both `PiPackage` messages whole with the base path, and a row the reviewer's mutation showed missing, a hostile entry beside a real package (the former case put both in one catalog; the split rows had lost "skipped, and the scan goes on") |

Truthiness bits now matching the variant: `install_channel/tests.rs::in_place_replacement_is_refused_off_a_direct_install` (the Unknown arm's `Err` value), `engine/adopt/tests/links.rs::a_target_that_changed_after_planning_fails_the_apply` (`RolledBack { cause: PlanStale { path } }`).

`command_update`'s errors are `Result<_, String>`; a typed discriminant there is a production change and out of scope, so the rows pin the message.

## Mutation

One must-fail mutant per surviving table, twelve tables, all killed (`mutants-refusals.txt` in the lane scratchpad; `mutate-refusals.py` mutates production in place and restores it from `HEAD`): yay preferred over paru; a blank `APPDIR` read as a directory; the packaged command always named `kendex-bin`; an occupied slot read as free; the SKILL.md marker not required behind a link; every name usable; `of_file` reading one byte past its bound; the tree depth unbounded; `Pre::Absent` holding over a file; any release read as the app's; a catalog nesting one level deeper before refusing; an ambiguous registration picking one.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, all applied. Blockers: the `pi_ext` fold had lost the hostile-entry-beside-a-real-package shape (the reviewer's mutant `hostile-entry-stops-the-scan` survived; the row above kills it); the `in_appimage` table's blank-`APPDIR` row could not fail with an executable to place (my own mutant survived; the no-executable row kills it). Suggestions, all taken: `Refusal::Bound` now carries the `SourceEscape` path and reason; `slots.rs` restores the directory mode before `unwrap_err()` so a regression cannot leave a 0o000 directory the TempDir cannot remove; the `pi_ext` looked-up name is a column rather than derived from the answer; the minisign row pins up to the verifier's words rather than its sentence; the passing-write case is named for what it does; `Held.keep` is gone (dropping the listener leaves the socket in the tree); the invalid `of_file` mutant is replaced; the row types dead on Windows carry `cfg_attr(not(unix), allow(dead_code))` so `cargo check --target x86_64-pc-windows-msvc` gains no warning from this diff. The reviewer's sixteen further mutants, one per row class the recorded mutant does not reach, all killed through the named row.

## Checks

- `cargo test -p kendex-core --lib`: green but for the one environment case (`discover::tests::project_root_walks_up_and_lock_file_wins_at_home`, which fails on main here because the owner's home carries a `.agents` directory; it passed in the reviewer's copy); `cargo clippy -p kendex-core --all-targets -- -D warnings` clean; `cargo fmt -p kendex-core -- --check` clean; `cargo check -p kendex-core --all-targets --target x86_64-pc-windows-msvc` adds no warning.
- `tools/guard --full`: exit 0 on 6f7753045 (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as ddb40c65f by the push.

KEN-1241

https://claude.ai/code/session_01NQ3TkQ6WiREfzEEH4nHGmc
