### PR TITLE
test(KEN-1241): kendex-core text-shape families as tables [no-changelog]

### DIFF
--- a/crates/core/src/frontmatter/tests.rs
+++ b/crates/core/src/frontmatter/tests.rs
@@ -9,8 +9,14 @@ fn splits_on_exact_terminator_lines_only() {
     let (yaml, body) = split("---\nname: x\n---\nBody --- dashes\n").unwrap();
     assert_eq!(yaml, "name: x\n");
     assert_eq!(body, "Body --- dashes\n");
-    assert!(split("---\nname: x\n----broken\n").is_err());
-    assert!(split("no frontmatter").is_err());
+    assert_eq!(
+        split("---\nname: x\n----broken\n"),
+        Err("unterminated frontmatter".to_owned())
+    );
+    assert_eq!(
+        split("no frontmatter"),
+        Err("file has no frontmatter".to_owned())
+    );
     // Trailing whitespace on either marker is tolerated.
     let (yaml, _) = split("--- \nname: x\n---  \nBody\n").unwrap();
     assert_eq!(yaml, "name: x\n");
@@ -56,14 +62,6 @@ fn plain_inline_values_are_taken_verbatim_like_harness_loaders_do() {
 }
 
 #[test]
-fn strict_keys_get_no_salvage() {
-    assert!(parse_tolerant("tools: *x\n").is_err());
-    assert!(parse_tolerant("role: *alias\n").is_err());
-    let broken_block = "description: |bad\n  content\n";
-    assert!(parse_tolerant(broken_block).is_err());
-}
-
-#[test]
 fn absent_empty_and_csv_lists_stay_distinct() {
     let parsed = parse_tolerant("tools:\nother: Read, Grep , \n").unwrap();
     assert_eq!(
@@ -76,26 +74,76 @@ fn absent_empty_and_csv_lists_stay_distinct() {
     assert_eq!(flow.map.string_list("tools").unwrap(), Vec::<String>::new());
 }
 
+/// One row per YAML the parsers refuse, and the refusal: the whole
+/// message where the parser composes it, and the key it names where the
+/// YAML library's own words follow. A strict key gets no salvage: an anchor
+/// under `tools` or `role`, and a broken block scalar, are refused
+/// outright. Adversarial YAML is refused by name: aliases, a duplicate
+/// key, nesting past the depth bound, a document past the byte bound,
+/// more nodes than the bound, complex keys, and multiple documents.
 #[test]
-fn adversarial_yaml_is_refused() {
-    assert!(parse("a: &x 1\nb: *x\n").unwrap_err().contains("alias"));
-    assert!(
-        parse_tolerant("a: 1\na: 2\n")
-            .unwrap_err()
-            .contains("duplicate")
-    );
+fn a_yaml_the_parsers_refuse_is_named_by_what_it_did() {
     let deep = format!("a: {}{}", "[".repeat(40), "]".repeat(40));
-    assert!(parse_tolerant(&deep).unwrap_err().contains("deeper"));
     let big = format!("a: {}\n", "x".repeat(MAX_YAML_BYTES));
-    assert!(parse_tolerant(&big).unwrap_err().contains("bytes"));
     let many = "k: [".to_owned() + &"a,".repeat(MAX_NODES + 1) + "]";
-    assert!(parse_tolerant(&many).unwrap_err().contains("nodes"));
-    assert!(
-        parse("? [a, b]\n: c\n")
-            .unwrap_err()
-            .contains("complex keys")
-    );
-    assert!(parse("a: 1\n---\nb: 2\n").unwrap_err().contains("multiple"));
+    let rows: [(&str, bool, &str, bool); 10] = [
+        ("tools: *x\n", true, "`tools`: ", false),
+        ("role: *alias\n", true, "`role`: ", false),
+        (
+            "description: |bad\n  content\n",
+            true,
+            "`description`: ",
+            false,
+        ),
+        (
+            "a: &x 1\nb: *x\n",
+            false,
+            "YAML aliases are not accepted in frontmatter",
+            true,
+        ),
+        ("a: 1\na: 2\n", true, "duplicate frontmatter key `a`", true),
+        (
+            &deep,
+            true,
+            "`a`: frontmatter nests deeper than 16 levels",
+            true,
+        ),
+        (
+            &big,
+            true,
+            "frontmatter is 65540 bytes — the limit is 65536",
+            true,
+        ),
+        (
+            &many,
+            true,
+            "`k`: frontmatter exceeds 4096 YAML nodes",
+            true,
+        ),
+        (
+            "? [a, b]\n: c\n",
+            false,
+            "YAML complex keys are not accepted in frontmatter",
+            true,
+        ),
+        (
+            "a: 1\n---\nb: 2\n",
+            false,
+            "multiple YAML documents in frontmatter",
+            true,
+        ),
+    ];
+    for (yaml, tolerant, refusal, whole) in rows {
+        let refused = match tolerant {
+            true => parse_tolerant(yaml).map(drop),
+            false => parse(yaml).map(drop),
+        }
+        .unwrap_err();
+        match whole {
+            true => assert_eq!(refused, refusal, "{yaml:?}"),
+            false => assert!(refused.starts_with(refusal), "{yaml:?}: {refused}"),
+        }
+    }
 }
 
 #[test]

--- a/crates/core/src/manifest/fold/tests.rs
+++ b/crates/core/src/manifest/fold/tests.rs
@@ -193,7 +193,9 @@ fn an_unparsable_document_is_refused() {
 
 /// The tools an agent is denied, as somebody annotates them: a comment after
 /// each of two entries, on the lines those entries sit on.
-const DENIED: &str = "schema = 6\n\n[agent-frontmatter.claude.orch]\ndeny-tools = [\n  \"Bash\",   # no shells\n  \"Write\",   # no writing files\n  \"WebFetch\",\n]\n";
+/// A hand-written list: two values annotated, one not, one per line.
+const ANNOTATED: &str =
+    "[\n  \"Bash\",   # no shells\n  \"Write\",   # no writing files\n  \"WebFetch\",\n]";
 
 /// The tools' own list, with `deny-tools` reached through the model.
 #[allow(clippy::unwrap_used)]
@@ -207,59 +209,6 @@ fn denied(manifest: &mut Manifest) -> &mut Vec<String> {
         .deny_tools
         .as_mut()
         .unwrap()
-}
-
-/// A re-sorted array of VALUES moves each comment with the value it was
-/// written about. TOML keeps the run between one value and the next against
-/// the LOWER value, so an annotation is stored on the entry below the one it
-/// describes; rebuilding from raw decoration hands it to whatever lands in
-/// that slot, and every comment then states something false.
-///
-/// `Manifest::suppress` sorts on every removal and the desktop editor rewrites
-/// these lists wholesale, so this is an ordinary `kendex remove` away.
-#[test]
-fn a_re_sorted_array_of_values_keeps_each_comment_on_its_own_value() {
-    assert_eq!(
-        folding(DENIED, |manifest| denied(manifest).sort()),
-        "schema = 6\n\n[agent-frontmatter.claude.orch]\ndeny-tools = [\n  \"Bash\",   # no shells\n  \"WebFetch\",\n  \"Write\",   # no writing files\n]\n"
-    );
-}
-
-/// A dropped value takes its own comment and leaves every other comment on the
-/// value it was written about — including the entry above it, whose annotation
-/// is stored in the dropped entry's own decoration.
-#[test]
-fn a_dropped_value_takes_its_own_comment_and_no_other() {
-    assert_eq!(
-        folding(DENIED, |manifest| {
-            denied(manifest).remove(1);
-        }),
-        "schema = 6\n\n[agent-frontmatter.claude.orch]\ndeny-tools = [\n  \"Bash\",   # no shells\n  \"WebFetch\",\n]\n"
-    );
-}
-
-/// A gained value takes the shape the list is already in — the indent its
-/// neighbours use and a line of its own — rather than the serializer's, and a
-/// list nothing is left in closes on the bracket it opened on.
-#[test]
-fn a_gained_value_takes_the_shape_the_list_is_in() {
-    assert_eq!(
-        folding(DENIED, |manifest| denied(manifest).push("Edit".to_owned())),
-        DENIED.replace("\"WebFetch\",\n]", "\"WebFetch\",\n  \"Edit\",\n]")
-    );
-    assert_eq!(
-        folding(DENIED, |manifest| denied(manifest).clear()),
-        "schema = 6\n\n[agent-frontmatter.claude.orch]\ndeny-tools = []\n"
-    );
-    // Flat lists keep being flat, and a gained entry is separated once
-    // wherever it lands.
-    let flat =
-        "schema = 6\n\n[agent-frontmatter.claude.orch]\ndeny-tools = [\"Bash\", \"Write\"]\n";
-    assert_eq!(
-        folding(flat, |manifest| denied(manifest)
-            .insert(0, "Agent".to_owned())),
-        flat.replace("[\"Bash\"", "[\"Agent\", \"Bash\"")
-    );
 }
 
 /// Two hooks, each with its own comment and its own `note` — a key the model
@@ -327,34 +276,117 @@ fn deny(list: &str) -> String {
     format!("schema = 6\n\n[agent-frontmatter.claude.orch]\ndeny-tools = {list}\n")
 }
 
-/// A gained entry is placed against what is already there, in every shape a
-/// list can be in when it has nothing to place it against. An empty list has
-/// no entry to take an indent from, one whose first entry shares the opening
-/// line says nothing about the margin, and a list holding only a comment says
-/// it in the whitespace holding its bracket out.
+/// One row per edit of a value list: the list as written, the edit made
+/// through the model, and the list as it comes back — every other byte of
+/// the document untouched. A re-sorted array of VALUES moves each comment
+/// with the value it was written about: TOML keeps the run between one
+/// value and the next against the LOWER value, so an annotation is stored
+/// on the entry below the one it describes; rebuilt from raw decoration it
+/// would go to whatever lands in that slot, and every comment then states
+/// something false (`Manifest::suppress` sorts on every removal and the
+/// desktop editor rewrites these lists wholesale, so this is an ordinary
+/// `kendex remove` away). A dropped value takes its own comment and no
+/// other, including the entry above it, whose annotation is stored in the
+/// dropped entry's own decoration. A gained value takes the shape the list
+/// is already in — the indent its neighbours use and a line of its own —
+/// rather than the serializer's; placed against what is already there in
+/// every shape a list can be in when it has nothing to place it against
+/// (an empty list has no entry to take an indent from, one whose first
+/// entry shares the opening line says nothing about the margin, and a list
+/// holding only a comment says it in the whitespace holding its bracket
+/// out); and flat lists keep being flat, a gained entry separated once
+/// wherever it lands. The run before `]` belongs to the bracket: an entry
+/// promoted to last by a removal must not bring the separator that led to
+/// the neighbour after it. Emptying a list keeps what was written about
+/// the list, in both spellings of the closing run (which slot holds the
+/// bytes before `]` turns on a trailing comma), while the lines the
+/// entries stood on are theirs and go with them, which is why a list
+/// carrying nothing but whitespace between its brackets closes as `[]`.
 #[test]
-fn a_gained_value_is_placed_against_the_list_it_lands_in() {
-    let one = |list: &str, add: &[&str]| {
-        folding(&deny(list), |manifest| {
-            denied(manifest).extend(add.iter().map(|tool| (*tool).to_owned()));
-        })
-    };
-    assert_eq!(one("[]", &["Bash"]), deny("[\"Bash\"]"));
-    assert_eq!(one("[]", &["aaa", "zzz"]), deny("[\"aaa\", \"zzz\"]"));
-    assert_eq!(
-        one("[\n  # nothing yet\n]", &["Bash"]),
-        deny("[\n  \"Bash\"\n  # nothing yet\n]")
-    );
-    assert_eq!(
-        one("[\"Bash\",\n  \"Write\",\n]", &["Edit"]),
-        deny("[\"Bash\",\n  \"Write\",\n  \"Edit\",\n]")
-    );
-    assert_eq!(
-        folding(&deny("[\n  \"Bash\",\n  \"Write\",\n]"), |manifest| {
-            denied(manifest).insert(0, "Agent".to_owned());
-        }),
-        deny("[\n  \"Agent\",\n  \"Bash\",\n  \"Write\",\n]")
-    );
+#[allow(clippy::too_many_lines)]
+fn a_value_list_folds_each_edit_into_the_shape_it_was_written_in() {
+    type Edit = fn(&mut Vec<String>);
+    let rows: [(&str, Edit, &str); 16] = [
+        (
+            ANNOTATED,
+            |list| list.sort(),
+            "[\n  \"Bash\",   # no shells\n  \"WebFetch\",\n  \"Write\",   # no writing files\n]",
+        ),
+        (
+            ANNOTATED,
+            |list| {
+                list.remove(1);
+            },
+            "[\n  \"Bash\",   # no shells\n  \"WebFetch\",\n]",
+        ),
+        (
+            ANNOTATED,
+            |list| list.push("Edit".to_owned()),
+            "[\n  \"Bash\",   # no shells\n  \"Write\",   # no writing files\n  \"WebFetch\",\n  \"Edit\",\n]",
+        ),
+        (ANNOTATED, |list| list.clear(), "[]"),
+        (
+            "[\"Bash\", \"Write\"]",
+            |list| list.insert(0, "Agent".to_owned()),
+            "[\"Agent\", \"Bash\", \"Write\"]",
+        ),
+        ("[]", |list| list.push("Bash".to_owned()), "[\"Bash\"]"),
+        (
+            "[]",
+            |list| list.extend(["aaa".to_owned(), "zzz".to_owned()]),
+            "[\"aaa\", \"zzz\"]",
+        ),
+        (
+            "[\n  # nothing yet\n]",
+            |list| list.push("Bash".to_owned()),
+            "[\n  \"Bash\"\n  # nothing yet\n]",
+        ),
+        (
+            "[\"Bash\",\n  \"Write\",\n]",
+            |list| list.push("Edit".to_owned()),
+            "[\"Bash\",\n  \"Write\",\n  \"Edit\",\n]",
+        ),
+        (
+            "[\n  \"Bash\",\n  \"Write\",\n]",
+            |list| list.insert(0, "Agent".to_owned()),
+            "[\n  \"Agent\",\n  \"Bash\",\n  \"Write\",\n]",
+        ),
+        (
+            "[\"Bash\", \"Write\"]",
+            |list| {
+                list.pop();
+            },
+            "[\"Bash\"]",
+        ),
+        (
+            "[   # what we deny\n  \"Bash\",\n]",
+            |list| list.clear(),
+            "[   # what we deny\n]",
+        ),
+        (
+            "[   # what we deny\n  \"Bash\"\n]",
+            |list| list.clear(),
+            "[   # what we deny\n]",
+        ),
+        (
+            "[\n  \"Bash\",\n  # keep this\n]",
+            |list| list.clear(),
+            "[\n  # keep this\n]",
+        ),
+        (
+            "[\n  \"Bash\"\n  # keep this\n]",
+            |list| list.clear(),
+            "[\n  # keep this\n]",
+        ),
+        ("[\n  \"Bash\",\n]", |list| list.clear(), "[]"),
+    ];
+    for (current, edit, expected) in rows {
+        assert_eq!(
+            folding(&deny(current), |manifest| edit(denied(manifest))),
+            deny(expected),
+            "{current:?}"
+        );
+    }
 }
 
 /// The run before `]` belongs to the bracket. An entry that stood mid-list
@@ -363,16 +395,11 @@ fn a_gained_value_is_placed_against_the_list_it_lands_in() {
 /// bracket would be a separator to nothing.
 #[test]
 fn removing_the_last_entry_leaves_no_separator_behind() {
-    assert_eq!(
-        folding(&deny("[\"Bash\", \"Write\"]"), |manifest| {
-            denied(manifest).pop();
-        }),
-        deny("[\"Bash\"]")
-    );
-    // The same in the other spelling, and the same run one level in: the
-    // spacing before an inline table's brace sits on whichever key is last, so
-    // an entry that loses that key must hand the run back to the brace. Here
-    // `matcher` is written last and is what the strip takes.
+    // The deny-list spelling is a row of the list table; here the same run
+    // one level in: the spacing before an inline table's brace sits on
+    // whichever key is last, so an entry that loses that key must hand the
+    // run back to the brace. Here `matcher` is written last and is what
+    // the strip takes.
     let inline = "schema = 6\ncustom-hooks = [{ event = \"A\", command = \"c\", matcher = \"x\" }, { event = \"B\", command = \"d\" }]\n";
     assert_eq!(
         folding(inline, |manifest| {
@@ -480,37 +507,4 @@ fn the_keys_in_a_slot_go_only_where_the_slot_was_not_the_entrys_own() {
         }),
         "schema = 6\n\n# about A\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./g2.sh\"\nnote = \"a note\"\n\n# about B\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\n"
     );
-}
-
-/// A comment after the `[` or before the `]` is about the list, not about any
-/// entry in it, so emptying the list keeps it. The lines the entries stood on
-/// are theirs and go with them, which is why a list carrying nothing but
-/// whitespace between its brackets closes as `[]`.
-///
-/// Both halves in both spellings of the closing run, since which slot holds
-/// the bytes before `]` turns on a trailing comma.
-#[test]
-fn emptying_a_list_keeps_what_was_written_about_the_list() {
-    let empty = |list: &str| {
-        folding(&deny(list), |manifest| {
-            denied(manifest).clear();
-        })
-    };
-    assert_eq!(
-        empty("[   # what we deny\n  \"Bash\",\n]"),
-        deny("[   # what we deny\n]")
-    );
-    assert_eq!(
-        empty("[   # what we deny\n  \"Bash\"\n]"),
-        deny("[   # what we deny\n]")
-    );
-    assert_eq!(
-        empty("[\n  \"Bash\",\n  # keep this\n]"),
-        deny("[\n  # keep this\n]")
-    );
-    assert_eq!(
-        empty("[\n  \"Bash\"\n  # keep this\n]"),
-        deny("[\n  # keep this\n]")
-    );
-    assert_eq!(empty("[\n  \"Bash\",\n]"), deny("[]"));
 }

--- a/crates/core/src/manifest/validate/tests.rs
+++ b/crates/core/src/manifest/validate/tests.rs
@@ -57,315 +57,115 @@ matcher = "Bash"
     }
 }
 
-/// The one schema this build reads. Anything else — an older number, a
-/// newer one, no number at all — is the same finding, so the editor
-/// rejects exactly what a file read does.
+/// One row per manifest, and every finding it gets as (location, problem)
+/// in order, so a row pins what was found, where, and that nothing else
+/// was. The location discriminates a finding; the fix beside it is
+/// authoring guidance, so every row asserts each finding carries one and
+/// none pins its wording. Only the current schema validates: an
+/// older number, a newer one, and no number at all are one finding, so
+/// the editor rejects exactly what a file read does. A known override key
+/// under a harness that never renders it is a setting the author believes
+/// is in force and is not. A plugin segment is only a name for the kinds
+/// a marketplace catalog offers: a hook, a server or a Pi extension named
+/// with a `/` would install into a directory nothing ever cleans up, so it
+/// is refused where it is written. A revision belongs to a repository, and
+/// a key nobody reads is a typo the user should hear about rather than a
+/// setting that quietly does nothing. An event no harness fires is a hook
+/// that would install cleanly and then never run — nothing downstream
+/// reads the name, so this is the only place it can be caught. A custom
+/// hook's identity and parity fields are each checked, and the clean one
+/// beside them gets nothing. The safety-decision tables schema 6 retired
+/// are stray keys like any other; an older file carrying them never
+/// reaches here, since the schema below current is refused at the read.
 #[test]
-fn only_the_current_schema_validates() {
-    let body = "[sources.kendex]\nrepo = \"vanillagreencom/kendex\"\n";
-    let located = |text: &str| -> Vec<String> {
-        validate(&parse(text))
-            .iter()
-            .map(|f| f.location.clone())
-            .collect()
-    };
-    assert_eq!(
-        located(&format!("schema = 6\n{body}")),
-        Vec::<String>::new()
-    );
-    assert_eq!(located(&format!("schema = 5\n{body}")), ["schema"]);
-    assert_eq!(located(&format!("schema = 7\n{body}")), ["schema"]);
-    assert_eq!(located(body), ["schema"]);
-}
-
-/// A known override key under a harness that never renders it is a
-/// setting the author believes is in force and is not.
-#[test]
-fn an_override_a_harness_never_renders_is_a_finding() {
-    let table = parse(
-        r#"schema = 6
-[agent-frontmatter.gemini.rust]
-effort = "high"
-model = "inherit"
-[agent-frontmatter.claude.rust]
-effort = "high"
-[agent-frontmatter.cursor.rust]
-color = "red"
-[agent-frontmatter.antigravity.rust]
-effort = "high"
-model = "opus"
-"#,
-    );
-    let findings = validate(&table);
-    let locations: Vec<_> = findings.iter().map(|f| f.location.as_str()).collect();
-    assert!(
-        locations.contains(&"agent-frontmatter.gemini.rust.effort"),
-        "{locations:?}"
-    );
-    assert!(
-        locations.contains(&"agent-frontmatter.cursor.rust.color"),
-        "{locations:?}"
-    );
-    assert!(
-        !locations.contains(&"agent-frontmatter.gemini.rust.model"),
-        "{locations:?}"
-    );
-    assert!(
-        !locations.contains(&"agent-frontmatter.claude.rust.effort"),
-        "{locations:?}"
-    );
-    assert!(
-        locations.contains(&"agent-frontmatter.antigravity.rust.effort"),
-        "{locations:?}"
-    );
-    assert!(
-        !locations.contains(&"agent-frontmatter.antigravity.rust.model"),
-        "{locations:?}"
-    );
-}
-
-#[test]
-fn a_clean_manifest_validates_empty() {
-    let table = parse(
-        r#"
-schema = 6
-[sources.kendex]
-repo = "vanillagreencom/kendex"
-[skills.github]
-source = "kendex"
-[agents.local-one]
-source = "local"
-[hooks.guard]
-source = "kendex"
-[mcp-servers.gh]
-source = "kendex"
-[plugins."fmt@main"]
-enabled = false
-harness = "copilot"
-"#,
-    );
-    assert_eq!(validate(&table), Vec::new());
-}
-
-/// A plugin segment is only a name for the kinds a marketplace catalog
-/// offers. A hook or a server named with a `/` would install into a
-/// directory nothing ever cleans up, so it is refused where it is written.
-#[test]
-fn only_the_kinds_a_catalog_offers_may_carry_a_plugin_segment() {
-    let table = parse(
-        r#"
-schema = 6
-[sources.market]
-repo = "owner/market"
-[skills."tools/eda"]
-source = "market"
-[agents."tools/reviewer"]
-source = "market"
-[commands."tools/report"]
-source = "market"
-[pi-extensions."@scope/pkg"]
-source = "market"
-"#,
-    );
-    assert_eq!(validate(&table), Vec::new());
-
-    let table = parse(
-        r#"
-schema = 6
-[sources.market]
-repo = "owner/market"
-[hooks."tools/guard"]
-source = "market"
-[mcp-servers."tools/gh"]
-source = "market"
-[pi-extensions."tools/ext"]
-source = "market"
-"#,
-    );
-    let findings = validate(&table);
-    let located: Vec<&str> = findings.iter().map(|f| f.location.as_str()).collect();
-    for location in [
-        "hooks.tools/guard",
-        "mcp-servers.tools/gh",
-        "pi-extensions.tools/ext",
-    ] {
-        assert!(located.contains(&location), "{located:?}");
+#[allow(clippy::too_many_lines)]
+fn every_manifest_defect_is_located_with_nothing_else_said() {
+    let kendex = "[sources.kendex]\nrepo = \"vanillagreencom/kendex\"\n";
+    let schema = ("schema", "missing or unsupported schema version");
+    let rows: Vec<(String, Vec<(&str, &str)>)> = vec![
+        (format!("schema = 6\n{kendex}"), vec![]),
+        (format!("schema = 5\n{kendex}"), vec![schema]),
+        (format!("schema = 7\n{kendex}"), vec![schema]),
+        (kendex.to_owned(), vec![schema]),
+        (
+            "schema = 6\n[agent-frontmatter.gemini.rust]\neffort = \"high\"\nmodel = \"inherit\"\n[agent-frontmatter.claude.rust]\neffort = \"high\"\n[agent-frontmatter.cursor.rust]\ncolor = \"red\"\n[agent-frontmatter.antigravity.rust]\neffort = \"high\"\nmodel = \"opus\"\n".to_owned(),
+            vec![
+                ("agent-frontmatter.antigravity.rust.effort", "antigravity renders no `effort`, so this override changes nothing"),
+                ("agent-frontmatter.cursor.rust.color", "cursor renders no `color`, so this override changes nothing"),
+                ("agent-frontmatter.gemini.rust.effort", "gemini renders no `effort`, so this override changes nothing"),
+            ],
+        ),
+        (
+            "schema = 6\n[sources.kendex]\nrepo = \"vanillagreencom/kendex\"\n[skills.github]\nsource = \"kendex\"\n[agents.local-one]\nsource = \"local\"\n[hooks.guard]\nsource = \"kendex\"\n[mcp-servers.gh]\nsource = \"kendex\"\n[plugins.\"fmt@main\"]\nenabled = false\nharness = \"copilot\"\n".to_owned(),
+            vec![],
+        ),
+        (
+            "schema = 6\n[sources.market]\nrepo = \"owner/market\"\n[skills.\"tools/eda\"]\nsource = \"market\"\n[agents.\"tools/reviewer\"]\nsource = \"market\"\n[commands.\"tools/report\"]\nsource = \"market\"\n[pi-extensions.\"@scope/pkg\"]\nsource = \"market\"\n".to_owned(),
+            vec![],
+        ),
+        (
+            "schema = 6\n[sources.market]\nrepo = \"owner/market\"\n[hooks.\"tools/guard\"]\nsource = \"market\"\n[mcp-servers.\"tools/gh\"]\nsource = \"market\"\n[pi-extensions.\"tools/ext\"]\nsource = \"market\"\n".to_owned(),
+            vec![
+                ("hooks.tools/guard", "`tools/guard` holds `/`, which no filename may"),
+                ("mcp-servers.tools/gh", "`tools/gh` holds `/`, which no filename may"),
+                ("pi-extensions.tools/ext", "`tools/ext` holds `/`, which no filename may"),
+            ],
+        ),
+        (
+            "schema = 6\n[sources.pinned]\nrepo = \"owner/repo\"\nrev = \"v1.2.0\"\n".to_owned(),
+            vec![],
+        ),
+        (
+            "schema = 6\n[sources.local-path]\npath = \"../catalog\"\nrev = \"v1.2.0\"\n[sources.typo]\nrepo = \"owner/repo\"\nrevision = \"v1\"\n[sources.wrong-type]\nrepo = \"owner/repo\"\nrev = 12\n".to_owned(),
+            vec![
+                ("sources.local-path", "only a repo has revisions"),
+                ("sources.typo", "unknown key 'revision'"),
+                ("sources.wrong-type", "rev must be a string"),
+            ],
+        ),
+        (
+            "schema = 6\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\n[[custom-hooks]]\nevent = \"PreToolUSe\"\ncommand = \"./guard.sh\"\n".to_owned(),
+            vec![("custom-hooks[1].event", "no harness fires 'PreToolUSe'")],
+        ),
+        (
+            "schema = 6\n[hooks.guard]\nsource = \"local\"\n[[custom-hooks]]\nname = \"guard\"\nevent = \"PreToolUse\"\ncommand = \"./a.sh\"\n[[custom-hooks]]\nname = \"Bad Name\"\nevent = \"Stop\"\ncommand = \"./b.sh\"\ntimeout = 0\nharnesses = [\"claude\", \"emacs\"]\ntypo-key = 1\n[[custom-hooks]]\nname = \"twice\"\nevent = \"Stop\"\ncommand = \"./c.sh\"\n[[custom-hooks]]\nname = \"twice\"\nevent = \"Stop\"\ncommand = \"./d.sh\"\n".to_owned(),
+            vec![
+                ("custom-hooks[0].name", "'guard' is already an installed hook"),
+                ("custom-hooks[1]", "unknown key 'typo-key'"),
+                ("custom-hooks[1].name", "'Bad Name' is not a usable hook name"),
+                ("custom-hooks[1].timeout", "timeout must be whole seconds, 1 to 3600"),
+                ("custom-hooks[1].harnesses", "unknown harness 'emacs'"),
+                ("custom-hooks[3].name", "'twice' names two custom hooks"),
+            ],
+        ),
+        (
+            "schema = 6\n[[custom-hooks]]\nname = \"guard-pretooluse\"\nevent = \"PreToolUse\"\nmatcher = \"Bash\"\ncommand = \"./guard.sh\"\ntimeout = 30\nharnesses = [\"claude\"]\nagents = \"all\"\n".to_owned(),
+            vec![],
+        ),
+        (
+            "schema = 6\n[sources.market]\nrepo = \"owner/market\"\n[skills.deploy]\nsource = \"market\"\n[safety-overrides.\"skill:deploy:claude\"]\nreview-hash = \"abc\"\n[safety-reviews.\"skill:deploy:claude\"]\nreview-hash = \"abc\"\n".to_owned(),
+            vec![
+                ("safety-overrides", "unknown table or key"),
+                ("safety-reviews", "unknown table or key"),
+            ],
+        ),
+    ];
+    for (manifest, expected) in rows {
+        let found = validate(&parse(&manifest));
+        assert!(
+            found.iter().all(|finding| !finding.fix.is_empty()),
+            "{manifest}: {found:?}"
+        );
+        let findings: Vec<(String, String)> = found
+            .into_iter()
+            .map(|finding| (finding.location, finding.problem))
+            .collect();
+        let expected: Vec<(String, String)> = expected
+            .into_iter()
+            .map(|(location, problem)| (location.to_owned(), problem.to_owned()))
+            .collect();
+        assert_eq!(findings, expected, "{manifest}");
     }
-    for finding in &findings {
-        assert!(finding.fix.contains("without a `/`"), "{finding}");
-    }
-}
-
-/// A revision belongs to a repository, and a key nobody reads is a typo
-/// the user should hear about rather than a setting that quietly does
-/// nothing.
-#[test]
-fn a_source_revision_is_a_string_on_a_repo_and_stray_keys_are_findings() {
-    let table = parse(
-        r#"
-schema = 6
-[sources.pinned]
-repo = "owner/repo"
-rev = "v1.2.0"
-"#,
-    );
-    assert_eq!(validate(&table), Vec::new());
-
-    let table = parse(
-        r#"
-schema = 6
-[sources.local-path]
-path = "../catalog"
-rev = "v1.2.0"
-[sources.typo]
-repo = "owner/repo"
-revision = "v1"
-[sources.wrong-type]
-repo = "owner/repo"
-rev = 12
-"#,
-    );
-    let findings = validate(&table);
-    let problems: Vec<&str> = findings.iter().map(|f| f.problem.as_str()).collect();
-    assert!(
-        problems.contains(&"only a repo has revisions"),
-        "{problems:?}"
-    );
-    assert!(problems.contains(&"unknown key 'revision'"), "{problems:?}");
-    assert!(problems.contains(&"rev must be a string"), "{problems:?}");
-    for finding in &findings {
-        assert!(finding.fix.contains("rev"), "{finding}");
-    }
-}
-
-/// An event no harness fires is a hook that would install cleanly and then
-/// never run — nothing downstream reads the name, so this is the only place
-/// it can be caught.
-#[test]
-fn a_custom_hook_event_must_be_one_a_harness_fires() {
-    let table: toml::Table = r#"
-schema = 1
-[[custom-hooks]]
-event = "PreToolUse"
-command = "./guard.sh"
-[[custom-hooks]]
-event = "PreToolUSe"
-command = "./guard.sh"
-"#
-    .parse()
-    .unwrap();
-
-    let findings = validate(&table);
-    let event = findings
-        .iter()
-        .find(|f| f.location == "custom-hooks[1].event")
-        .expect("the typo should be reported");
-    assert!(event.problem.contains("PreToolUSe"), "{event:?}");
-    assert!(event.fix.contains("PreToolUse"), "{event:?}");
-    assert!(
-        !findings
-            .iter()
-            .any(|f| f.location.starts_with("custom-hooks[0]")),
-        "{findings:?}"
-    );
-}
-
-#[test]
-fn custom_hook_identity_and_parity_fields_are_checked() {
-    let table: toml::Table = r#"
-schema = 1
-[hooks.guard]
-source = "local"
-[[custom-hooks]]
-name = "guard"
-event = "PreToolUse"
-command = "./a.sh"
-[[custom-hooks]]
-name = "Bad Name"
-event = "Stop"
-command = "./b.sh"
-timeout = 0
-harnesses = ["claude", "emacs"]
-typo-key = 1
-[[custom-hooks]]
-name = "twice"
-event = "Stop"
-command = "./c.sh"
-[[custom-hooks]]
-name = "twice"
-event = "Stop"
-command = "./d.sh"
-"#
-    .parse()
-    .unwrap();
-
-    let findings = validate(&table);
-    let at = |loc: &str| {
-        findings
-            .iter()
-            .find(|f| f.location == loc)
-            .unwrap_or_else(|| panic!("expected a finding at {loc}: {findings:?}"))
-    };
-    assert!(
-        at("custom-hooks[0].name")
-            .problem
-            .contains("installed hook")
-    );
-    assert!(at("custom-hooks[1].name").problem.contains("Bad Name"));
-    assert!(at("custom-hooks[1].timeout").problem.contains("1 to 3600"));
-    assert!(at("custom-hooks[1].harnesses").problem.contains("emacs"));
-    assert!(at("custom-hooks[1]").problem.contains("typo-key"));
-    assert!(at("custom-hooks[3].name").problem.contains("names two"));
-    assert!(
-        !findings
-            .iter()
-            .any(|f| f.location.starts_with("custom-hooks[2]")),
-        "{findings:?}"
-    );
-}
-
-#[test]
-fn a_clean_named_custom_hook_validates_empty() {
-    let table: toml::Table = r#"
-schema = 6
-[[custom-hooks]]
-name = "guard-pretooluse"
-event = "PreToolUse"
-matcher = "Bash"
-command = "./guard.sh"
-timeout = 30
-harnesses = ["claude"]
-agents = "all"
-"#
-    .parse()
-    .unwrap();
-    assert_eq!(validate(&table), Vec::new());
-}
-
-/// The safety-decision tables schema 6 retired are stray keys like any
-/// other: a record put back by hand is named with the remove-it fix, never
-/// dropped in silence. An older file carrying them never reaches here —
-/// the schema below current is refused at the read.
-#[test]
-fn retired_safety_tables_are_stray_keys_on_a_current_file() {
-    let body = r#"
-[sources.market]
-repo = "owner/market"
-[skills.deploy]
-source = "market"
-[safety-overrides."skill:deploy:claude"]
-review-hash = "abc"
-[safety-reviews."skill:deploy:claude"]
-review-hash = "abc"
-"#;
-    let findings = validate(&parse(&format!("schema = 6\n{body}")));
-    let located: Vec<&str> = findings.iter().map(|f| f.location.as_str()).collect();
-    assert_eq!(
-        located,
-        ["safety-overrides", "safety-reviews"],
-        "{findings:?}"
-    );
-    assert!(findings.iter().all(|f| f.fix.starts_with("remove it")));
 }
 
 /// Every part of a finding is escaped, because the refusal that carries

--- a/crates/core/src/render/validate/tests.rs
+++ b/crates/core/src/render/validate/tests.rs
@@ -17,7 +17,19 @@ fn blocking(findings: &[Finding]) -> Vec<&Finding> {
     findings.iter().filter(|f| f.is_breakage()).collect()
 }
 
-/// Findings are joined for `contains` assertions on message and fix alike.
+/// Whether some finding's message carries the fragment: the clause the
+/// check emits, read apart from the fix beside it.
+fn said(findings: &[Finding], fragment: &str) -> bool {
+    findings.iter().any(|f| f.message.contains(fragment))
+}
+
+/// Whether some finding's fix carries the value: read only where a fix
+/// spells something computed, never for its wording.
+fn fixed(findings: &[Finding], value: &str) -> bool {
+    findings.iter().any(|f| f.remediation.contains(value))
+}
+
+/// Findings joined for a failure's diagnostic.
 fn spoken(findings: &[Finding]) -> String {
     findings
         .iter()
@@ -71,55 +83,156 @@ fn every_finding_carries_a_fix() {
     }
 }
 
+/// One row per rendering a harness would refuse or query, and what the
+/// findings say: one message fragment per breakage finding in order, one
+/// per advisory finding in order, and the values the remediations carry
+/// where a fix spells something computed (a name, the accepted set). The
+/// `Finding` carries no rule code, so the message fragment a row pins is
+/// the clause only that check emits; a remedy's wording is not pinned. A
+/// Codex agent must parse as TOML and carry its keys, and name a sandbox
+/// Codex knows. An OpenCode agent must declare a mode and permissions it
+/// can read, a `provider/model` id, and a lowercase-kebab name of at most
+/// 64 characters, which the fix spells. A Claude agent must answer to the
+/// name it installs under. Cursor rule keys outside the three are
+/// folklore, and only advice.
 #[test]
-fn codex_agents_must_parse_as_toml_and_carry_their_keys() {
-    let broken = validate_agent(HarnessId::Codex, "rust", "name = \"rust\ndescription = 1\n");
-    assert_eq!(blocking(&broken).len(), 1);
-    assert!(spoken(&broken).contains("does not parse"), "{broken:?}");
-
-    let bare = validate_agent(HarnessId::Codex, "rust", "name = \"\"\nother = \"x\"\n");
-    let said = spoken(&bare);
-    assert_eq!(blocking(&bare).len(), 3, "{said}");
-    for key in ["`name`", "`description`", "`developer_instructions`"] {
-        assert!(said.contains(key), "{said}");
+#[allow(clippy::too_many_lines)]
+fn a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong() {
+    struct Row {
+        harness: HarnessId,
+        name: &'static str,
+        text: String,
+        breakage: &'static [&'static str],
+        advice: &'static [&'static str],
+        remedy: &'static [&'static str],
     }
-}
-
-#[test]
-fn an_unknown_codex_sandbox_is_refused_and_the_fix_lists_the_real_ones() {
-    let text = CODEX_AGENT.replace("workspace-write", "yolo");
-    let findings = validate_agent(HarnessId::Codex, "rust", &text);
-    assert_eq!(blocking(&findings).len(), 1);
-    let said = spoken(&findings);
-    assert!(said.contains("not a sandbox Codex knows"), "{said}");
-    assert!(said.contains("danger-full-access"), "{said}");
-}
-
-#[test]
-fn opencode_agents_must_declare_a_mode_and_permissions_it_can_read() {
-    let text = OPENCODE_AGENT.replace("mode: subagent", "mode: helper");
-    let findings = validate_agent(HarnessId::Opencode, "rust", &text);
-    assert_eq!(blocking(&findings).len(), 1);
-    assert!(spoken(&findings).contains("`mode: helper`"), "{findings:?}");
-
-    let text = OPENCODE_AGENT.replace("bash: deny", "bash: maybe");
-    let findings = validate_agent(HarnessId::Opencode, "rust", &text);
-    let said = spoken(&findings);
-    assert_eq!(blocking(&findings).len(), 1, "{said}");
-    assert!(said.contains("permission `bash`"), "{said}");
-    assert!(said.contains("allow, ask, deny"), "{said}");
-
-    let findings = validate_agent(HarnessId::Opencode, "rust", "no frontmatter here\n");
-    assert_eq!(blocking(&findings).len(), 1);
-    assert!(spoken(&findings).contains("there is none"), "{findings:?}");
-}
-
-#[test]
-fn a_bare_opencode_model_is_refused_with_the_shape_named() {
-    let text = OPENCODE_AGENT.replace("anthropic/claude", "opus");
-    let findings = validate_agent(HarnessId::Opencode, "rust", &text);
-    assert_eq!(blocking(&findings).len(), 1, "{findings:?}");
-    assert!(spoken(&findings).contains("provider/model"), "{findings:?}");
+    let rows = [
+        Row {
+            harness: HarnessId::Codex,
+            name: "rust",
+            text: "name = \"rust\ndescription = 1\n".to_owned(),
+            breakage: &["does not parse"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Codex,
+            name: "rust",
+            text: "name = \"\"\nother = \"x\"\n".to_owned(),
+            breakage: &["`name`", "`description`", "`developer_instructions`"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Codex,
+            name: "rust",
+            text: CODEX_AGENT.replace("workspace-write", "yolo"),
+            breakage: &["not a sandbox Codex knows"],
+            advice: &[],
+            remedy: &["danger-full-access"],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "rust",
+            text: OPENCODE_AGENT.replace("mode: subagent", "mode: helper"),
+            breakage: &["`mode: helper`"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "rust",
+            text: OPENCODE_AGENT.replace("bash: deny", "bash: maybe"),
+            breakage: &["permission `bash`"],
+            advice: &[],
+            remedy: &["allow, ask, deny"],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "rust",
+            text: "no frontmatter here\n".to_owned(),
+            breakage: &["there is none"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "rust",
+            text: OPENCODE_AGENT.replace("anthropic/claude", "opus"),
+            breakage: &["provider/model"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Claude,
+            name: "rust",
+            text: CLAUDE_AGENT.replace("name: rust", "name: rustacean"),
+            breakage: &["calls itself `rustacean`"],
+            advice: &[],
+            remedy: &["`rustacean`"],
+        },
+        Row {
+            harness: HarnessId::Claude,
+            name: "rust",
+            text: CLAUDE_AGENT.replace("name: rust\n", ""),
+            breakage: &["has no name"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Cursor,
+            name: "rust",
+            text: CURSOR_RULE.replace("alwaysApply: false", "agentRequested: true\nmode: auto"),
+            breakage: &[],
+            advice: &["`agentRequested:`", "`mode:`"],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "My_Skill",
+            text: OPENCODE_AGENT.to_owned(),
+            breakage: &["will not load `My_Skill`"],
+            advice: &[],
+            remedy: &["`my-skill`"],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            text: OPENCODE_AGENT.to_owned(),
+            breakage: &["65 characters"],
+            advice: &[],
+            remedy: &[],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "code-review-2",
+            text: OPENCODE_AGENT.to_owned(),
+            breakage: &[],
+            advice: &[],
+            remedy: &[],
+        },
+    ];
+    for row in rows {
+        let label = format!("{} {}", row.harness.name(), row.name);
+        let findings = validate_agent(row.harness, row.name, &row.text);
+        let (breakage, advice): (Vec<_>, Vec<_>) =
+            findings.iter().partition(|finding| finding.is_breakage());
+        assert_eq!(breakage.len(), row.breakage.len(), "{label}: {findings:?}");
+        for (finding, fragment) in breakage.iter().zip(row.breakage) {
+            assert!(finding.message.contains(fragment), "{label}: {finding:?}");
+        }
+        assert_eq!(advice.len(), row.advice.len(), "{label}: {findings:?}");
+        for (finding, fragment) in advice.iter().zip(row.advice) {
+            assert!(finding.message.contains(fragment), "{label}: {finding:?}");
+        }
+        let remedies: Vec<&str> = findings.iter().map(|f| f.remediation.as_str()).collect();
+        for value in row.remedy {
+            assert!(
+                remedies.iter().any(|r| r.contains(value)),
+                "{label}: {remedies:?}"
+            );
+        }
+    }
 }
 
 /// One control per harness with an effort key: a level outside the
@@ -169,7 +282,12 @@ fn an_effort_level_the_harness_does_not_accept_is_refused() {
             harness.name(),
             spoken(&refused)
         );
-        assert!(spoken(&refused).contains(bad), "{}", harness.name());
+        assert!(
+            said(&refused, bad),
+            "{}: {}",
+            harness.name(),
+            spoken(&refused)
+        );
     }
 }
 
@@ -227,52 +345,6 @@ fn a_model_of_the_wrong_shape_for_the_harness_is_refused() {
 }
 
 #[test]
-fn claude_agents_must_answer_to_the_name_they_install_under() {
-    let findings = validate_agent(HarnessId::Claude, "rust", CLAUDE_AGENT);
-    assert!(findings.is_empty());
-
-    let text = CLAUDE_AGENT.replace("name: rust", "name: rustacean");
-    let findings = validate_agent(HarnessId::Claude, "rust", &text);
-    let said = spoken(&findings);
-    assert_eq!(blocking(&findings).len(), 1, "{said}");
-    assert!(said.contains("calls itself `rustacean`"), "{said}");
-    assert!(said.contains("declare the agent as `rustacean`"), "{said}");
-
-    let text = CLAUDE_AGENT.replace("name: rust\n", "");
-    let findings = validate_agent(HarnessId::Claude, "rust", &text);
-    assert_eq!(blocking(&findings).len(), 1);
-    assert!(spoken(&findings).contains("has no name"), "{findings:?}");
-}
-
-#[test]
-fn cursor_rule_keys_outside_the_three_are_folklore() {
-    let text = CURSOR_RULE.replace("alwaysApply: false", "agentRequested: true\nmode: auto");
-    let findings = validate_agent(HarnessId::Cursor, "rust", &text);
-    assert!(blocking(&findings).is_empty(), "{findings:?}");
-    let said = spoken(&findings);
-    assert!(said.contains("`agentRequested:`"), "{said}");
-    assert!(said.contains("`mode:`"), "{said}");
-    assert!(said.contains("folklore"), "{said}");
-}
-
-#[test]
-fn opencode_names_must_be_lowercase_kebab_and_the_fix_spells_one() {
-    let findings = validate_agent(HarnessId::Opencode, "My_Skill", OPENCODE_AGENT);
-    let said = spoken(&findings);
-    assert_eq!(blocking(&findings).len(), 1, "{said}");
-    assert!(said.contains("will not load `My_Skill`"), "{said}");
-    assert!(said.contains("declare it as `my-skill`"), "{said}");
-
-    let long = "a".repeat(65);
-    let findings = validate_agent(HarnessId::Opencode, &long, OPENCODE_AGENT);
-    let said = spoken(&findings);
-    assert_eq!(blocking(&findings).len(), 1, "{said}");
-    assert!(said.contains("65 characters"), "{said}");
-
-    assert!(validate_agent(HarnessId::Opencode, "code-review-2", OPENCODE_AGENT).is_empty());
-}
-
-#[test]
 fn other_harnesses_refuse_names_that_leave_their_own_directory() {
     let legal = validate_agent(
         HarnessId::Claude,
@@ -289,7 +361,7 @@ fn other_harnesses_refuse_names_that_leave_their_own_directory() {
             &skill_tree(&format!("---\nname: {name}\ndescription: d\n---\n")),
         );
         assert!(
-            spoken(&findings).contains("points out of the directory"),
+            said(&findings, "points out of the directory"),
             "{name}: {findings:?}"
         );
     }
@@ -299,7 +371,7 @@ fn other_harnesses_refuse_names_that_leave_their_own_directory() {
 fn a_skill_tree_must_carry_a_skill_md_that_names_its_own_directory() {
     let missing = validate_skill_tree(HarnessId::Claude, "gh", "gh", &[]);
     assert_eq!(blocking(&missing).len(), 1);
-    assert!(spoken(&missing).contains("no SKILL.md"), "{missing:?}");
+    assert!(said(&missing, "no SKILL.md"), "{missing:?}");
 
     let mismatch = validate_skill_tree(
         HarnessId::Claude,
@@ -307,10 +379,9 @@ fn a_skill_tree_must_carry_a_skill_md_that_names_its_own_directory() {
         "gh",
         &skill_tree("---\nname: github\ndescription: d\n---\n"),
     );
-    let said = spoken(&mismatch);
-    assert_eq!(blocking(&mismatch).len(), 1, "{said}");
-    assert!(said.contains("calls the skill `github`"), "{said}");
-    assert!(said.contains("set `name: gh`"), "{said}");
+    assert_eq!(blocking(&mismatch).len(), 1, "{mismatch:?}");
+    assert!(said(&mismatch, "calls the skill `github`"), "{mismatch:?}");
+    assert!(fixed(&mismatch, "`name: gh`"), "{mismatch:?}");
 
     // An item that carries its plugin installs under a name no catalog file
     // knows and no declaration can spell, so the fix has to be about the
@@ -321,9 +392,8 @@ fn a_skill_tree_must_carry_a_skill_md_that_names_its_own_directory() {
         "data-science__eda",
         &skill_tree("---\nname: eda\ndescription: d\n---\n"),
     );
-    let said = spoken(&derived);
-    assert!(!said.contains("declare the skill as"), "{said}");
-    assert!(said.contains("frontmatter"), "{said}");
+    assert!(!fixed(&derived, "declare the skill as"), "{derived:?}");
+    assert!(fixed(&derived, "frontmatter"), "{derived:?}");
 
     let no_description = validate_skill_tree(
         HarnessId::Claude,
@@ -332,7 +402,10 @@ fn a_skill_tree_must_carry_a_skill_md_that_names_its_own_directory() {
         &skill_tree("---\nname: gh\n---\nBody.\n"),
     );
     assert!(blocking(&no_description).is_empty(), "{no_description:?}");
-    assert!(spoken(&no_description).contains("no description"));
+    assert!(
+        said(&no_description, "no description"),
+        "{no_description:?}"
+    );
 
     // A disabled tree parks the same content under `.disabled`.
     let disabled = vec![(
@@ -350,13 +423,12 @@ fn a_skill_whose_description_runs_past_codexs_limit_is_refused_there_and_install
     );
     let files = skill_tree(&body);
     let codex = validate_skill_tree(HarnessId::Codex, "gh", "gh", &files);
-    let said = spoken(&codex);
-    assert_eq!(blocking(&codex).len(), 1, "{said}");
+    assert_eq!(blocking(&codex).len(), 1, "{codex:?}");
     assert!(
-        said.contains("`gh`'s description is 1025 characters"),
-        "{said}"
+        said(&codex, "`gh`'s description is 1025 characters"),
+        "{codex:?}"
     );
-    assert!(said.contains("past 1024"), "{said}");
+    assert!(said(&codex, "past 1024"), "{codex:?}");
     assert!(validate_skill_tree(HarnessId::Claude, "gh", "gh", &files).is_empty());
 
     // Exactly at the limit is fine, and the body's length is nobody's

--- a/crates/core/src/render/vocab/tests.rs
+++ b/crates/core/src/render/vocab/tests.rs
@@ -98,32 +98,6 @@ fn one_warning_names_every_tool_reworded_for_the_harness() {
 }
 
 #[test]
-fn code_links_and_skill_paths_keep_every_byte() {
-    let body = concat!(
-        "```\nuse the Read tool\n```\n",
-        "~~~md\nuse the Read tool\n~~~\n",
-        "````\n```\nuse the Read tool\n```\n````\n",
-        "Run `use the Read tool` verbatim.\n",
-        "See [the Read tool](https://example.com/the-Read-tool).\n",
-        "- dev: .agents/skills/dev/SKILL.md — read it with the Read tool\n",
-    );
-    for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
-        let (text, warnings) = rewrite_prose(body, harness);
-        assert_eq!(text, body, "{harness:?} rewrote protected text");
-        assert!(
-            warnings.is_empty(),
-            "{harness:?} warned about protected text"
-        );
-    }
-}
-
-#[test]
-fn an_unclosed_fence_protects_the_rest_of_the_body() {
-    let body = "```\nuse the Read tool\nstill fenced: the Bash tool\n";
-    assert_eq!(rewrite(body, HarnessId::Opencode), body);
-}
-
-#[test]
 fn unknown_and_mcp_references_pass_through_with_one_warning_each() {
     let body =
         "Call the mcp__github__search tool, the SendMessage tool, the mcp__github__search tool.\n";
@@ -157,87 +131,76 @@ fn a_tool_codex_has_no_word_for_is_reported_not_guessed_at() {
     assert!(warnings[0].message.contains("`TodoWrite`"));
 }
 
-/// A fenced block nested in a list item is indented four spaces — the shape
-/// most real skills use. Reading that as prose rewrites a sample the agent
-/// was told to copy verbatim.
-///
-/// Four spaces at the top level is the other reading of the same indent,
-/// and markdown's: with no list marker to hang off, the run opens an
+/// Four spaces at the top level, with no list marker to hang off, open an
 /// indented code block and the backticks are its first line of text. So
-/// the fence closes nothing and the line below it is prose. Both are
-/// pinned, because they are one rule seen from two columns.
+/// the fence closes nothing and the line below it is prose — the other
+/// reading of the indent `an_indented_fence` pins below, one rule seen
+/// from two columns.
 #[test]
-fn an_indented_fence_is_still_a_fence() {
-    let body = "1. Run this:\n\n    ```sh\n    use the Bash tool\n    ```\n\nDone.\n";
-    for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
-        let (text, warnings) = rewrite_prose(body, harness);
-        assert_eq!(text, body, "{harness:?} rewrote an indented block");
-        assert!(warnings.is_empty(), "{harness:?} warned: {warnings:?}");
-    }
+fn a_top_level_indented_fence_opens_nothing() {
     assert_eq!(
         rewrite("    ```\nuse the Read tool\n", HarnessId::Opencode),
         "    ```\nuse the read tool\n"
     );
 }
 
-/// A run of backticks may close on a later line, and a reader asked one
-/// line at a time sees the opener meet nothing and calls the line prose.
-/// The rewrite then edits bytes the author quoted for an agent to copy.
+/// One row per markdown shape the rewrite must read as not prose: the
+/// body comes back byte for byte on every harness that has words of its
+/// own, and nothing warns. Fenced code, tilde fences, a fence nested in a
+/// fence, inline code, a link's text and target, and a skill path keep
+/// every byte. An unclosed fence protects the rest of the body. A fenced
+/// block nested in a list item is indented four spaces — the shape most
+/// real skills use — and reading that as prose rewrites a sample the
+/// agent was told to copy verbatim. A run of backticks may close on a
+/// later line, and a reader asked one line at a time sees the opener meet
+/// nothing and calls the line prose; a span clipped at a line's start
+/// opens on content, not on a backtick, so a containment test that wants
+/// the name strictly inside the span lets through the one that begins the
+/// line; a line the span crosses whole carries no delimiter of its own and
+/// is covered end to end. Markdown reads nothing inside a raw HTML block:
+/// a fence there is three literal backticks, and prose tight under a
+/// wrapper keeps Claude's words with no warning naming it — the whole of
+/// what the Changed entry promises, which a fixture carrying a fence or a
+/// backtick cannot pin, since narrowing the HTML arm to blocks that hold
+/// code marks would leave those green. Four spaces open a code block with
+/// no fence to mark it. And prose about tools is never a reference.
 #[test]
-fn a_span_that_closes_on_a_later_line_quotes_both_lines() {
-    let body = "Paste `use the Read tool\n--dry-run` into the prompt.\n";
-    for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
-        let (text, warnings) = rewrite_prose(body, harness);
-        assert_eq!(text, body, "{harness:?} rewrote inside a code span");
-        assert!(warnings.is_empty(), "{harness:?} warned: {warnings:?}");
-    }
-}
-
-/// A span clipped at a line's start opens on content, not on a backtick,
-/// so a containment test that wants the name strictly inside the span
-/// lets through the one that begins the line. Both shapes reach the same
-/// byte: the name at column 0 of a continuation line.
-#[test]
-fn a_reference_at_column_zero_of_a_continuation_line_is_inside_the_span() {
-    for body in [
+fn a_sample_or_prose_about_tools_keeps_every_byte_on_every_harness() {
+    let rows: [&str; 18] = [
+        concat!(
+            "```\nuse the Read tool\n```\n",
+            "~~~md\nuse the Read tool\n~~~\n",
+            "````\n```\nuse the Read tool\n```\n````\n",
+            "Run `use the Read tool` verbatim.\n",
+            "See [the Read tool](https://example.com/the-Read-tool).\n",
+            "- dev: .agents/skills/dev/SKILL.md — read it with the Read tool\n",
+        ),
+        "```\nuse the Read tool\nstill fenced: the Bash tool\n",
+        "1. Run this:\n\n    ```sh\n    use the Bash tool\n    ```\n\nDone.\n",
+        "Paste `use the Read tool\n--dry-run` into the prompt.\n",
         "Paste `run\nRead tool now` here.\n",
         "Paste `x\nRead tool` now\n",
-    ] {
-        for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
-            let (text, warnings) = rewrite_prose(body, harness);
-            assert_eq!(text, body, "{harness:?} rewrote inside a code span");
-            assert!(warnings.is_empty(), "{harness:?} warned: {warnings:?}");
-        }
-    }
-}
-
-/// A line the span crosses whole carries no delimiter of its own, so it is
-/// covered end to end and every reference on it is a byte of the sample.
-#[test]
-fn a_line_a_span_crosses_whole_is_covered_end_to_end() {
-    let body = "Paste `one\nuse the Read tool\ntwo` here.\n";
-    for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
-        let (text, warnings) = rewrite_prose(body, harness);
-        assert_eq!(text, body, "{harness:?} rewrote a line a span crosses");
-        assert!(warnings.is_empty(), "{harness:?} warned: {warnings:?}");
-    }
-}
-
-/// Markdown reads nothing inside a raw HTML block: a fence there is three
-/// literal backticks. A reader that took those lines for prose would find
-/// no marks on the sample and rewrite straight through it — the tight
-/// forms, where no blank line has ended the block.
-#[test]
-fn a_sample_inside_a_raw_html_block_keeps_every_byte() {
-    for body in [
+        "Paste `one\nuse the Read tool\ntwo` here.\n",
         "<details>\n<summary>x</summary>\n```sh\nuse the Read tool\n```\n</details>\n",
         "<!--\n```\nuse the Read tool\n```\n-->\n",
         "<div>\nRun `use the Read tool` verbatim.\n</div>\n",
-    ] {
+        "<div>\nUse the Read tool here.\n</div>\n",
+        "<details>\nUse the Read tool here.\n</details>\n",
+        "<br>\nUse the Read tool here.\n",
+        "Then run:\n\n    use the Read tool --dry-run\n",
+        "Pick the right tool for the job.\n",
+        "Prefer the dedicated tools over shell commands.\n",
+        "The toolkit is yours.\n",
+        "the Read toolbox\n",
+    ];
+    for body in rows {
         for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
             let (text, warnings) = rewrite_prose(body, harness);
-            assert_eq!(text, body, "{harness:?} rewrote inside raw HTML");
-            assert!(warnings.is_empty(), "{harness:?} warned: {warnings:?}");
+            assert_eq!(text, body, "{harness:?} rewrote {body:?}");
+            assert!(
+                warnings.is_empty(),
+                "{harness:?} warned about {body:?}: {warnings:?}"
+            );
         }
     }
 }
@@ -256,25 +219,6 @@ fn prose_a_blank_line_below_a_wrapper_is_still_prose() {
     );
 }
 
-/// The cost of reading a raw HTML block as markup, on a line carrying no
-/// code mark at all: prose tight under a wrapper keeps Claude's words and
-/// no warning names it. That is the whole of what the Changed entry
-/// promises, and a fixture carrying a fence or a backtick cannot pin it —
-/// narrowing the HTML arm to blocks that hold code marks would leave those
-/// green and revert this.
-#[test]
-fn prose_tight_under_a_wrapper_is_left_in_claudes_words() {
-    for body in [
-        "<div>\nUse the Read tool here.\n</div>\n",
-        "<details>\nUse the Read tool here.\n</details>\n",
-        "<br>\nUse the Read tool here.\n",
-    ] {
-        let (text, warnings) = rewrite_prose(body, HarnessId::Opencode);
-        assert_eq!(text, body, "rewrote prose inside raw HTML: {body:?}");
-        assert!(warnings.is_empty(), "warned: {warnings:?}");
-    }
-}
-
 /// The converse, and the reading main did not have: a fence line inside an
 /// HTML block opens no fence, because markdown never read it as one. So
 /// the blank line below it ends the block rather than the fence, and what
@@ -285,18 +229,6 @@ fn a_fence_inside_a_raw_html_block_opens_nothing() {
         rewrite("<div>\n```\n\nuse the Read tool\n", HarnessId::Opencode),
         "<div>\n```\n\nuse the read tool\n"
     );
-}
-
-/// Four spaces open a code block with no fence to mark it, so a reader
-/// watching for fences finds none and rewrites the sample.
-#[test]
-fn an_indented_code_block_is_a_code_block() {
-    let body = "Then run:\n\n    use the Read tool --dry-run\n";
-    for harness in [HarnessId::Codex, HarnessId::Opencode, HarnessId::Cursor] {
-        let (text, warnings) = rewrite_prose(body, harness);
-        assert_eq!(text, body, "{harness:?} rewrote an indented block");
-        assert!(warnings.is_empty(), "{harness:?} warned: {warnings:?}");
-    }
 }
 
 /// A table cell is a leaf block of its own, so a backtick in one cell and
@@ -315,20 +247,6 @@ fn backticks_in_two_table_cells_do_not_pair_across_the_boundary() {
         rewrite(body, HarnessId::Opencode),
         "| how | when |\n|---|---|\n| `git log | use the read tool` |\n"
     );
-}
-
-#[test]
-fn prose_about_tools_is_never_mistaken_for_a_reference() {
-    for body in [
-        "Pick the right tool for the job.\n",
-        "Prefer the dedicated tools over shell commands.\n",
-        "The toolkit is yours.\n",
-        "the Read toolbox\n",
-    ] {
-        let (text, warnings) = rewrite_prose(body, HarnessId::Codex);
-        assert_eq!(text, body);
-        assert!(warnings.is_empty(), "{body} warned");
-    }
 }
 
 #[test]

--- a/crates/core/src/scan/metadata/tests.rs
+++ b/crates/core/src/scan/metadata/tests.rs
@@ -5,13 +5,6 @@ fn frontmatter(body: &str) -> Metadata {
     from_markdown(&format!("---\n{body}\n---\nbody text\n"))
 }
 
-#[test]
-fn reads_a_description_and_an_inline_tag_list() {
-    let meta = frontmatter("description: reviews code\ntags: [review, testing]");
-    assert_eq!(meta.description.as_deref(), Some("reviews code"));
-    assert_eq!(meta.tags, vec![Tag::Review, Tag::Testing]);
-}
-
 /// The summary is the marketplace's line and the description the agent's;
 /// a package that writes only the description is shown that one.
 #[test]
@@ -50,46 +43,6 @@ fn a_summary_is_read_beside_the_description_and_stands_in_for_it() {
     assert_eq!(blank.summary_or_description(), Some("a db"));
 }
 
-#[test]
-fn reads_a_block_tag_list() {
-    let meta = frontmatter("tags:\n  - review\n  - security");
-    assert_eq!(meta.tags, vec![Tag::Review, Tag::Security]);
-}
-
-#[test]
-fn an_unbracketed_inline_list_is_still_a_list() {
-    let meta = frontmatter("tags: review, docs");
-    assert_eq!(meta.tags, vec![Tag::Review, Tag::Docs]);
-}
-
-/// A trailing comment is ordinary YAML. Reading it as part of the value
-/// loses every tag on the item and then names the comment as the mistake.
-#[test]
-fn a_trailing_comment_is_not_part_of_a_tag() {
-    for body in ["tags: [review] # main job", "tags: review # main job"] {
-        let meta = frontmatter(body);
-        assert_eq!(meta.tags, vec![Tag::Review], "{body}");
-        assert!(meta.unknown_tags.is_empty(), "{body}");
-    }
-}
-
-/// Blank lines and comments sit inside a block sequence all the time; a
-/// reader that stops at the first one drops the rest of the list silently.
-#[test]
-fn a_blank_line_or_comment_does_not_end_a_block_list() {
-    let meta = frontmatter("tags:\n  - review\n\n  # the other one\n  - security");
-    assert_eq!(meta.tags, vec![Tag::Review, Tag::Security]);
-}
-
-/// The dashes under `tags` belong to `tags`. A later key's list items must
-/// not be swept up as tags too.
-#[test]
-fn a_block_list_ends_at_the_next_key() {
-    let meta = frontmatter("tags:\n  - review\nallowed-tools:\n  - Bash\n  - Read");
-    assert_eq!(meta.tags, vec![Tag::Review]);
-    assert!(meta.unknown_tags.is_empty());
-}
-
 /// A folded description is prose, not the character that introduces it.
 #[test]
 fn a_folded_description_is_read_as_its_text() {
@@ -97,44 +50,6 @@ fn a_folded_description_is_read_as_its_text() {
     assert_eq!(
         meta.description.as_deref(),
         Some("a long description over two lines")
-    );
-}
-
-#[test]
-fn an_empty_tag_list_is_no_tags_and_no_complaint() {
-    for body in ["tags: []", "tags:"] {
-        let meta = frontmatter(body);
-        assert!(meta.tags.is_empty(), "{body}");
-        assert!(meta.unknown_tags.is_empty(), "{body}");
-    }
-}
-
-#[test]
-fn a_word_that_is_not_a_tag_is_kept_for_the_warning() {
-    let meta = frontmatter("tags: [review, wizardry]");
-    assert_eq!(meta.tags, vec![Tag::Review]);
-    assert_eq!(meta.unknown_tags, vec!["wizardry".to_owned()]);
-}
-
-#[test]
-fn a_repeated_tag_is_still_one_tag() {
-    assert_eq!(
-        frontmatter("tags: [review, review]").tags,
-        vec![Tag::Review]
-    );
-}
-
-#[test]
-fn casing_and_padding_are_the_authors_business() {
-    let meta = frontmatter("tags: [ Review , SECURITY ]");
-    assert_eq!(meta.tags, vec![Tag::Review, Tag::Security]);
-}
-
-#[test]
-fn tags_come_back_in_vocabulary_order_however_they_were_written() {
-    assert_eq!(
-        frontmatter("tags: [testing, review]").tags,
-        vec![Tag::Review, Tag::Testing]
     );
 }
 
@@ -150,42 +65,108 @@ fn toml_carries_the_same_two_keys() {
     assert_eq!(meta.tags, vec![Tag::Git, Tag::Release]);
 }
 
-/// A near miss is one letter from correct, so the warning says which letter
-/// — printing the whole vocabulary makes the reader do that work.
 #[test]
-fn a_near_miss_is_told_what_it_nearly_was() {
-    let meta = frontmatter("tags: [tests]");
-    let warning = meta.unknown_warning().unwrap();
-    assert!(warning.contains("did you mean `testing`?"), "{warning}");
+fn reads_a_plain_description() {
+    let meta = frontmatter("description: reviews code\ntags: [review, testing]");
+    assert_eq!(meta.description.as_deref(), Some("reviews code"));
 }
 
-/// Nothing close means no guess: naming a tag it plainly is not would send
-/// the reader to fix the wrong thing.
+/// One row per spelling a tag list takes in a header: the tags it decodes
+/// to, in vocabulary order however they were written, and the words kept
+/// for the warning. A trailing comment is ordinary YAML, and reading it as
+/// part of the value loses every tag on the item and then names the
+/// comment as the mistake. Blank lines and comments sit inside a block
+/// sequence all the time; a reader that stops at the first one drops the
+/// rest of the list silently. The dashes under `tags` belong to `tags`,
+/// so a later key's list items are not swept up as tags. An empty list is
+/// no tags and no complaint. Casing and padding are the author's
+/// business, a repeated tag is one tag, and the same bad word twice is one
+/// mistake whatever case it was written in.
 #[test]
-fn a_word_nothing_like_a_tag_gets_the_vocabulary() {
-    let meta = frontmatter("tags: [wizardry]");
-    let warning = meta.unknown_warning().unwrap();
-    assert!(!warning.contains("did you mean"), "{warning}");
-    assert!(warning.contains("review, testing"), "{warning}");
+fn a_tag_list_decodes_to_its_tags_and_keeps_the_rest_for_the_warning() {
+    let rows: [(&str, &[Tag], &[&str]); 14] = [
+        ("tags: [review, testing]", &[Tag::Review, Tag::Testing], &[]),
+        (
+            "tags:\n  - review\n  - security",
+            &[Tag::Review, Tag::Security],
+            &[],
+        ),
+        ("tags: review, docs", &[Tag::Review, Tag::Docs], &[]),
+        ("tags: [review] # main job", &[Tag::Review], &[]),
+        ("tags: review # main job", &[Tag::Review], &[]),
+        (
+            "tags:\n  - review\n\n  # the other one\n  - security",
+            &[Tag::Review, Tag::Security],
+            &[],
+        ),
+        (
+            "tags:\n  - review\nallowed-tools:\n  - Bash\n  - Read",
+            &[Tag::Review],
+            &[],
+        ),
+        ("tags: []", &[], &[]),
+        ("tags:", &[], &[]),
+        ("tags: [review, wizardry]", &[Tag::Review], &["wizardry"]),
+        ("tags: [review, review]", &[Tag::Review], &[]),
+        (
+            "tags: [ Review , SECURITY ]",
+            &[Tag::Review, Tag::Security],
+            &[],
+        ),
+        ("tags: [testing, review]", &[Tag::Review, Tag::Testing], &[]),
+        ("tags: [tests, Tests]", &[], &["tests"]),
+    ];
+    for (body, tags, unknown) in rows {
+        let meta = frontmatter(body);
+        assert_eq!(meta.tags, tags, "{body:?}");
+        assert_eq!(meta.unknown_tags, unknown, "{body:?}");
+    }
 }
 
+/// One row per shape the unknown-tag warning takes. A near miss is one
+/// letter from correct, so the warning says which letter — printing the
+/// whole vocabulary makes the reader do that work. Nothing close means no
+/// guess, since naming a tag it plainly is not would send the reader to
+/// fix the wrong thing; that arm ends in the vocabulary, which is
+/// `tags::ALL_TAGS`'s to list and is not pinned here. Several bad words
+/// are counted rather than all listed. Nothing unknown is nothing to warn
+/// about.
 #[test]
-fn several_bad_words_are_counted_rather_than_all_listed() {
-    let meta = frontmatter("tags: [tests, wizardry, sorcery]");
-    let warning = meta.unknown_warning().unwrap();
-    assert!(warning.contains("and 2 others"), "{warning}");
-}
-
-#[test]
-fn nothing_unknown_means_nothing_to_warn_about() {
-    assert_eq!(frontmatter("tags: [review]").unknown_warning(), None);
-}
-
-/// The same word twice is one mistake, whatever case it was written in.
-#[test]
-fn a_repeated_bad_word_is_reported_once() {
-    let meta = frontmatter("tags: [tests, Tests]");
-    assert_eq!(meta.unknown_tags.len(), 1);
+fn the_unknown_tag_warning_names_the_nearest_tag_or_the_vocabulary() {
+    /// The whole warning, or everything of it up to the vocabulary.
+    enum Warning {
+        Whole(&'static str),
+        Prefix(&'static str),
+        None,
+    }
+    let rows = [
+        (
+            "tags: [tests]",
+            Warning::Whole("`tests` is not a tag — did you mean `testing`?"),
+        ),
+        (
+            "tags: [wizardry]",
+            Warning::Prefix("`wizardry` is not a tag — the tags are "),
+        ),
+        (
+            "tags: [tests, wizardry, sorcery]",
+            Warning::Whole("`tests` is not a tag — did you mean `testing`? (and 2 others)"),
+        ),
+        ("tags: [review]", Warning::None),
+    ];
+    for (body, warning) in rows {
+        let got = frontmatter(body).unknown_warning();
+        match warning {
+            Warning::Whole(whole) => assert_eq!(got.as_deref(), Some(whole), "{body}"),
+            Warning::Prefix(prefix) => {
+                assert!(
+                    got.as_deref().is_some_and(|w| w.starts_with(prefix)),
+                    "{body}: {got:?}"
+                );
+            }
+            Warning::None => assert_eq!(got, None, "{body}"),
+        }
+    }
 }
 
 /// A markdown header that never closes inside the cap is not a header, and

--- a/crates/core/src/settings_seed/tests.rs
+++ b/crates/core/src/settings_seed/tests.rs
@@ -325,116 +325,152 @@ fn entry_keys(entries: &[EnvEntry]) -> Vec<&str> {
     entries.iter().map(|entry| entry.key.as_str()).collect()
 }
 
-/// A value TOML lets span lines is seeded whole. Stopping at the line
-/// carrying the `=` would write `BLOB = """` with nothing under it: the
-/// string never closes, every key seeded after it falls inside it, and the
-/// consumer's file stops parsing from there down.
+/// One row per value TOML lets span lines or hold structure, seeded whole:
+/// one entry rather than one per line the value holds, its comment still
+/// only the comment, the whole assignment spelled as the template spells
+/// it, nothing to note, and the seeded file parsing back to the value the
+/// template declares. Stopping at the line carrying the `=` would write
+/// `BLOB = """` with nothing under it: the string never closes, every key
+/// seeded after it falls inside it, and the consumer's file stops parsing
+/// from there down. An inline table that closes is an ordinary complete
+/// value, on one line or across several — treated as line-local it was
+/// refused, and worse, the lines holding it read as structure, so `a = 1`
+/// beneath `MAP = {` seeded as a key of its own that the template never
+/// declared. A completeness rule that refused every brace would be as
+/// wrong as one that accepted every brace.
 #[test]
-fn a_value_spanning_lines_is_seeded_whole() {
-    for value in [
-        "\"\"\"\nsome text\n\"\"\"",
-        "'''\nsome text\n'''",
-        "[\n  \"a\",\n  \"b\",\n]",
-    ] {
-        let template = format!("[env]\n# A blob.\nBLOB = {value}\n\n# How deep.\nDEPTH = \"2\"\n");
+fn a_value_that_spans_lines_or_holds_structure_is_seeded_whole() {
+    let rows: [(&str, &str); 11] = [
+        ("BLOB", "\"\"\"\nsome text\n\"\"\""),
+        ("BLOB", "'''\nsome text\n'''"),
+        ("BLOB", "[\n  \"a\",\n  \"b\",\n]"),
+        ("MAP", "{ a = 1 }"),
+        ("MAP", "{ a = { b = 1 } }"),
+        ("MAP", "{ a = \"}\" }"),
+        ("MAP", "{ a = [1, 2] }"),
+        ("MAP", "{\na = 1\n}"),
+        ("MAP", "{ items = [\n  1,\n] }"),
+        ("MAP", "{\n  a = { b = 1 },\n}"),
+        ("MAP", "{\n  a = \"\"\"\n  text\n  \"\"\",\n}"),
+    ];
+    for (key, value) in rows {
+        let template =
+            format!("[env]\n# A value.\n{key} = {value}\n\n# How deep.\nDEPTH = \"2\"\n");
         let entries = extract_env_entries(&template);
-        assert_eq!(entry_keys(&entries), ["BLOB", "DEPTH"], "{value}");
-        // The value's continuation lines are the assignment's, and the
-        // comment above it is still only the comment.
-        assert_eq!(entries[0].comment, ["# A blob."], "{value}");
-        // The whole assignment, spelled as the template spells it.
-        assert_eq!(entries[0].assignment, format!("BLOB = {value}"), "{value}");
+        assert_eq!(entry_keys(&entries), [key, "DEPTH"], "{value}");
+        assert_eq!(entries[0].comment, ["# A value."], "{value}");
+        assert_eq!(entries[0].assignment, format!("{key} = {value}"), "{value}");
         assert!(entries[0].complete(), "{value}");
 
         let shipped = seeded(&template, "review");
-        let (text, added) = merge(None, &shipped, &all(&shipped)).expect("both are missing");
-        assert_eq!(added, ["BLOB", "DEPTH"], "{value}");
-        // Spelled as the template spells it, and closed: the seeded file
-        // parses, and BLOB reads back as the value the template declares.
         assert!(
-            text.contains(&format!("BLOB = {value}\n")),
+            seed_notes(&shipped, &nothing(&shipped), &all(&shipped)).is_empty(),
+            "{value}"
+        );
+        let (text, added) = merge(None, &shipped, &all(&shipped)).expect("both are missing");
+        assert_eq!(added, [key, "DEPTH"], "{value}");
+        assert!(
+            text.contains(&format!("{key} = {value}\n")),
             "{value}: {text}"
         );
         let want: toml::Table = template.parse().expect("the template parses");
         let got: toml::Table = text
             .parse()
             .unwrap_or_else(|error| panic!("{value}: seeded file must parse: {error}\n{text}"));
-        assert_eq!(got["env"]["BLOB"], want["env"]["BLOB"], "{value}");
+        assert_eq!(got["env"][key], want["env"][key], "{value}");
         assert_eq!(got["env"]["DEPTH"], want["env"]["DEPTH"], "{value}");
     }
 }
 
-/// A value nothing closes is not a multiline value: there is no complete
-/// text to copy, and writing the opening line alone is the corruption
-/// itself. Seeding writes nothing for that key — and says so, naming it.
-/// A silent drop would leave a key nobody finds until a script reads it.
+/// One row per value nothing closes. There is no complete text to copy,
+/// and writing the opening line alone is the corruption itself, so
+/// seeding writes nothing for that key — and says so, naming the key and
+/// who ships it, with no particular delimiter named, since the note is
+/// one sentence for every form. A silent drop would leave a key nobody
+/// finds until a script reads it. Closing and being finished are
+/// different questions: a single-line string ends with its line by
+/// definition, so `TOKEN = "` carries nothing onto the next line and is
+/// still unfinished, and read off the absence of a carry it would seed.
+/// An inline table the file never closes is refused like any other
+/// container: the carry runs to the end and nothing completes it. Where
+/// the file goes on, the complete keys around the refused one still seed
+/// and the seeded file still parses.
 #[test]
-fn a_value_nothing_closes_is_refused_by_name() {
-    let template = "[env]\n# How deep.\nDEPTH = \"2\"\n\n# A blob.\nBLOB = \"\"\"\nsome text\n";
-    let entries = extract_env_entries(template);
-    assert_eq!(entry_keys(&entries), ["DEPTH", "BLOB"]);
-    assert!(!entries[1].complete(), "{entries:?}");
-    assert!(entries[1].assignment.is_empty(), "{entries:?}");
+fn a_value_nothing_closes_is_refused_by_name_and_seeds_nothing() {
+    let rows: [(&str, &str, Option<&[&str]>); 10] = [
+        (
+            "[env]\n# How deep.\nDEPTH = \"2\"\n\n# A blob.\nBLOB = \"\"\"\nsome text\n",
+            "BLOB",
+            Some(&["DEPTH"]),
+        ),
+        ("[env]\n# A blob.\nBLOB = \"\"\"\n", "BLOB", None),
+        ("[env]\n# A token.\nTOKEN = \"\n", "TOKEN", None),
+        (
+            "[env]\n# A token.\nTOKEN = \"\n\n# How deep.\nDEPTH = \"2\"\n",
+            "TOKEN",
+            Some(&["DEPTH"]),
+        ),
+        ("[env]\n# A token.\nTOKEN = \"", "TOKEN", None),
+        ("[env]\n# A map.\nMAP = {\n", "MAP", None),
+        // The key below an open table is inside it, so nothing is complete.
+        (
+            "[env]\n# A map.\nMAP = { a = 1,\n\n# How deep.\nDEPTH = \"2\"\n",
+            "MAP",
+            None,
+        ),
+        ("[env]\n# A map.\nMAP = { a = { b = 1 }\n", "MAP", None),
+        ("[env]\n# A map.\nMAP = {", "MAP", None),
+        ("[env]\n# A list.\nLIST = [\n", "LIST", None),
+    ];
+    for (template, key, added) in rows {
+        let entries = extract_env_entries(template);
+        let entry = entries
+            .iter()
+            .find(|entry| entry.key == key)
+            .unwrap_or_else(|| panic!("{template:?}: {entries:?}"));
+        assert!(!entry.complete(), "{template:?}: {entries:?}");
+        assert!(entry.assignment.is_empty(), "{template:?}");
 
-    let shipped = seeded(template, "review");
-    let (text, added) = merge(None, &shipped, &all(&shipped)).expect("DEPTH is missing");
-    assert_eq!(added, ["DEPTH"]);
-    assert!(
-        !text.contains("BLOB"),
-        "no part of it may be written:\n{text}"
+        let shipped = seeded(template, "review");
+        let written = merge(None, &shipped, &all(&shipped));
+        assert_eq!(
+            written
+                .as_ref()
+                .map(|(_, added)| added.iter().map(String::as_str).collect::<Vec<_>>()),
+            added.map(<[&str]>::to_vec),
+            "{template:?}: {written:?}"
+        );
+        if let Some((text, _)) = &written {
+            assert!(
+                !text.contains(key),
+                "{template:?}: nothing may be written for it: {text}"
+            );
+            text.parse::<toml::Table>()
+                .unwrap_or_else(|e| panic!("{template:?}: seeded file must parse: {e}\n{text}"));
+        }
+        let notes = unterminated_notes(&shipped);
+        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
+        let said = format!(
+            "{SETTINGS_FILE} {key}: review's template never finishes this value — it opens something that is never closed — so there is no complete default to seed and nothing was written for this key"
+        );
+        assert!(notes[0].starts_with(&said), "{template:?}: {notes:?}");
+    }
+}
+
+/// Where another skill ships the same key whole, that one is seeded and
+/// nothing is reported: there is nothing for a person to do.
+#[test]
+fn a_key_another_skill_ships_whole_is_seeded_and_nothing_is_reported() {
+    let shipped = seeded(
+        "[env]\n# How deep.\nDEPTH = \"2\"\n\n# A blob.\nBLOB = \"\"\"\nsome text\n",
+        "review",
     );
-    text.parse::<toml::Table>().expect("the seeded file parses");
-
-    let notes = unterminated_notes(&shipped);
-    assert_eq!(notes.len(), 1, "{notes:?}");
-    assert!(notes[0].contains("BLOB"), "the key is named: {notes:?}");
-    assert!(notes[0].contains("review"), "and who ships it: {notes:?}");
-
-    // Where another skill ships the same key whole, that one is seeded
-    // and nothing is reported: there is nothing for a person to do.
     let whole = seeded("[env]\n# A blob.\nBLOB = \"ok\"\n", "other");
     let both: Vec<SeededEnv> = shipped.iter().cloned().chain(whole).collect();
     assert!(unterminated_notes(&both).is_empty(), "{both:?}");
     let (text, added) = merge(None, &both, &all(&both)).expect("both are missing");
     assert_eq!(added, ["DEPTH", "BLOB"]);
     assert!(text.contains("BLOB = \"ok\""), "{text}");
-}
-
-/// Closing and being finished are different questions, and the shape that
-/// proves it is the one closest to what this all exists to prevent: a
-/// single-line string ends with its line by definition, so `TOKEN = "`
-/// carries nothing onto the next line and is still unfinished. Read
-/// completeness off the absence of a carry and it seeds, putting an
-/// unterminated line in the consumer's file — the exact outcome refused
-/// everywhere else here.
-#[test]
-fn a_one_line_value_left_unterminated_is_refused_by_name() {
-    for template in [
-        "[env]\n# A token.\nTOKEN = \"\n",
-        // With the file continuing under it, and with no terminator.
-        "[env]\n# A token.\nTOKEN = \"\n\n# How deep.\nDEPTH = \"2\"\n",
-        "[env]\n# A token.\nTOKEN = \"",
-    ] {
-        let entries = extract_env_entries(template);
-        assert!(!entries[0].complete(), "{template:?}: {entries:?}");
-        assert!(entries[0].assignment.is_empty(), "{template:?}");
-
-        let shipped = seeded(template, "review");
-        let written = merge(None, &shipped, &all(&shipped));
-        assert!(
-            !written
-                .as_ref()
-                .is_some_and(|(text, _)| text.contains("TOKEN")),
-            "{template:?}: nothing may be written for it: {written:?}"
-        );
-        if let Some((text, _)) = &written {
-            text.parse::<toml::Table>()
-                .unwrap_or_else(|e| panic!("{template:?}: seeded file must parse: {e}\n{text}"));
-        }
-        let notes = unterminated_notes(&shipped);
-        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
-        assert!(notes[0].contains("TOKEN"), "{template:?}: {notes:?}");
-    }
 }
 
 /// One key, one winner, and everyone has to name it. A broken template
@@ -466,71 +502,12 @@ fn a_broken_declaration_before_a_valid_one_never_becomes_the_owner() {
     );
 
     // And the notes: a broken declaration is not a competing default that
-    // lands, so nothing claims the broken skill's value was written.
-    for note in seed_notes(&shipped, &nothing(&shipped), &all(&shipped)) {
-        assert!(!note.contains("broken's is the one written"), "{note}");
-    }
-}
-
-/// An inline table the file never closes is refused like any other
-/// container the file never closes: the carry runs to the end and nothing
-/// completes it. Completeness comes off the grammar's own split rather
-/// than a rule per form, so this needs no case of its own.
-#[test]
-fn an_inline_table_left_open_is_refused_by_name() {
-    for template in [
-        "[env]\n# A map.\nMAP = {\n",
-        "[env]\n# A map.\nMAP = { a = 1,\n\n# How deep.\nDEPTH = \"2\"\n",
-        "[env]\n# A map.\nMAP = { a = { b = 1 }\n",
-        "[env]\n# A map.\nMAP = {",
-    ] {
-        let entries = extract_env_entries(template);
-        assert!(!entries[0].complete(), "{template:?}: {entries:?}");
-
-        let shipped = seeded(template, "review");
-        let written = merge(None, &shipped, &all(&shipped));
-        assert!(
-            !written
-                .as_ref()
-                .is_some_and(|(text, _)| text.contains("MAP")),
-            "{template:?}: nothing may be written for it: {written:?}"
-        );
-        if let Some((text, _)) = &written {
-            text.parse::<toml::Table>()
-                .unwrap_or_else(|e| panic!("{template:?}: must parse: {e}\n{text}"));
-        }
-        let notes = unterminated_notes(&shipped);
-        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
-        assert!(notes[0].contains("MAP"), "{template:?}: {notes:?}");
-    }
-}
-
-/// The other half: an inline table that closes is an ordinary complete
-/// value and seeds like any other. A completeness rule that refused every
-/// brace would be as wrong as one that accepted every brace.
-#[test]
-fn an_inline_table_that_closes_seeds_like_any_other_value() {
-    for value in [
-        "{ a = 1 }",
-        "{ a = { b = 1 } }",
-        "{ a = \"}\" }",
-        "{ a = [1, 2] }",
-    ] {
-        let template = format!("[env]\n# A map.\nMAP = {value}\n");
-        let entries = extract_env_entries(&template);
-        assert!(entries[0].complete(), "{value}: {entries:?}");
-        assert_eq!(entries[0].assignment, format!("MAP = {value}"), "{value}");
-
-        let shipped = seeded(&template, "review");
-        assert!(unterminated_notes(&shipped).is_empty(), "{value}");
-        let (text, added) = merge(None, &shipped, &all(&shipped)).expect("MAP is missing");
-        assert_eq!(added, ["MAP"], "{value}");
-        let want: toml::Table = template.parse().expect("the template parses");
-        let got: toml::Table = text
-            .parse()
-            .unwrap_or_else(|e| panic!("{value}: seeded file must parse: {e}\n{text}"));
-        assert_eq!(got["env"]["MAP"], want["env"]["MAP"], "{value}");
-    }
+    // lands, and the key has a complete default, so there is no note at
+    // all — nothing claims the broken skill's value was written.
+    assert_eq!(
+        seed_notes(&shipped, &nothing(&shipped), &all(&shipped)),
+        Vec::<String>::new()
+    );
 }
 
 /// Two kinds of newline meet in a seeded block and only one of them is the
@@ -613,64 +590,6 @@ fn an_incomplete_declaration_is_not_a_default_to_disagree_with() {
     );
 }
 
-/// The refusal fires for every form the grammar can leave open, so it may
-/// not name a subset of them. Naming "a string or an array" sent somebody
-/// whose inline table was unclosed to the wrong part of their template,
-/// and any list goes stale the moment the enumerated grammar grows.
-#[test]
-fn the_refusal_names_the_key_and_no_particular_delimiter() {
-    for (template, key) in [
-        ("[env]\n# A.\nTOKEN = \"\n", "TOKEN"),
-        ("[env]\n# A.\nMAP = {\n", "MAP"),
-        ("[env]\n# A.\nLIST = [\n", "LIST"),
-        ("[env]\n# A.\nBLOB = \"\"\"\n", "BLOB"),
-    ] {
-        let notes = unterminated_notes(&seeded(template, "review"));
-        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
-        assert!(notes[0].contains(key), "the key is named: {notes:?}");
-        for named in ["string", "array", "inline table", "quote", "bracket"] {
-            assert!(
-                !notes[0].contains(named),
-                "{template:?}: names {named}, which is only true of some: {notes:?}"
-            );
-        }
-    }
-}
-
-/// An inline table spanning lines is a value like any other under the spec
-/// this workspace parses with. Treated as line-local it was refused, and
-/// worse: the lines holding it read as structure, so `a = 1` beneath
-/// `MAP = {` seeded as a key of its own that the template never declared.
-#[test]
-fn an_inline_table_spanning_lines_is_seeded_whole() {
-    for value in [
-        "{\na = 1\n}",
-        "{ items = [\n  1,\n] }",
-        "{\n  a = { b = 1 },\n}",
-        "{\n  a = \"\"\"\n  text\n  \"\"\",\n}",
-    ] {
-        let template = format!("[env]\n# A map.\nMAP = {value}\n");
-        let entries = extract_env_entries(&template);
-        // One entry, not one per line the value happens to hold.
-        assert_eq!(entry_keys(&entries), ["MAP"], "{value}");
-        assert!(entries[0].complete(), "{value}: {entries:?}");
-        assert_eq!(entries[0].assignment, format!("MAP = {value}"), "{value}");
-
-        let shipped = seeded(&template, "review");
-        assert!(
-            seed_notes(&shipped, &nothing(&shipped), &all(&shipped)).is_empty(),
-            "{value}"
-        );
-        let (text, added) = merge(None, &shipped, &all(&shipped)).expect("MAP is missing");
-        assert_eq!(added, ["MAP"], "{value}");
-        let want: toml::Table = template.parse().expect("the template parses");
-        let got: toml::Table = text
-            .parse()
-            .unwrap_or_else(|e| panic!("{value}: seeded file must parse: {e}\n{text}"));
-        assert_eq!(got["env"]["MAP"], want["env"]["MAP"], "{value}");
-    }
-}
-
 /// A key beneath a multiline value belongs to the value, and one beneath a
 /// closed one belongs to the file. Both directions, because reading the
 /// first as structure is what invented a declaration.
@@ -683,7 +602,7 @@ fn a_key_under_an_inline_table_belongs_to_whichever_owns_its_line() {
     let (text, added) = merge(None, &shipped, &all(&shipped)).expect("both are missing");
     assert_eq!(added, ["MAP", "DEPTH"]);
     let got: toml::Table = text.parse().expect("the seeded file parses");
-    assert!(got["env"]["MAP"].get("a").is_some(), "{text}");
+    assert_eq!(got["env"]["MAP"]["a"], toml::Value::Integer(1), "{text}");
     assert!(
         got["env"].get("a").is_none(),
         "a is MAP's, not the table's: {text}"

--- a/crates/core/src/settings_seed/tests/notes.rs
+++ b/crates/core/src/settings_seed/tests/notes.rs
@@ -22,145 +22,171 @@ fn conflict_notes_all(entries: &[SeededEnv]) -> Vec<String> {
     conflict_notes(entries, &super::nothing(entries), &super::all(entries))
 }
 
-#[test]
-fn one_note_groups_every_owner_and_every_distinct_default() {
-    let notes = conflict_notes_all(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"900\"\n"),
-        ("gamma", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-    ]));
-    assert_eq!(
-        notes,
-        [
-            "kendex.settings.toml WAIT: packages ship different defaults — \"900\" (alpha, beta), \"600\" (gamma) — alpha's is the one written, so set the value yourself if that is not the one you want"
-        ]
-    );
+/// The one conflict note a key gets, whole: the defaults grouped by the
+/// owners shipping each, and the owner whose value is written.
+fn disagreement(key: &str, defaults: &str, written: &str) -> String {
+    format!(
+        "kendex.settings.toml {key}: packages ship different defaults — {defaults} — {written}'s is the one written, so set the value yourself if that is not the one you want"
+    )
 }
 
+/// One row per set of templates sharing a key, and the conflict notes
+/// they get. One note groups every owner and every distinct default, and
+/// names the owner whose value merge actually seeds: alpha's default
+/// carrying a trailing comment, which the loaders read and a stricter
+/// decoder once threw away — dropping alpha from the note and naming beta
+/// as the package whose value lands. A default no decoder reads still
+/// names its owner. Packages agreeing on a shared key, a key only one
+/// package ships, and a trailing comment on the same value say nothing.
+/// Two packages shipping one key with different multiline values do
+/// disagree, and shown from the `=` line alone both read as a bare `"""`
+/// and would group as agreeing, so each value is shown whole on the one
+/// line; two defaults that differ only in what the display collapses (the
+/// display joins a value's lines with a space, so `a\nb` and `a b` render
+/// alike) are still two defaults; and two shipping the same multiline
+/// value still say nothing. Catalog text reaches a note escaped.
 #[test]
-fn packages_agreeing_on_a_shared_key_say_nothing() {
-    let notes = conflict_notes_all(&shipped(&[
+#[allow(
+    clippy::too_many_lines,
+    reason = "one table: eleven template sets judged by one note builder, each row a set of its own"
+)]
+fn a_shared_key_gets_one_conflict_note_or_none() {
+    /// The owners and their templates, and the notes they get.
+    type Row = (Vec<(&'static str, String)>, Vec<String>);
+    let blob = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
+    let rows: Vec<Row> = vec![
         (
-            "alpha",
-            "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n",
+            vec![
+                ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n".to_owned()),
+                ("beta", "[env]\n# Wait.\nWAIT = \"900\"\n".to_owned()),
+                ("gamma", "[env]\n# Wait.\nWAIT = \"600\"\n".to_owned()),
+            ],
+            vec![disagreement(
+                "WAIT",
+                "\"900\" (alpha, beta), \"600\" (gamma)",
+                "alpha",
+            )],
         ),
         (
-            "beta",
-            "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n",
+            vec![
+                (
+                    "alpha",
+                    "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n".to_owned(),
+                ),
+                (
+                    "beta",
+                    "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n".to_owned(),
+                ),
+            ],
+            vec![],
         ),
-    ]));
-    assert!(notes.is_empty(), "{notes:?}");
+        (
+            vec![
+                ("alpha", "[env]\n# Depth.\nDEPTH = \"2\"\n".to_owned()),
+                ("beta", "[env]\n# Width.\nWIDTH = \"3\"\n".to_owned()),
+            ],
+            vec![],
+        ),
+        (
+            vec![
+                (
+                    "alpha",
+                    "[env]\n# Wait.\nWAIT = \"900\" # seconds\n".to_owned(),
+                ),
+                ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n".to_owned()),
+                ("gamma", "[env]\n# Wait.\nWAIT = \"300\"\n".to_owned()),
+            ],
+            vec![disagreement(
+                "WAIT",
+                "\"900\" (alpha), \"600\" (beta), \"300\" (gamma)",
+                "alpha",
+            )],
+        ),
+        (
+            vec![
+                ("alpha", "[env]\n# Wait.\nWAIT = 900\n".to_owned()),
+                ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n".to_owned()),
+            ],
+            vec![disagreement("WAIT", "900 (alpha), \"600\" (beta)", "alpha")],
+        ),
+        (
+            vec![
+                ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n".to_owned()),
+                (
+                    "beta",
+                    "[env]\n# Wait.\nWAIT = \"900\" # seconds\n".to_owned(),
+                ),
+            ],
+            vec![],
+        ),
+        (
+            vec![
+                (
+                    "alpha",
+                    "[env]\n# Wait.\nWAIT = \"90\u{1b}[31m0\"\n".to_owned(),
+                ),
+                (
+                    "be\u{1b}[31mta",
+                    "[env]\n# Wait.\nWAIT = \"600\"\n".to_owned(),
+                ),
+            ],
+            vec![disagreement(
+                "WAIT",
+                "\"90\\u{1b}[31m0\" (alpha), \"600\" (be\\u{1b}[31mta)",
+                "alpha",
+            )],
+        ),
+        (
+            vec![("a", blob("from a")), ("b", blob("from b"))],
+            vec![disagreement(
+                "BLOB",
+                "\"\"\" from a \"\"\" (a), \"\"\" from b \"\"\" (b)",
+                "a",
+            )],
+        ),
+        (vec![("a", blob("same")), ("b", blob("same"))], vec![]),
+        (
+            vec![("split", blob("a\nb")), ("joined", blob("a b"))],
+            vec![disagreement(
+                "BLOB",
+                "\"\"\" a b \"\"\" (split), \"\"\" a b \"\"\" (joined)",
+                "split",
+            )],
+        ),
+        (vec![("one", blob("a\nb")), ("two", blob("a\nb"))], vec![]),
+    ];
+    for (owners, notes) in rows {
+        let entries: Vec<SeededEnv> = owners
+            .iter()
+            .flat_map(|(owner, template)| seeded(template, owner))
+            .collect();
+        assert_eq!(conflict_notes_all(&entries), notes, "{owners:?}");
+    }
 }
 
+/// The owner the note names is what merge writes: alpha's default, with
+/// its trailing comment, is the value that lands.
 #[test]
-fn a_key_only_one_package_ships_says_nothing() {
-    let notes = conflict_notes_all(&shipped(&[
-        ("alpha", "[env]\n# Depth.\nDEPTH = \"2\"\n"),
-        ("beta", "[env]\n# Width.\nWIDTH = \"3\"\n"),
-    ]));
-    assert!(notes.is_empty(), "{notes:?}");
-}
-
-#[test]
-fn the_note_names_the_owner_whose_value_merge_actually_seeds() {
-    // alpha's default carries a trailing comment, which the loaders read
-    // and a stricter decoder once threw away — dropping alpha from the note
-    // and naming beta as the package whose value lands.
+fn merge_writes_the_value_of_the_owner_the_note_names() {
     let entries = shipped(&[
         ("alpha", "[env]\n# Wait.\nWAIT = \"900\" # seconds\n"),
         ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
         ("gamma", "[env]\n# Wait.\nWAIT = \"300\"\n"),
     ]);
-    let notes = conflict_notes(&entries, &super::nothing(&entries), &super::all(&entries));
-    assert_eq!(
-        notes,
-        [
-            "kendex.settings.toml WAIT: packages ship different defaults — \"900\" (alpha), \"600\" (beta), \"300\" (gamma) — alpha's is the one written, so set the value yourself if that is not the one you want"
-        ]
-    );
-    // And alpha is what merge writes, which is what the note claims.
     let (merged, added) = merge(None, &entries, &super::all(&entries)).unwrap();
     assert_eq!(added, ["WAIT"]);
     assert!(merged.contains("WAIT = \"900\" # seconds"), "{merged}");
 }
 
+/// The display cannot tell `a\nb` from `a b`; the key the note groups on
+/// still must.
 #[test]
-fn a_default_no_decoder_reads_still_names_its_owner() {
-    let notes = conflict_notes_all(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = 900\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-    ]));
-    assert_eq!(
-        notes,
-        [
-            "kendex.settings.toml WAIT: packages ship different defaults — 900 (alpha), \"600\" (beta) — alpha's is the one written, so set the value yourself if that is not the one you want"
-        ]
-    );
-}
-
-#[test]
-fn a_trailing_comment_is_not_a_different_default() {
-    let notes = conflict_notes_all(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"900\" # seconds\n"),
-    ]));
-    assert!(notes.is_empty(), "{notes:?}");
-}
-
-#[test]
-fn catalog_text_reaches_a_note_escaped() {
-    let notes = conflict_notes_all(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"90\u{1b}[31m0\"\n"),
-        ("be\u{1b}[31mta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-    ]));
-    assert_eq!(notes.len(), 1, "{notes:?}");
-    assert!(!notes[0].contains('\u{1b}'), "{notes:?}");
-    assert!(notes[0].contains("\\u{1b}[31m"), "{notes:?}");
-}
-
-/// Two packages shipping one key with different multiline values do
-/// disagree, and the note has to say so. Shown from the `=` line alone
-/// both read as a bare `"""` and the note would group them as agreeing.
-#[test]
-fn two_different_multiline_defaults_are_not_one_default() {
-    let template = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
-    let mut shipped = seeded(&template("from a"), "a");
-    shipped.extend(seeded(&template("from b"), "b"));
-    let notes = conflict_notes_all(&shipped);
-    assert_eq!(notes.len(), 1, "{notes:?}");
-    // Each value shown whole on the one line, so the two read as the
-    // different defaults they are.
-    assert!(notes[0].contains("\"\"\" from a \"\"\" (a)"), "{notes:?}");
-    assert!(notes[0].contains("\"\"\" from b \"\"\" (b)"), "{notes:?}");
-
-    // And two shipping the SAME multiline value still say nothing.
-    let mut agreeing = seeded(&template("same"), "a");
-    agreeing.extend(seeded(&template("same"), "b"));
-    assert!(conflict_notes_all(&agreeing).is_empty());
-}
-/// Two defaults that differ only in what the display collapses are still
-/// two defaults. `default_shown` joins a value's lines with a space for
-/// reading, so a multiline holding `a\nb` and one holding `a b` render
-/// alike; grouped on that text the disagreement disappears, which is the
-/// one thing this note exists to catch.
-#[test]
-fn defaults_the_display_collapses_alike_are_still_a_disagreement() {
+fn the_display_collapses_what_the_default_key_keeps_apart() {
     let template = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
     let mut shipped = seeded(&template("a\nb"), "split");
     shipped.extend(seeded(&template("a b"), "joined"));
-    // The display cannot tell them apart; the note still must.
     assert_eq!(shipped[0].default_shown(), shipped[1].default_shown());
     assert_ne!(shipped[0].default_key(), shipped[1].default_key());
-
-    let notes = conflict_notes_all(&shipped);
-    assert_eq!(notes.len(), 1, "{notes:?}");
-    assert!(notes[0].contains("(split)"), "{notes:?}");
-    assert!(notes[0].contains("(joined)"), "{notes:?}");
-
-    // Two that really are the same value still say nothing.
-    let mut agreeing = seeded(&template("a\nb"), "one");
-    agreeing.extend(seeded(&template("a\nb"), "two"));
-    assert!(conflict_notes_all(&agreeing).is_empty());
 }
 
 /// A marked key nothing answers, on the ordinary pass: nothing arriving,
@@ -225,7 +251,7 @@ fn the_pass_that_writes_the_key_is_silent_and_the_pass_that_does_not_names_it() 
 
 /// Owner names come from a catalog a download supplied, and the note is
 /// read on a terminal: what reaches it is escaped, the way
-/// `catalog_text_reaches_a_note_escaped` holds the conflict note.
+/// `a_shared_key_gets_one_conflict_note_or_none` holds the conflict note.
 #[test]
 fn catalog_text_reaches_an_unanswered_note_escaped() {
     let notes = unanswered_now(&shipped(&[(

--- a/crates/core/src/settings_template/tests.rs
+++ b/crates/core/src/settings_template/tests.rs
@@ -41,36 +41,6 @@ fn a_file_that_does_not_parse_is_one_finding() {
 }
 
 #[test]
-fn an_assignment_outside_env_is_located() {
-    let found = located("# Why.\nDEPTH = \"2\"\n\n[env]\n# Why.\nOTHER = \"1\"\n");
-    assert_eq!(found, [(2, "DEPTH is assigned outside [env]".to_owned())]);
-}
-
-#[test]
-fn a_second_env_header_is_located() {
-    let found = located("[env]\n# Why.\nA = \"1\"\n\n[env]\n# Why.\nB = \"2\"\n");
-    assert_eq!(
-        found,
-        [(
-            5,
-            "a second [env] header; the first is on line 1".to_owned()
-        )]
-    );
-}
-
-#[test]
-fn a_key_with_no_comment_block_is_located() {
-    let found = located("[env]\n# Why.\nA = \"1\"\n\nB = \"2\"\n");
-    assert_eq!(found, [(5, "B has no comment block above it".to_owned())]);
-}
-
-#[test]
-fn a_blank_line_cuts_a_comment_off_its_key() {
-    let found = located("[env]\n# Why.\n\nA = \"1\"\n");
-    assert_eq!(found, [(4, "A has no comment block above it".to_owned())]);
-}
-
-#[test]
 fn a_value_that_is_not_a_plain_quoted_string_is_located() {
     let refused = [
         "[env]\n# Why.\nA = 2\n",
@@ -90,20 +60,6 @@ fn a_value_that_is_not_a_plain_quoted_string_is_located() {
             "{text:?}"
         );
     }
-}
-
-#[test]
-fn a_duplicate_key_is_located() {
-    // Across tables: valid TOML, and exactly what seeding's file-wide
-    // presence check trips over.
-    let found = located("[other]\n# Why.\nA = \"1\"\n\n[env]\n# Why.\nA = \"2\"\n");
-    assert_eq!(
-        found,
-        [
-            (3, "A is assigned outside [env]".to_owned()),
-            (7, "A is assigned again; it is already on line 3".to_owned()),
-        ]
-    );
 }
 
 #[test]
@@ -354,18 +310,6 @@ fn a_template_with_no_env_table_is_located() {
 }
 
 #[test]
-fn a_header_shaped_wrong_is_not_also_reported_as_an_absent_table() {
-    let found = located("[env] # the table\n# How long to wait.\nWAIT = \"900\"\n");
-    assert_eq!(
-        found,
-        [(
-            1,
-            "this is not a table header the settings loaders read".to_owned()
-        )]
-    );
-}
-
-#[test]
 fn an_independent_toml_error_is_reported_beside_the_scan_finding() {
     // The value on line 3 is a shape the loaders refuse; line 5 is a
     // separate syntax error the scan reads past. Fixing one and coming
@@ -380,44 +324,100 @@ fn an_independent_toml_error_is_reported_beside_the_scan_finding() {
     );
 }
 
+/// One row per template defect the scan locates, and the whole finding
+/// list it reports: every finding's line and problem, in order, so a row
+/// pins both that the defect was found and that nothing else was said. A
+/// defect the parser also sees is reported once, by the scan, which names
+/// the key where the parser would only say "duplicate key": a key
+/// assigned again, a second `[env]` header, a value that is not a
+/// readable string, and a header shaped wrong, which is not also reported
+/// as an absent table. An assignment outside `[env]` and a duplicate
+/// across tables (valid TOML, and exactly what seeding's file-wide
+/// presence check trips over) are each located. A key needs a comment
+/// block above it, and a blank line cuts a comment off its key. Both
+/// defects on one line are both reported: being told about one, fixing
+/// it, and only then hearing about the other is the round trip every
+/// both-defects rule here exists to prevent, and deleting the first
+/// `WAIT` to be told the second was never a readable value is the same
+/// trip.
 #[test]
-fn one_defect_the_parser_also_sees_is_reported_once() {
-    // Every shape where the scan and the parser land on the same line: the
-    // scan names the key, the parser would only say "duplicate key".
-    for text in [
-        "[env]\n# Why.\nWAIT = \"900\"\n# Again.\nWAIT = \"600\"\n",
-        "[env]\n# Why.\nA = \"1\"\n\n[env]\n# Why.\nB = \"2\"\n",
-        "[env]\n# A path.\nWAIT = \"base\".tsv\n",
-        "[env][env]\n# Why.\nWAIT = \"900\"\n",
-    ] {
-        let found = located(text);
-        assert_eq!(found.len(), 1, "{text:?} -> {found:?}");
-        assert!(
-            !found[0].1.starts_with("this is not valid TOML:"),
-            "{text:?} -> {found:?}"
-        );
+fn every_template_defect_is_located_with_nothing_else_said() {
+    let not_a_string = |key: &str| {
+        format!("{key}'s default is not a one-line double-quoted string free of \" and \\")
+    };
+    let rows: [(&str, Vec<(u32, String)>); 11] = [
+        (
+            "# Why.\nDEPTH = \"2\"\n\n[env]\n# Why.\nOTHER = \"1\"\n",
+            vec![(2, "DEPTH is assigned outside [env]".to_owned())],
+        ),
+        (
+            "[env]\n# Why.\nA = \"1\"\n\n[env]\n# Why.\nB = \"2\"\n",
+            vec![(
+                5,
+                "a second [env] header; the first is on line 1".to_owned(),
+            )],
+        ),
+        (
+            "[env]\n# Why.\nA = \"1\"\n\nB = \"2\"\n",
+            vec![(5, "B has no comment block above it".to_owned())],
+        ),
+        (
+            "[env]\n# Why.\n\nA = \"1\"\n",
+            vec![(4, "A has no comment block above it".to_owned())],
+        ),
+        (
+            "[other]\n# Why.\nA = \"1\"\n\n[env]\n# Why.\nA = \"2\"\n",
+            vec![
+                (3, "A is assigned outside [env]".to_owned()),
+                (7, "A is assigned again; it is already on line 3".to_owned()),
+            ],
+        ),
+        (
+            "[env] # the table\n# How long to wait.\nWAIT = \"900\"\n",
+            vec![(
+                1,
+                "this is not a table header the settings loaders read".to_owned(),
+            )],
+        ),
+        (
+            "[env][env]\n# Why.\nWAIT = \"900\"\n",
+            vec![(
+                1,
+                "this is not a table header the settings loaders read".to_owned(),
+            )],
+        ),
+        (
+            "[env]\n# Why.\nWAIT = \"900\"\n# Again.\nWAIT = \"600\"\n",
+            vec![(
+                5,
+                "WAIT is assigned again; it is already on line 3".to_owned(),
+            )],
+        ),
+        (
+            "[env]\n# A path.\nWAIT = \"base\".tsv\n",
+            vec![(3, not_a_string("WAIT"))],
+        ),
+        (
+            "[env]\n# Why.\nWAIT = \"900\"\n# Again.\nWAIT = 900\n",
+            vec![
+                (
+                    5,
+                    "WAIT is assigned again; it is already on line 3".to_owned(),
+                ),
+                (5, not_a_string("WAIT")),
+            ],
+        ),
+        (
+            "[env]\n# Why.\nA = \"1\"\nB = 2\n",
+            vec![
+                (4, "B has no comment block above it".to_owned()),
+                (4, not_a_string("B")),
+            ],
+        ),
+    ];
+    for (text, findings) in rows {
+        assert_eq!(located(text), findings, "{text:?}");
     }
-}
-
-#[test]
-fn a_duplicate_does_not_hide_the_rest_of_its_own_line() {
-    // Deleting the first WAIT and re-running to be told the second was
-    // never a readable value is a round trip the author should not make.
-    let found = located("[env]\n# Why.\nWAIT = \"900\"\n# Again.\nWAIT = 900\n");
-    assert_eq!(
-        found,
-        [
-            (
-                5,
-                "WAIT is assigned again; it is already on line 3".to_owned()
-            ),
-            (
-                5,
-                "WAIT's default is not a one-line double-quoted string free of \" and \\"
-                    .to_owned()
-            ),
-        ]
-    );
 }
 
 #[test]
@@ -427,24 +427,6 @@ fn a_duplicate_that_is_otherwise_fine_is_one_finding_and_no_row() {
     // The first assignment is the row; the second is a line to delete.
     assert_eq!(read.entries.len(), 1);
     assert_eq!(read.entries[0].value, "900");
-}
-
-#[test]
-fn one_assignment_wrong_two_ways_is_two_findings() {
-    // No comment block AND a value the loaders refuse. Being told about
-    // one, fixing it, and only then hearing about the other is the round
-    // trip every both-defects rule here exists to prevent.
-    let found = located("[env]\n# Why.\nA = \"1\"\nB = 2\n");
-    assert_eq!(
-        found,
-        [
-            (4, "B has no comment block above it".to_owned()),
-            (
-                4,
-                "B's default is not a one-line double-quoted string free of \" and \\".to_owned()
-            ),
-        ]
-    );
 }
 
 #[test]

--- a/crates/core/src/settings_toml/tests.rs
+++ b/crates/core/src/settings_toml/tests.rs
@@ -61,34 +61,6 @@ fn nothing_inside_a_multiline_value_is_structure() {
     }
 }
 
-/// A multiline that opens and closes on one line never carries.
-#[test]
-fn a_multiline_closed_on_its_own_line_leaves_the_next_line_alone() {
-    assert_eq!(
-        keys("A = \"\"\"one line\"\"\"\nMODE = \"real\"\n"),
-        vec!["A".to_owned(), "MODE".to_owned()]
-    );
-    // Three to five quotes end it: the extras are content.
-    assert_eq!(
-        keys("A = \"\"\"say \"\"\"\"\"\nMODE = \"real\"\n"),
-        vec!["A".to_owned(), "MODE".to_owned()]
-    );
-}
-
-/// A backslash escapes the delimiter in a basic string and does not in a
-/// literal one, so the two close in different places.
-#[test]
-fn an_escaped_delimiter_does_not_close_a_basic_string() {
-    assert_eq!(
-        keys("A = \"\"\"\n\\\"\"\"\n\"\"\"\nMODE = \"real\"\n"),
-        vec!["A".to_owned(), "MODE".to_owned()]
-    );
-    assert_eq!(
-        keys("A = '''\n\\'''\nMODE = \"real\"\n"),
-        vec!["A".to_owned(), "MODE".to_owned()]
-    );
-}
-
 /// TOML reads all three spellings as one key. Seeding beside any of them
 /// would put the key in the file twice; only the bare one is a name a
 /// shell exports, and both facts travel together.
@@ -197,17 +169,6 @@ fn a_span_covers_the_value_and_only_where_one_is_readable() {
     }
 }
 
-/// An unterminated single-line string ends with its line rather than
-/// swallowing the rest of the file — which is also what the grep-shaped
-/// shell loaders do with one.
-#[test]
-fn an_unterminated_single_line_string_does_not_carry() {
-    assert_eq!(
-        keys("A = \"oops\nMODE = \"real\"\n"),
-        vec!["A".to_owned(), "MODE".to_owned()]
-    );
-}
-
 /// Rows carry their own bytes back: `raw` re-emits the line terminator and
 /// nothing else, which is what every byte-faithful splice re-emits.
 #[test]
@@ -311,61 +272,79 @@ fn an_array_carries_across_lines_and_nests() {
     assert_eq!(keys(text), vec!["LIST".to_owned(), "MODE".to_owned()]);
 }
 
-/// A header's own brackets balance, so the line after one is structure
-/// again — for a plain table and for an array of tables alike.
+/// One row per line shape that leaves nothing open, so the `MODE`
+/// assignment below it reads as itself: the keys the text declares, and
+/// where a row is about the line's own kind, that kind at its index. A
+/// multiline that opens and closes on one line never carries, and three
+/// to five quotes end it with the extras as content. A backslash escapes
+/// the delimiter in a basic string and does not in a literal one, so the
+/// two close in different places. An unterminated single-line string ends
+/// with its line rather than swallowing the rest of the file — which is
+/// also what the grep-shaped shell loaders do with one. A header's own
+/// brackets balance, for a plain table and an array of tables alike. An
+/// inline table that closes on its own line leaves nothing open, and what
+/// it held reaches no decision: the assignment's `=` is the first one
+/// outside a string, and only a line-leading `[` is a table. Every scalar
+/// is one token with nothing structural in it. A stray `]` cannot take
+/// the depth below zero: an unbalanced file is not TOML, and underflowing
+/// would read everything after it as one value.
 #[test]
-fn a_table_header_leaves_nothing_open() {
-    for header in ["[env]", "[a.b]", "[[items]]", "[env] # note"] {
-        let text = format!("{header}\nMODE = \"real\"\n");
-        assert_eq!(kinds(&text)[0], Line::Table, "{header}");
-        assert_eq!(keys(&text), vec!["MODE".to_owned()], "{header}");
-    }
-}
-
-/// An inline table that closes on its own line leaves nothing open, so the
-/// line below it is structure again. What it held reaches no decision: the
-/// assignment's `=` is the first one outside a string, and only a
-/// line-leading `[` is a table.
-#[test]
-fn a_closed_inline_table_does_not_reach_the_line_below_it() {
-    let text = "[env]\nA = { b = [1], c = \"x\" }\nMODE = \"real\"\n";
-    assert_eq!(keys(text), vec!["A".to_owned(), "MODE".to_owned()]);
-    assert_eq!(
-        kinds(text)[2],
-        Line::Assignment {
-            key: "MODE ",
-            value: " \"real\"",
-            value_at: 6,
-        }
+fn a_line_that_leaves_nothing_open_lets_the_next_line_read_as_itself() {
+    let a_mode: &[&str] = &["A", "MODE"];
+    let mode: &[&str] = &["MODE"];
+    type Row = (
+        &'static str,
+        &'static [&'static str],
+        Option<(usize, Line<'static>)>,
     );
-}
-
-/// Every scalar is one token with nothing structural in it, so a line
-/// holding one leaves nothing open and the next line reads as itself.
-#[test]
-fn a_scalar_leaves_nothing_open() {
-    for scalar in [
-        "1",
-        "-0.5",
-        "true",
-        "1979-05-27T07:32:00Z",
-        "07:32:00",
-        "0xdead_beef",
-    ] {
-        let text = format!("[env]\nA = {scalar}\nMODE = \"real\"\n");
-        assert_eq!(
-            keys(&text),
-            vec!["A".to_owned(), "MODE".to_owned()],
-            "{scalar}"
-        );
+    let rows: [Row; 17] = [
+        ("A = \"\"\"one line\"\"\"\nMODE = \"real\"\n", a_mode, None),
+        ("A = \"\"\"say \"\"\"\"\"\nMODE = \"real\"\n", a_mode, None),
+        (
+            "A = \"\"\"\n\\\"\"\"\n\"\"\"\nMODE = \"real\"\n",
+            a_mode,
+            None,
+        ),
+        ("A = '''\n\\'''\nMODE = \"real\"\n", a_mode, None),
+        ("A = \"oops\nMODE = \"real\"\n", a_mode, None),
+        ("[env]\nMODE = \"real\"\n", mode, Some((0, Line::Table))),
+        ("[a.b]\nMODE = \"real\"\n", mode, Some((0, Line::Table))),
+        ("[[items]]\nMODE = \"real\"\n", mode, Some((0, Line::Table))),
+        (
+            "[env] # note\nMODE = \"real\"\n",
+            mode,
+            Some((0, Line::Table)),
+        ),
+        (
+            "[env]\nA = { b = [1], c = \"x\" }\nMODE = \"real\"\n",
+            a_mode,
+            Some((
+                2,
+                Line::Assignment {
+                    key: "MODE ",
+                    value: " \"real\"",
+                    value_at: 6,
+                },
+            )),
+        ),
+        ("[env]\nA = 1\nMODE = \"real\"\n", a_mode, None),
+        ("[env]\nA = -0.5\nMODE = \"real\"\n", a_mode, None),
+        ("[env]\nA = true\nMODE = \"real\"\n", a_mode, None),
+        (
+            "[env]\nA = 1979-05-27T07:32:00Z\nMODE = \"real\"\n",
+            a_mode,
+            None,
+        ),
+        ("[env]\nA = 07:32:00\nMODE = \"real\"\n", a_mode, None),
+        ("[env]\nA = 0xdead_beef\nMODE = \"real\"\n", a_mode, None),
+        ("]\n[env]\nMODE = \"real\"\n", mode, None),
+    ];
+    for (text, expected, kind) in rows {
+        assert_eq!(keys(text), expected, "{text:?}");
+        if let Some((at, kind)) = kind {
+            assert_eq!(kinds(text)[at], kind, "{text:?}");
+        }
     }
-}
-
-/// A stray `]` cannot take the depth below zero: an unbalanced file is not
-/// TOML, and underflowing would read everything after it as one value.
-#[test]
-fn an_unbalanced_bracket_does_not_swallow_the_file() {
-    assert_eq!(keys("]\n[env]\nMODE = \"real\"\n"), vec!["MODE".to_owned()]);
 }
 
 /// One header parse for everyone, carrying the facts each caller needs:


### PR DESCRIPTION
The second of three `crates/core/src` PRs of the tests audit (the classification pass covered all 160 in-crate test modules; 44 carry findings). This one is the text-shape families: ten modules whose cases each fed one spelling of a header, a TOML text, a markdown body, a manifest or a YAML document to one reader and asserted its answer, written as one `#[test]` per spelling, or pinned a finding's prose through a join of its fields where the field itself discriminates. Test code only; no production Rust changes; `[no-changelog]`.

## Folded or deleted cases, with the surviving row

| Former cases | Surviving table or case |
|---|---|
| `scan/metadata/tests.rs`: `reads_a_description_and_an_inline_tag_list` (its tag half), `reads_a_block_tag_list`, `an_unbracketed_inline_list_is_still_a_list`, `a_trailing_comment_is_not_part_of_a_tag` (two bodies), `a_blank_line_or_comment_does_not_end_a_block_list`, `a_block_list_ends_at_the_next_key`, `an_empty_tag_list_is_no_tags_and_no_complaint` (two bodies), `a_word_that_is_not_a_tag_is_kept_for_the_warning`, `a_repeated_tag_is_still_one_tag`, `casing_and_padding_are_the_authors_business`, `tags_come_back_in_vocabulary_order_however_they_were_written`, `a_repeated_bad_word_is_reported_once` (a `len() == 1` bit) | `a_tag_list_decodes_to_its_tags_and_keeps_the_rest_for_the_warning`, 14 rows of (body, tags, unknown words); `unknown_tags` asserted on every row (five former cases asserted it). The description half is `reads_a_plain_description` |
| `scan/metadata/tests.rs`: `a_near_miss_is_told_what_it_nearly_was`, `a_word_nothing_like_a_tag_gets_the_vocabulary`, `several_bad_words_are_counted_rather_than_all_listed`, `nothing_unknown_means_nothing_to_warn_about` | `the_unknown_tag_warning_names_the_nearest_tag_or_the_vocabulary`, 4 rows: two whole warnings, one prefix up to the vocabulary (which is `tags::ALL_TAGS`'s to list; the former "review, testing" substring is dropped), one `None` |
| `render/vocab/tests.rs`: `code_links_and_skill_paths_keep_every_byte`, `an_unclosed_fence_protects_the_rest_of_the_body`, the list-item half of `an_indented_fence_is_still_a_fence`, `a_span_that_closes_on_a_later_line_quotes_both_lines`, `a_reference_at_column_zero_of_a_continuation_line_is_inside_the_span` (two bodies), `a_line_a_span_crosses_whole_is_covered_end_to_end`, `a_sample_inside_a_raw_html_block_keeps_every_byte` (three), `prose_tight_under_a_wrapper_is_left_in_claudes_words` (three), `an_indented_code_block_is_a_code_block`, `prose_about_tools_is_never_mistaken_for_a_reference` (four) | `a_sample_or_prose_about_tools_keeps_every_byte_on_every_harness`, 18 bodies, each over Codex, OpenCode and Cursor (three former cases asserted one harness; all pass on three). The top-level four-space fence half is `a_top_level_indented_fence_opens_nothing` |
| `render/validate/tests.rs`: `codex_agents_must_parse_as_toml_and_carry_their_keys`, `an_unknown_codex_sandbox_is_refused_and_the_fix_lists_the_real_ones`, `opencode_agents_must_declare_a_mode_and_permissions_it_can_read`, `a_bare_opencode_model_is_refused_with_the_shape_named`, `claude_agents_must_answer_to_the_name_they_install_under`, `cursor_rule_keys_outside_the_three_are_folklore`, `opencode_names_must_be_lowercase_kebab_and_the_fix_spells_one` | `a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong`, 13 rows: one message fragment per breakage finding in order, one per advisory finding, and the computed values a remediation must carry (`danger-full-access`, `allow, ask, deny`, `` `rustacean` ``, `` `my-skill` ``); remedy wording is not pinned. `spoken()` is diagnostic-only now; the other cases read messages through `said()` and fixes through `fixed()` |
| `settings_toml/tests.rs`: `a_multiline_closed_on_its_own_line_leaves_the_next_line_alone` (two), `an_escaped_delimiter_does_not_close_a_basic_string` (two), `an_unterminated_single_line_string_does_not_carry`, `a_table_header_leaves_nothing_open` (four), `a_closed_inline_table_does_not_reach_the_line_below_it`, `a_scalar_leaves_nothing_open` (six), `an_unbalanced_bracket_does_not_swallow_the_file` | `a_line_that_leaves_nothing_open_lets_the_next_line_read_as_itself`, 17 rows of (text, keys, optional (index, kind)) |
| `settings_template/tests.rs`: `an_assignment_outside_env_is_located`, `a_second_env_header_is_located`, `a_key_with_no_comment_block_is_located`, `a_blank_line_cuts_a_comment_off_its_key`, `a_duplicate_key_is_located`, `a_header_shaped_wrong_is_not_also_reported_as_an_absent_table`, `one_defect_the_parser_also_sees_is_reported_once` (four inputs), `a_duplicate_does_not_hide_the_rest_of_its_own_line`, `one_assignment_wrong_two_ways_is_two_findings` | `every_template_defect_is_located_with_nothing_else_said`, 11 rows pinning the whole finding list; the parser-also-sees inputs pin their whole findings rather than `len() == 1` and a negated prefix, and its second input, the exact text of `a_second_env_header_is_located`, is dropped as the subset it was |
| `settings_seed/tests.rs`: `a_value_spanning_lines_is_seeded_whole` (three), `an_inline_table_that_closes_seeds_like_any_other_value` (four), `an_inline_table_spanning_lines_is_seeded_whole` (four) | `a_value_that_spans_lines_or_holds_structure_is_seeded_whole`, 11 rows, every row with a `DEPTH` after the value and `seed_notes` empty (two former cases had no second key; one asserted only `unterminated_notes`) |
| `settings_seed/tests.rs`: `a_value_nothing_closes_is_refused_by_name`, `a_one_line_value_left_unterminated_is_refused_by_name` (three), `an_inline_table_left_open_is_refused_by_name` (four), `the_refusal_names_the_key_and_no_particular_delimiter` (four, two of them the same texts as rows above) | `a_value_nothing_closes_is_refused_by_name_and_seeds_nothing`, 10 rows; the note is pinned by its head up to "nothing was written for this key" (the remedy clause after it is not), which implies the former delimiter-neutral negatives; the `added` keys of the merge are a column (the open inline table swallows the `DEPTH` below it, so that row's merge writes nothing). The second-skill-ships-it-whole control is `a_key_another_skill_ships_whole_is_seeded_and_nothing_is_reported`. `a_broken_declaration_before_a_valid_one_never_becomes_the_owner`'s negated fragment is `seed_notes(..) == []`; `a_key_under_an_inline_table_belongs_to_whichever_owns_its_line`'s `get("a").is_some()` is `== Integer(1)` |
| `settings_seed/tests/notes.rs`: `one_note_groups_every_owner_and_every_distinct_default`, `packages_agreeing_on_a_shared_key_say_nothing`, `a_key_only_one_package_ships_says_nothing`, `the_note_names_the_owner_whose_value_merge_actually_seeds` (note half), `a_default_no_decoder_reads_still_names_its_owner`, `a_trailing_comment_is_not_a_different_default`, `catalog_text_reaches_a_note_escaped`, `two_different_multiline_defaults_are_not_one_default` (two fragment pins and an agreeing control), `defaults_the_display_collapses_alike_are_still_a_disagreement` (two fragment pins and an agreeing control) | `a_shared_key_gets_one_conflict_note_or_none`, 11 rows, every note whole through one `disagreement(key, defaults, written)` builder. The merge half is `merge_writes_the_value_of_the_owner_the_note_names`; the display/key half is `the_display_collapses_what_the_default_key_keeps_apart` |
| `manifest/validate/tests.rs`: `only_the_current_schema_validates` (four), `an_override_a_harness_never_renders_is_a_finding`, `a_clean_manifest_validates_empty`, `only_the_kinds_a_catalog_offers_may_carry_a_plugin_segment` (two), `a_source_revision_is_a_string_on_a_repo_and_stray_keys_are_findings` (two), `a_custom_hook_event_must_be_one_a_harness_fires`, `custom_hook_identity_and_parity_fields_are_checked`, `a_clean_named_custom_hook_validates_empty`, `retired_safety_tables_are_stray_keys_on_a_current_file` | `every_manifest_defect_is_located_with_nothing_else_said`, 14 rows pinning the whole `(location, problem)` list in order (the former `!locations.contains` negatives are implied). The `fix` fragments the former cases pinned (`without a `/``, `rev`, `remove it`) are dropped: a remedy's wording is authoring guidance, and `every_finding_carries_a_fix` covers presence. Fixture fix: the two custom-hook cases used `schema = 1`, which added a `schema` finding their location filters never saw; the rows use `schema = 6` |
| `manifest/fold/tests.rs`: `a_re_sorted_array_of_values_keeps_each_comment_on_its_own_value`, `a_dropped_value_takes_its_own_comment_and_no_other`, `a_gained_value_takes_the_shape_the_list_is_in` (three), `a_gained_value_is_placed_against_the_list_it_lands_in` (five), `emptying_a_list_keeps_what_was_written_about_the_list` (five), the deny-list half of `removing_the_last_entry_leaves_no_separator_behind` | `a_value_list_folds_each_edit_into_the_shape_it_was_written_in`, 16 rows of (list, edit, list); `DENIED` is the `ANNOTATED` list literal read through `deny()`. The `NOTED`/`THREE` hook-edit cases stay: each is already one op with one document, and its doc comment is the claim |
| `frontmatter/tests.rs`: `strict_keys_get_no_salvage` (three `is_err()` bits), `adversarial_yaml_is_refused` (seven fragment pins) | `a_yaml_the_parsers_refuse_is_named_by_what_it_did`, 10 rows: whole messages where the parser composes them, prefixes where the YAML library's own words follow. The two `is_err()` bits of `splits_on_exact_terminator_lines_only` pin their messages |

`frontmatter` and `render/validate`'s errors and findings carry no code (`Result<_, String>`; `Finding { message, remediation }`); a typed discriminant there is a production change and out of scope, so the rows pin the message.

## Mutation

One must-fail mutant per surviving table, twelve tables, all killed (`mutants-shapes.txt` in the lane scratchpad; `mutate-shapes.py` mutates production in place and restores it from `HEAD`): a trailing comment read as part of the tag; one too many "others"; code rewritten like prose; a name one past the limit loading; a stray bracket underflowing the depth; a missing comment block passing; a value stopping at its first line; an open value read as complete; defaults grouped on the display; the override check inverted; a gained value losing the list's indent; YAML nesting four times deeper before refusing.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, all applied. Blockers: the `manifest/validate` table had dropped fix-presence for five finding kinds `every_finding_carries_a_fix` never reaches (every row now asserts each finding carries a fix, and the doc comment says so); a doc comment in `notes.rs` still named the deleted `catalog_text_reaches_a_note_escaped`. Suggestions taken: the Cursor row no longer pins the word `folklore` as a remedy value; the three `frontmatter` rows whose message is the YAML library's own prose pin only the key the parser prefixes, so a dependency bump cannot fail them. Left as is: the `vocab` and `seed` rows carry two asserts each (bytes and warnings; text and parse-back), one claim per row. The reviewer's eleven further mutants, one per row group the recorded battery reaches only through an earlier row, all killed at the intended row; the whole-list pins were checked against the producers (a `BTreeMap` walk, a line-by-line scan, a keyed map with declaration order inside), all deterministic.

## Checks

- `cargo test -p kendex-core --lib`: green but for the one environment case (`discover::tests::project_root_walks_up_and_lock_file_wins_at_home`, which fails on main here because the owner's home carries a `.agents` directory); `cargo clippy -p kendex-core --all-targets -- -D warnings` clean; `cargo fmt -p kendex-core -- --check` clean.
- `tools/guard --full`: exit 0 on 86c7651d5 (TMPDIR=/var/tmp/ken-c), before the four one-line reviewer fixes above.

KEN-1241

https://claude.ai/code/session_01NQ3TkQ6WiREfzEEH4nHGmc
