### PR TITLE
fix(KEN-1274): attention rows name what is wrong and land on it

### DIFF
--- a/changelog.d/changed/1274-cli.md
+++ b/changelog.d/changed/1274-cli.md
@@ -1,0 +1,1 @@
+- `kendex updates` lists an install edited on disk, marked `[edited on disk …]`, even with nothing newer, so it agrees with the app's Home about the same scope.

--- a/changelog.d/fixed/1274-once-per-file.md
+++ b/changelog.d/fixed/1274-once-per-file.md
@@ -1,0 +1,1 @@
+- A config file several surfaces read is warned about once, so Home, Problems and the footer count one broken file as one.

--- a/changelog.d/fixed/1274.md
+++ b/changelog.d/fixed/1274.md
@@ -1,0 +1,1 @@
+- Home's Needs attention rows say what is wrong and what to do: the edited row names each package and opens the Library narrowed to them; an unreadable config file gets a row and a Problems card.

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -54,7 +54,7 @@ pub fn run(env: &Env, filter: ScopeFilter, harness: Option<String>) -> CliResult
         }
     }
     for warning in &result.warnings {
-        say(&format!("warning: {}", warning));
+        say(&format!("warning: {warning}"));
     }
     Ok(())
 }

--- a/crates/cli/src/commands/updates_cmd.rs
+++ b/crates/cli/src/commands/updates_cmd.rs
@@ -88,9 +88,16 @@ pub fn run(env: &Env, args: UpdatesArgs) -> CliResult {
     let report = kendex_core::package::updates::updates(env, &scope)?;
     let mut shown = 0;
     for row in &report.rows {
-        // Mixed installs and packages gone upstream are standing facts worth
-        // a line even when no newer version exists to move to.
-        if !row.update_available && !row.mixed && !row.removed_upstream {
+        // Mixed installs, packages gone upstream and installs edited on
+        // disk are standing facts worth a line even when no newer version
+        // exists to move to: the edit is what stands between the package
+        // and its next update, and Home counts it, so the listing must
+        // say it too.
+        if !row.update_available
+            && !row.mixed
+            && !row.removed_upstream
+            && !row.blocked_by_local_edit
+        {
             continue;
         }
         shown += 1;
@@ -106,6 +113,9 @@ pub fn run(env: &Env, args: UpdatesArgs) -> CliResult {
         }
         if row.removed_upstream {
             notes.push("no longer in its source");
+        }
+        if row.blocked_by_local_edit {
+            notes.push("edited on disk — keep it as a fork, or refresh with edits discarded");
         }
         let notes = if notes.is_empty() {
             String::new()

--- a/crates/cli/tests/remote_e2e.rs
+++ b/crates/cli/tests/remote_e2e.rs
@@ -414,3 +414,40 @@ fn updates_refuses_a_whole_place_apply_beside_a_named_package() {
         "the refused run applied something: {printed}"
     );
 }
+
+/// An install edited on disk is a standing fact the listing says, with or
+/// without a newer version behind it: Home counts every edited package,
+/// and a listing that stayed silent about one with nothing newer would
+/// disagree with it about the same scope.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_edited_install_is_listed_even_with_nothing_newer() {
+    let tmp = fixture();
+    let home = tmp.path();
+    let proj = home.join("proj");
+    fs::create_dir_all(&proj).unwrap();
+    let output = kendex(home, &proj, &["add", "--skill", "gh", "-y"]);
+    assert!(output.status.success(), "{}", said(&output));
+
+    let clean = said(&kendex(home, &proj, &["updates"]));
+    assert!(
+        clean.contains("everything is on its latest version"),
+        "{clean}"
+    );
+
+    fs::write(
+        proj.join(".agents/skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: github flows\n---\nMy edit.\n",
+    )
+    .unwrap();
+    let edited = said(&kendex(home, &proj, &["updates"]));
+    let line = edited
+        .lines()
+        .find(|line| line.contains("skill gh"))
+        .unwrap_or_else(|| panic!("no gh line in {edited}"));
+    assert!(line.contains("[edited on disk"), "{line}");
+    assert!(
+        !edited.contains("everything is on its latest version"),
+        "{edited}"
+    );
+}

--- a/crates/core/src/ownership.rs
+++ b/crates/core/src/ownership.rs
@@ -161,7 +161,9 @@ pub fn find(
         None => {
             scanned =
                 crate::scan::scan_scopes(env, &settings.harness_roots, std::slice::from_ref(scope));
-            records.warnings.extend(scanned.warnings.iter().cloned());
+            records
+                .warnings
+                .extend(scanned.warnings.iter().map(ToString::to_string));
             scanned.items.as_slice()
         }
     };

--- a/crates/core/src/scan/antigravity.rs
+++ b/crates/core/src/scan/antigravity.rs
@@ -13,7 +13,7 @@ use super::readers::read_json;
 /// hooks guide, <https://antigravity.google/docs/hooks>). A name switched off
 /// by `enabled: false` is read with every handler off — a hook that will not
 /// run must not read as one that will.
-pub fn read(path: &Path) -> Result<Vec<RawEntry>, String> {
+pub fn read(path: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let value = read_json(path)?;
     let Some(named) = value.as_object() else {
         return Ok(Vec::new());

--- a/crates/core/src/scan/copilot.rs
+++ b/crates/core/src/scan/copilot.rs
@@ -18,7 +18,7 @@ use crate::hook::command_stem;
 /// `disableAllHooks` switches every entry in the file off, and that is what
 /// the scan reports — a hook that will not run must not read as one that
 /// will.
-pub fn read(path: &Path) -> Result<Vec<RawEntry>, String> {
+pub fn read(path: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let value = read_json(path)?;
     let Some(events) = value.get("hooks").and_then(Value::as_object) else {
         return Ok(Vec::new());
@@ -94,7 +94,7 @@ fn action(entry: &Value) -> Option<String> {
 /// bool}`, a clean boolean flip at either scope
 /// ([CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference),
 /// matrix §2).
-pub fn plugins(path: &Path) -> Result<Vec<RawEntry>, String> {
+pub fn plugins(path: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let value = read_json(path)?;
     let Some(plugins) = value.get("enabledPlugins").and_then(Value::as_object) else {
         return Ok(Vec::new());

--- a/crates/core/src/scan/files.rs
+++ b/crates/core/src/scan/files.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use super::metadata;
-use super::{ScanProblem, ScanWarning, SurfaceOwner};
+use super::{ScanProblem, ScanWarning, SurfaceOwner, push_warning};
 use crate::model::FileState;
 
 pub struct FoundFile {
@@ -62,12 +62,15 @@ fn warn_unreadable(
     warnings: &mut Vec<ScanWarning>,
 ) {
     if error.kind() != std::io::ErrorKind::NotFound {
-        warnings.push(owner.warning(
-            dir.to_path_buf(),
-            ScanProblem::Unreadable {
-                message: error.to_string(),
-            },
-        ));
+        push_warning(
+            warnings,
+            owner.warning(
+                dir.to_path_buf(),
+                ScanProblem::Unreadable {
+                    message: error.to_string(),
+                },
+            ),
+        );
     }
 }
 

--- a/crates/core/src/scan/files.rs
+++ b/crates/core/src/scan/files.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use super::metadata;
+use super::{ScanProblem, ScanWarning, SurfaceOwner};
 use crate::model::FileState;
 
 pub struct FoundFile {
@@ -54,9 +55,19 @@ pub fn state_of(path: &Path) -> FileState {
 /// A directory that exists but cannot be listed is truth the scan could not
 /// reach — reported, never silently read as empty. A missing directory is
 /// just a surface nothing installed to.
-fn warn_unreadable(dir: &Path, error: &std::io::Error, warnings: &mut Vec<String>) {
+fn warn_unreadable(
+    dir: &Path,
+    error: &std::io::Error,
+    owner: SurfaceOwner,
+    warnings: &mut Vec<ScanWarning>,
+) {
     if error.kind() != std::io::ErrorKind::NotFound {
-        warnings.push(format!("{}: unreadable — {error}", dir.display()));
+        warnings.push(owner.warning(
+            dir.to_path_buf(),
+            ScanProblem::Unreadable {
+                message: error.to_string(),
+            },
+        ));
     }
 }
 
@@ -66,10 +77,11 @@ pub fn scan_file_dir(
     dir: &Path,
     exts: &[&str],
     prefixes: &[&str],
-    warnings: &mut Vec<String>,
+    owner: SurfaceOwner,
+    warnings: &mut Vec<ScanWarning>,
 ) -> Vec<FoundFile> {
     let mut found = Vec::new();
-    collect_files(dir, exts, prefixes, None, &mut found, warnings);
+    collect_files(dir, exts, prefixes, None, owner, &mut found, warnings);
     found.sort_by(|a, b| a.name.cmp(&b.name));
     found
 }
@@ -79,13 +91,14 @@ fn collect_files(
     exts: &[&str],
     prefixes: &[&str],
     namespace: Option<&str>,
+    owner: SurfaceOwner,
     found: &mut Vec<FoundFile>,
-    warnings: &mut Vec<String>,
+    warnings: &mut Vec<ScanWarning>,
 ) {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(error) => {
-            warn_unreadable(dir, &error, warnings);
+            warn_unreadable(dir, &error, owner, warnings);
             return;
         }
     };
@@ -95,7 +108,15 @@ fn collect_files(
             continue;
         };
         if path.is_dir() && namespace.is_none() {
-            collect_files(&path, exts, prefixes, Some(file_name), found, warnings);
+            collect_files(
+                &path,
+                exts,
+                prefixes,
+                Some(file_name),
+                owner,
+                found,
+                warnings,
+            );
             continue;
         }
         let Some((stem, enabled)) = match_item(file_name, exts) else {
@@ -137,12 +158,17 @@ fn match_item<'a>(file_name: &'a str, exts: &[&str]) -> Option<(&'a str, bool)> 
 }
 
 /// `<dir>/<name>/<marker>` items; `<marker>.disabled` marks a disabled item.
-pub fn scan_subdirs(dir: &Path, marker: &str, warnings: &mut Vec<String>) -> Vec<FoundFile> {
+pub fn scan_subdirs(
+    dir: &Path,
+    marker: &str,
+    owner: SurfaceOwner,
+    warnings: &mut Vec<ScanWarning>,
+) -> Vec<FoundFile> {
     let mut found = Vec::new();
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(error) => {
-            warn_unreadable(dir, &error, warnings);
+            warn_unreadable(dir, &error, owner, warnings);
             return found;
         }
     };
@@ -179,11 +205,16 @@ pub fn scan_subdirs(dir: &Path, marker: &str, warnings: &mut Vec<String>) -> Vec
 /// Every `<dir>/*.<ext>` document, sorted by name. A `.disabled` suffix
 /// takes a file out of the list the same way it does everywhere else: the
 /// harness globs one extension, so the renamed file is not loaded.
-pub fn scan_documents(dir: &Path, ext: &str, warnings: &mut Vec<String>) -> Vec<PathBuf> {
+pub fn scan_documents(
+    dir: &Path,
+    ext: &str,
+    owner: SurfaceOwner,
+    warnings: &mut Vec<ScanWarning>,
+) -> Vec<PathBuf> {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(error) => {
-            warn_unreadable(dir, &error, warnings);
+            warn_unreadable(dir, &error, owner, warnings);
             return Vec::new();
         }
     };
@@ -199,6 +230,12 @@ pub fn scan_documents(dir: &Path, ext: &str, warnings: &mut Vec<String>) -> Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::{HarnessId, ItemKind};
+
+    const OWNER: SurfaceOwner = SurfaceOwner {
+        harness: HarnessId::Claude,
+        kind: ItemKind::Skill,
+    };
 
     #[test]
     fn disabled_suffix_and_namespacing() {
@@ -210,7 +247,7 @@ mod tests {
         fs::write(tmp.path().join("ns/c.md"), "").unwrap();
 
         let mut warnings = Vec::new();
-        let found = scan_file_dir(tmp.path(), &["md"], &[], &mut warnings);
+        let found = scan_file_dir(tmp.path(), &["md"], &[], OWNER, &mut warnings);
         let names: Vec<_> = found.iter().map(|f| (f.name.as_str(), f.enabled)).collect();
         assert_eq!(names, [("a", true), ("b", false), ("ns/c", true)]);
         assert!(found.iter().all(|f| f.modified_at.is_some()));
@@ -232,6 +269,7 @@ mod tests {
             tmp.path(),
             &["md"],
             &["kendex-hook-", "kendex-rule-"],
+            OWNER,
             &mut warnings,
         );
         let names: Vec<_> = found.iter().map(|f| f.name.as_str()).collect();
@@ -243,9 +281,22 @@ mod tests {
     fn missing_directory_is_silent_but_unreadable_is_a_warning() {
         let tmp = tempfile::tempdir().unwrap();
         let mut warnings = Vec::new();
-        assert!(scan_file_dir(&tmp.path().join("absent"), &["md"], &[], &mut warnings).is_empty());
-        assert!(scan_subdirs(&tmp.path().join("absent"), "SKILL.md", &mut warnings).is_empty());
-        assert!(scan_documents(&tmp.path().join("absent"), "json", &mut warnings).is_empty());
+        assert!(
+            scan_file_dir(
+                &tmp.path().join("absent"),
+                &["md"],
+                &[],
+                OWNER,
+                &mut warnings
+            )
+            .is_empty()
+        );
+        assert!(
+            scan_subdirs(&tmp.path().join("absent"), "SKILL.md", OWNER, &mut warnings).is_empty()
+        );
+        assert!(
+            scan_documents(&tmp.path().join("absent"), "json", OWNER, &mut warnings).is_empty()
+        );
         assert!(warnings.is_empty());
 
         #[cfg(unix)]
@@ -254,11 +305,16 @@ mod tests {
             let sealed = tmp.path().join("sealed");
             fs::create_dir(&sealed).unwrap();
             fs::set_permissions(&sealed, fs::Permissions::from_mode(0o000)).unwrap();
-            let found = scan_file_dir(&sealed, &["md"], &[], &mut warnings);
+            let found = scan_file_dir(&sealed, &["md"], &[], OWNER, &mut warnings);
             fs::set_permissions(&sealed, fs::Permissions::from_mode(0o755)).unwrap();
             assert!(found.is_empty());
             assert_eq!(warnings.len(), 1);
-            assert!(warnings[0].contains("unreadable"), "{}", warnings[0]);
+            assert_eq!(warnings[0].path, sealed);
+            assert!(
+                matches!(warnings[0].problem, ScanProblem::Unreadable { .. }),
+                "{}",
+                warnings[0]
+            );
         }
     }
 
@@ -290,7 +346,7 @@ mod tests {
         fs::write(tmp.path().join("off/SKILL.md.disabled"), "").unwrap();
         fs::create_dir(tmp.path().join("junk")).unwrap();
 
-        let found = scan_subdirs(tmp.path(), "SKILL.md", &mut Vec::new());
+        let found = scan_subdirs(tmp.path(), "SKILL.md", OWNER, &mut Vec::new());
         let names: Vec<_> = found.iter().map(|f| (f.name.as_str(), f.enabled)).collect();
         assert_eq!(names, [("off", false), ("real", true)]);
         assert_eq!(found[1].meta.description.as_deref(), Some("x"));

--- a/crates/core/src/scan/hooks.rs
+++ b/crates/core/src/scan/hooks.rs
@@ -66,12 +66,12 @@ impl Registration {
 /// `{"hooks": {"<Event>": [{matcher?, hooks: [{command}]} | {command}]}}` —
 /// claude settings.json and codex/cursor hooks.json share this shape; cursor
 /// omits `matcher` and nests no handler array.
-pub fn read(path: &Path) -> Result<Vec<RawEntry>, String> {
+pub fn read(path: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     Ok(rows(registrations(read_json(path)?)))
 }
 
 /// Every registration in one document, in its parts.
-pub(crate) fn read_registrations(path: &Path) -> Result<Vec<Registration>, String> {
+pub(crate) fn read_registrations(path: &Path) -> Result<Vec<Registration>, super::ScanProblem> {
     Ok(registrations(read_json(path)?))
 }
 

--- a/crates/core/src/scan/mod.rs
+++ b/crates/core/src/scan/mod.rs
@@ -96,6 +96,21 @@ impl std::fmt::Display for ScanWarning {
     }
 }
 
+/// Say a warning once per file. Several surfaces read one file — Claude's
+/// settings.json is a hook surface and a plugin surface, `~/.claude.json`
+/// is the MCP surface of the personal scope and of every project — and a
+/// file that cannot be read fails every one of them the same way. The
+/// first surface to say so names the file; a second saying of the same
+/// path and problem is the same fact, and dropped.
+pub(crate) fn push_warning(warnings: &mut Vec<ScanWarning>, warning: ScanWarning) {
+    let said = warnings
+        .iter()
+        .any(|known| known.path == warning.path && known.problem == warning.problem);
+    if !said {
+        warnings.push(warning);
+    }
+}
+
 /// The tool and kind a surface is scanned for, stamped on every warning
 /// the surface's files raise.
 #[derive(Debug, Clone, Copy)]
@@ -322,17 +337,10 @@ fn warn_unknown_tags(found: &files::FoundFile, owner: SurfaceOwner, result: &mut
     let Some(message) = found.meta.unknown_warning() else {
         return;
     };
-    // One file read through two tools' folders is one mistake, not two: the
-    // paths differ (each tool links to the shared folder its own way) and
-    // the complaint is identical, so it is said once.
-    let warning = owner.warning(found.path.clone(), ScanProblem::UnknownTag { message });
-    let said = result
-        .warnings
-        .iter()
-        .any(|known| known.path == warning.path && known.problem == warning.problem);
-    if !said {
-        result.warnings.push(warning);
-    }
+    push_warning(
+        &mut result.warnings,
+        owner.warning(found.path.clone(), ScanProblem::UnknownTag { message }),
+    );
 }
 
 fn scan_structured_file(
@@ -377,9 +385,10 @@ fn scan_structured_file(
                 });
             }
         }
-        Err(problem) => result
-            .warnings
-            .push(owner.warning(path.to_path_buf(), problem)),
+        Err(problem) => push_warning(
+            &mut result.warnings,
+            owner.warning(path.to_path_buf(), problem),
+        ),
     }
 }
 

--- a/crates/core/src/scan/mod.rs
+++ b/crates/core/src/scan/mod.rs
@@ -5,7 +5,7 @@ use specta::Type;
 
 use crate::env::Env;
 use crate::harness::{HarnessAdapter, Surface, all_adapters};
-use crate::model::{DetectedHarness, FileState, ItemKind, ObservedItem, Scope};
+use crate::model::{DetectedHarness, FileState, HarnessId, ItemKind, ObservedItem, Scope};
 use crate::settings::AppSettings;
 
 pub(crate) mod antigravity;
@@ -27,7 +27,92 @@ pub struct ScanResult {
     /// Registered projects whose directory is gone — flagged, never dropped.
     pub missing_projects: Vec<PathBuf>,
     /// Unreadable or unparsable surfaces; truth the scan could not reach.
-    pub warnings: Vec<String>,
+    pub warnings: Vec<ScanWarning>,
+}
+
+/// One surface the scan could not read as the document it expects, with
+/// the tool and kind the surface belongs to: a reader deciding what to do
+/// about a broken file needs to know whose file it is, and the path alone
+/// says that only to someone who already knows every tool's layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanWarning {
+    pub harness: HarnessId,
+    pub kind: ItemKind,
+    pub path: PathBuf,
+    pub problem: ScanProblem,
+}
+
+/// What kept a surface from being read, by shape rather than by parser
+/// message: an empty file and a file with a stray comma are one parser
+/// error and two different remedies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ScanProblem {
+    /// A document was expected and the file holds nothing: zero bytes,
+    /// whitespace, or comments alone. Another tool leaves such a file
+    /// behind when it creates its config before writing to it.
+    EmptyFile,
+    /// The text is not the format the surface reads; the parser's own
+    /// message says where it stopped.
+    InvalidJson {
+        message: String,
+    },
+    InvalidToml {
+        message: String,
+    },
+    /// A directory or file the scan could not read at all.
+    Unreadable {
+        message: String,
+    },
+    /// A word in a document's tags that names no tag.
+    UnknownTag {
+        message: String,
+    },
+}
+
+impl std::fmt::Display for ScanProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScanProblem::EmptyFile => f.write_str("the file is empty"),
+            ScanProblem::InvalidJson { message } => write!(f, "not valid JSON: {message}"),
+            ScanProblem::InvalidToml { message } => write!(f, "not valid TOML: {message}"),
+            ScanProblem::Unreadable { message } => write!(f, "unreadable — {message}"),
+            ScanProblem::UnknownTag { message } => f.write_str(message),
+        }
+    }
+}
+
+impl std::fmt::Display for ScanWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} {}: {}",
+            self.harness.display_name(),
+            self.kind.name(),
+            self.path.display(),
+            self.problem
+        )
+    }
+}
+
+/// The tool and kind a surface is scanned for, stamped on every warning
+/// the surface's files raise.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SurfaceOwner {
+    pub(crate) harness: HarnessId,
+    pub(crate) kind: ItemKind,
+}
+
+impl SurfaceOwner {
+    pub(crate) fn warning(self, path: PathBuf, problem: ScanProblem) -> ScanWarning {
+        ScanWarning {
+            harness: self.harness,
+            kind: self.kind,
+            path,
+            problem,
+        }
+    }
 }
 
 /// Read-only truth of this machine: every kind, every harness, global scope
@@ -168,14 +253,18 @@ fn scan_surface(
     provenance: &mut provenance::OriginCache,
     result: &mut ScanResult,
 ) {
+    let owner = SurfaceOwner {
+        harness: adapter.id(),
+        kind,
+    };
     match surface {
         Surface::FileDir {
             dir,
             exts,
             prefixes,
         } => {
-            for found in files::scan_file_dir(dir, exts, prefixes, &mut result.warnings) {
-                warn_unknown_tags(&found, result);
+            for found in files::scan_file_dir(dir, exts, prefixes, owner, &mut result.warnings) {
+                warn_unknown_tags(&found, owner, result);
                 result.items.push(ObservedItem {
                     kind,
                     name: found.name,
@@ -193,8 +282,8 @@ fn scan_surface(
             }
         }
         Surface::SubdirPerItem { dir, marker } => {
-            for found in files::scan_subdirs(dir, marker, &mut result.warnings) {
-                warn_unknown_tags(&found, result);
+            for found in files::scan_subdirs(dir, marker, owner, &mut result.warnings) {
+                warn_unknown_tags(&found, owner, result);
                 result.items.push(ObservedItem {
                     kind,
                     name: found.name,
@@ -213,12 +302,12 @@ fn scan_surface(
         }
         Surface::Structured { path, reader } => {
             if path.exists() {
-                scan_structured_file(adapter, kind, &scope, path, reader, env, result);
+                scan_structured_file(adapter, owner, &scope, path, reader, env, result);
             }
         }
         Surface::StructuredDir { dir, ext, reader } => {
-            for path in files::scan_documents(dir, ext, &mut result.warnings) {
-                scan_structured_file(adapter, kind, &scope, &path, reader, env, result);
+            for path in files::scan_documents(dir, ext, owner, &mut result.warnings) {
+                scan_structured_file(adapter, owner, &scope, &path, reader, env, result);
             }
         }
     }
@@ -229,29 +318,33 @@ fn scan_surface(
 // thinking the item is tagged when it is not, so the scan says so and names
 // the vocabulary.
 
-fn warn_unknown_tags(found: &files::FoundFile, result: &mut ScanResult) {
+fn warn_unknown_tags(found: &files::FoundFile, owner: SurfaceOwner, result: &mut ScanResult) {
     let Some(message) = found.meta.unknown_warning() else {
         return;
     };
     // One file read through two tools' folders is one mistake, not two: the
     // paths differ (each tool links to the shared folder its own way) and
     // the complaint is identical, so it is said once.
-    let warning = format!("{}: {message}", found.path.display());
-    if !result.warnings.contains(&warning) {
+    let warning = owner.warning(found.path.clone(), ScanProblem::UnknownTag { message });
+    let said = result
+        .warnings
+        .iter()
+        .any(|known| known.path == warning.path && known.problem == warning.problem);
+    if !said {
         result.warnings.push(warning);
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn scan_structured_file(
     adapter: &dyn HarnessAdapter,
-    kind: ItemKind,
+    owner: SurfaceOwner,
     scope: &Scope,
     path: &std::path::Path,
     reader: &crate::harness::Reader,
     env: &Env,
     result: &mut ScanResult,
 ) {
+    let kind = owner.kind;
     match readers::read_structured(path, reader, env) {
         Ok(entries) => {
             for entry in entries {
@@ -284,9 +377,9 @@ fn scan_structured_file(
                 });
             }
         }
-        Err(message) => result
+        Err(problem) => result
             .warnings
-            .push(format!("{}: {message}", path.display())),
+            .push(owner.warning(path.to_path_buf(), problem)),
     }
 }
 

--- a/crates/core/src/scan/pi_packages.rs
+++ b/crates/core/src/scan/pi_packages.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use super::RawEntry;
 use super::readers::read_json;
 
-pub(super) fn pi_packages(path: &Path) -> Result<Vec<RawEntry>, String> {
+pub(super) fn pi_packages(path: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let value = read_json(path)?;
     let Some(packages) = value.get("packages").and_then(|p| p.as_array()) else {
         return Ok(Vec::new());

--- a/crates/core/src/scan/plugins.rs
+++ b/crates/core/src/scan/plugins.rs
@@ -8,7 +8,7 @@ use crate::fs::read_if_exists;
 
 /// `~/.claude/plugins/installed_plugins.json` (`{"plugins": {"name@mkt": …}}`)
 /// joined with `enabledPlugins` from `~/.claude/settings.json`.
-pub fn claude_registry(path: &Path, env: &Env) -> Result<Vec<RawEntry>, String> {
+pub fn claude_registry(path: &Path, env: &Env) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let value = read_json(path)?;
     let Some(registry) = value.get("plugins").and_then(|p| p.as_object()) else {
         return Ok(Vec::new());
@@ -34,7 +34,7 @@ fn claude_enabled_map(settings: &Path) -> Option<serde_json::Map<String, serde_j
 }
 
 /// Project `.claude/settings*.json` `enabledPlugins` entries.
-pub fn claude_settings(path: &Path) -> Result<Vec<RawEntry>, String> {
+pub fn claude_settings(path: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let value = read_json(path)?;
     let Some(map) = value.get("enabledPlugins").and_then(|p| p.as_object()) else {
         return Ok(Vec::new());
@@ -53,7 +53,7 @@ pub fn claude_settings(path: &Path) -> Result<Vec<RawEntry>, String> {
 /// `<root>/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json`,
 /// newest version wins; disabled via `[plugins."name@mkt"] enabled = false`
 /// in the sibling config.toml.
-pub fn codex_cache(plugins_dir: &Path) -> Result<Vec<RawEntry>, String> {
+pub fn codex_cache(plugins_dir: &Path) -> Result<Vec<RawEntry>, super::ScanProblem> {
     let mut entries = Vec::new();
     let disabled = codex_disabled_set(plugins_dir);
     let cache = plugins_dir.join("cache");

--- a/crates/core/src/scan/readers.rs
+++ b/crates/core/src/scan/readers.rs
@@ -1,11 +1,15 @@
 use std::path::Path;
 
-use super::{RawEntry, antigravity, copilot, hooks, jsonc, plugins};
+use super::{RawEntry, ScanProblem, antigravity, copilot, hooks, jsonc, plugins};
 use crate::env::Env;
 use crate::fs::read_if_exists;
 use crate::harness::Reader;
 
-pub fn read_structured(path: &Path, reader: &Reader, env: &Env) -> Result<Vec<RawEntry>, String> {
+pub fn read_structured(
+    path: &Path,
+    reader: &Reader,
+    env: &Env,
+) -> Result<Vec<RawEntry>, ScanProblem> {
     match reader {
         Reader::McpServersJson | Reader::ClaudeUserMcp => {
             Ok(mcp_object(read_json(path)?.get("mcpServers")))
@@ -35,11 +39,27 @@ pub fn read_structured(path: &Path, reader: &Reader, env: &Env) -> Result<Vec<Ra
 }
 
 /// jsonc-tolerant read: comments and trailing commas never block a scan.
-pub fn read_json(path: &Path) -> Result<serde_json::Value, String> {
-    let text = read_if_exists(path)
-        .map_err(|e| e.to_string())?
-        .ok_or("file vanished mid-scan")?;
-    serde_json::from_str(&jsonc::to_json(&text)).map_err(|e| e.to_string())
+/// A file with nothing in it once the comments are gone is said as empty,
+/// not as the parser's "EOF at line 1": the remedy differs.
+pub fn read_json(path: &Path) -> Result<serde_json::Value, ScanProblem> {
+    let text = read_text(path)?;
+    let json = jsonc::to_json(&text);
+    if json.trim().is_empty() {
+        return Err(ScanProblem::EmptyFile);
+    }
+    serde_json::from_str(&json).map_err(|e| ScanProblem::InvalidJson {
+        message: e.to_string(),
+    })
+}
+
+fn read_text(path: &Path) -> Result<String, ScanProblem> {
+    read_if_exists(path)
+        .map_err(|e| ScanProblem::Unreadable {
+            message: e.to_string(),
+        })?
+        .ok_or_else(|| ScanProblem::Unreadable {
+            message: "file vanished mid-scan".to_owned(),
+        })
 }
 
 fn mcp_object(servers: Option<&serde_json::Value>) -> Vec<RawEntry> {
@@ -85,7 +105,7 @@ fn mcp_summary(entry: &serde_json::Value) -> Option<String> {
 /// `mcp.excluded` list gates them too — so a server a project declared can
 /// still be off, and reading the declaration alone would say otherwise
 /// (matrix §1). Nothing said about a server means Gemini's own default: on.
-fn gemini_mcp(path: &Path, env: &Env) -> Result<Vec<RawEntry>, String> {
+fn gemini_mcp(path: &Path, env: &Env) -> Result<Vec<RawEntry>, ScanProblem> {
     let settings = read_json(path)?;
     let state = crate::harness::gemini::settings::mcp_enablement_file(env);
     let state = read_if_exists(&state)
@@ -119,11 +139,13 @@ fn gemini_mcp(path: &Path, env: &Env) -> Result<Vec<RawEntry>, String> {
         .collect())
 }
 
-fn mcp_toml(path: &Path) -> Result<Vec<RawEntry>, String> {
-    let text = read_if_exists(path)
-        .map_err(|e| e.to_string())?
-        .ok_or("file vanished mid-scan")?;
-    let value: toml::Table = text.parse().map_err(|e: toml::de::Error| e.to_string())?;
+fn mcp_toml(path: &Path) -> Result<Vec<RawEntry>, ScanProblem> {
+    let text = read_text(path)?;
+    let value: toml::Table =
+        text.parse()
+            .map_err(|e: toml::de::Error| ScanProblem::InvalidToml {
+                message: e.to_string(),
+            })?;
     let Some(servers) = value.get("mcp_servers").and_then(|s| s.as_table()) else {
         return Ok(Vec::new());
     };
@@ -148,7 +170,7 @@ fn mcp_toml(path: &Path) -> Result<Vec<RawEntry>, String> {
         .collect())
 }
 
-fn opencode_mcp(path: &Path) -> Result<Vec<RawEntry>, String> {
+fn opencode_mcp(path: &Path) -> Result<Vec<RawEntry>, ScanProblem> {
     let value = read_json(path)?;
     let Some(map) = value.get("mcp").and_then(|m| m.as_object()) else {
         return Ok(Vec::new());
@@ -169,7 +191,7 @@ fn opencode_mcp(path: &Path) -> Result<Vec<RawEntry>, String> {
         .collect())
 }
 
-fn opencode_plugin_refs(path: &Path) -> Result<Vec<RawEntry>, String> {
+fn opencode_plugin_refs(path: &Path) -> Result<Vec<RawEntry>, ScanProblem> {
     let value = read_json(path)?;
     let Some(refs) = value.get("plugin").and_then(|p| p.as_array()) else {
         return Ok(Vec::new());

--- a/crates/core/src/scan/tests.rs
+++ b/crates/core/src/scan/tests.rs
@@ -275,6 +275,34 @@ fn an_unreadable_config_names_its_tool_kind_path_and_problem_shape() {
     }
 }
 
+/// The TOML surface has its own parser and its own shape: Codex's
+/// config.toml that does not parse is said as invalid TOML, by Codex.
+#[test]
+fn a_malformed_toml_config_is_said_as_invalid_toml() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let env = Env::fake(home, FakeOs::Linux);
+    let config = home.join(".codex/config.toml");
+    fs::create_dir_all(config.parent().unwrap()).unwrap();
+    fs::write(&config, "[mcp_servers\n").unwrap();
+
+    let result = scan_scopes(&env, &BTreeMap::new(), &[Scope::Global]);
+
+    let warning = result
+        .warnings
+        .iter()
+        .find(|w| w.path == config)
+        .expect("nothing said the file was malformed");
+    assert_eq!(
+        (warning.harness, warning.kind),
+        (HarnessId::Codex, ItemKind::McpServer)
+    );
+    assert!(
+        matches!(warning.problem, ScanProblem::InvalidToml { .. }),
+        "{warning}"
+    );
+}
+
 /// One file, several surfaces, one warning: Claude's settings.json is
 /// read for hooks and again for plugins, and an empty one would otherwise
 /// be said twice — two rows on Home and two units of the footer's count

--- a/crates/core/src/scan/tests.rs
+++ b/crates/core/src/scan/tests.rs
@@ -65,7 +65,7 @@ fn scans_a_realistic_machine() {
 
     let result = scan(&env, &settings);
 
-    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.warnings, Vec::new());
     assert_eq!(result.missing_projects, [home.join("dev/vanished")]);
 
     let detected: Vec<_> = result.harnesses.iter().map(|h| h.harness).collect();
@@ -162,7 +162,7 @@ fn sees_gemini_and_copilot_without_double_counting_claude_files() {
     settings.projects.push(project.clone());
     let result = scan(&env, &settings);
 
-    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.warnings, Vec::new());
     let detected: Vec<_> = result.harnesses.iter().map(|h| h.harness).collect();
     assert!(detected.contains(&HarnessId::Gemini) && detected.contains(&HarnessId::Copilot));
 
@@ -218,9 +218,61 @@ fn a_skill_s_tags_are_scanned_and_a_bad_one_is_reported() {
     let warning = result
         .warnings
         .iter()
-        .find(|w| w.contains("reviewer"))
+        .find(|w| w.path == skill)
         .expect("nothing said the tag was wrong");
-    assert!(warning.contains("did you mean `testing`?"), "{warning}");
+    assert_eq!(
+        (warning.harness, warning.kind),
+        (HarnessId::Claude, ItemKind::Skill)
+    );
+    let ScanProblem::UnknownTag { message } = &warning.problem else {
+        panic!("{warning}");
+    };
+    assert!(message.contains("did you mean `testing`?"), "{warning}");
+}
+
+/// A structured surface that cannot be read says whose file it is and the
+/// shape of what is wrong — an empty file and a malformed one are one
+/// parser error and two remedies, so the scan tells them apart before
+/// anything downstream words a remedy off the result.
+#[test]
+fn an_unreadable_config_names_its_tool_kind_path_and_problem_shape() {
+    type Expect = Option<fn(&ScanProblem) -> bool>;
+    let rows: [(&str, Expect); 4] = [
+        ("", Some(|problem| *problem == ScanProblem::EmptyFile)),
+        (
+            "   \n// only a comment\n",
+            Some(|problem| *problem == ScanProblem::EmptyFile),
+        ),
+        (
+            "{\"mcpServers\": {",
+            Some(|problem| matches!(problem, ScanProblem::InvalidJson { .. })),
+        ),
+        ("{\"mcpServers\": {}}", None),
+    ];
+    for (text, expected) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let env = Env::fake(home, FakeOs::Linux);
+        let config = home.join(".gemini/config/mcp_config.json");
+        fs::create_dir_all(config.parent().unwrap()).unwrap();
+        fs::write(&config, text).unwrap();
+
+        let result = scan_scopes(&env, &BTreeMap::new(), &[Scope::Global]);
+
+        let about = result.warnings.iter().find(|w| w.path == config);
+        match (about, expected) {
+            (Some(warning), Some(expected)) => {
+                assert_eq!(
+                    (warning.harness, warning.kind),
+                    (HarnessId::Antigravity, ItemKind::McpServer),
+                    "{text:?}: {warning}"
+                );
+                assert!(expected(&warning.problem), "{text:?}: {warning}");
+            }
+            (None, None) => {}
+            (found, _) => panic!("{text:?}: {found:?}"),
+        }
+    }
 }
 
 /// A pi package registered by a relative spec is a folder of its own, so it

--- a/crates/core/src/scan/tests.rs
+++ b/crates/core/src/scan/tests.rs
@@ -275,6 +275,31 @@ fn an_unreadable_config_names_its_tool_kind_path_and_problem_shape() {
     }
 }
 
+/// One file, several surfaces, one warning: Claude's settings.json is
+/// read for hooks and again for plugins, and an empty one would otherwise
+/// be said twice — two rows on Home and two units of the footer's count
+/// for one file.
+#[test]
+fn a_file_two_surfaces_read_is_warned_about_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let env = Env::fake(home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    let settings = project.join(".claude/settings.json");
+    fs::create_dir_all(settings.parent().unwrap()).unwrap();
+    fs::write(&settings, "").unwrap();
+
+    let result = scan_scopes(&env, &BTreeMap::new(), &[Scope::Project { root: project }]);
+
+    let about: Vec<_> = result
+        .warnings
+        .iter()
+        .filter(|w| w.path == settings)
+        .collect();
+    assert_eq!(about.len(), 1, "{about:?}");
+    assert_eq!(about[0].problem, ScanProblem::EmptyFile);
+}
+
 /// A pi package registered by a relative spec is a folder of its own, so it
 /// can say what it is and when it changed. One registered by name is only a
 /// line in a shared config file, and has neither.

--- a/crates/core/tests/antigravity.rs
+++ b/crates/core/tests/antigravity.rs
@@ -327,7 +327,7 @@ fn a_registered_hook_is_read_back_from_the_registry() {
         &std::collections::BTreeMap::new(),
         std::slice::from_ref(&f.scope),
     );
-    assert_eq!(scanned.warnings, Vec::<String>::new());
+    assert_eq!(scanned.warnings, Vec::new());
     let hooks: Vec<_> = scanned
         .items
         .iter()

--- a/crates/core/tests/copilot.rs
+++ b/crates/core/tests/copilot.rs
@@ -230,7 +230,7 @@ fn a_registered_hook_is_read_back_from_copilots_own_directory() {
         &std::collections::BTreeMap::new(),
         std::slice::from_ref(&f.scope),
     );
-    assert_eq!(scanned.warnings, Vec::<String>::new());
+    assert_eq!(scanned.warnings, Vec::new());
     let hooks: Vec<_> = scanned
         .items
         .iter()

--- a/crates/core/tests/edits_and_forks/customized.rs
+++ b/crates/core/tests/edits_and_forks/customized.rs
@@ -1,0 +1,58 @@
+//! A supported customization is not an edit: the project's own
+//! instructions overlaid into a skill through the manifest, and a setting
+//! value saved in the project's settings file, both change what a person
+//! sees without touching the bytes kendex compares — so the package must
+//! never be counted as edited, and a hand edit beside them still must.
+
+use std::fs;
+
+use super::*;
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_settings_customized_package_is_not_edited_until_a_file_is_changed() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    fs::write(
+        w.upstream.join("skills/gh/kendex.settings.toml.example"),
+        "[env]\n# Which reviewers run by default.\nREVIEWERS = \"arch\" # required\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.gh]\nsource = \"cat\"\n\n[skill-instructions]\ngh = \"Run the project's own checks first.\"\n",
+    );
+    fs::write(
+        w.home.join("app/kendex.settings.toml"),
+        "[env]\nREVIEWERS = \"security\"\n",
+    )
+    .unwrap();
+    sync_and_apply(&w);
+    let rendered = fs::read_to_string(skill_file(&w)).unwrap();
+    assert!(
+        rendered.contains("Run the project's own checks first."),
+        "the overlay is in the render: {rendered}"
+    );
+
+    let row = |report: &kendex_core::package::updates::UpdatesReport| {
+        report
+            .rows
+            .iter()
+            .find(|row| row.kind == ItemKind::Skill && row.name == "gh")
+            .cloned()
+            .unwrap()
+    };
+    let customized = row(&kendex_core::package::updates::updates(&w.env, &w.scope).unwrap());
+    assert!(
+        !customized.blocked_by_local_edit && customized.edited_harnesses.is_empty(),
+        "{customized:?}"
+    );
+
+    // The must-fail control: a hand edit on top of the same customizations
+    // is still an edit.
+    fs::write(skill_file(&w), rendered + "My own line.\n").unwrap();
+    let edited = row(&kendex_core::package::updates::updates(&w.env, &w.scope).unwrap());
+    assert!(edited.blocked_by_local_edit, "{edited:?}");
+    assert_eq!(edited.edited_harnesses, vec![HarnessId::Claude]);
+}

--- a/crates/core/tests/edits_and_forks/main.rs
+++ b/crates/core/tests/edits_and_forks/main.rs
@@ -9,6 +9,7 @@ mod agent_settings;
 mod agent_tables;
 mod available;
 mod beside;
+mod customized;
 mod disabled;
 mod edited_harness;
 mod vacant;

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2983,13 +2983,48 @@ export type Said = {
 	stderr: string[],
 };
 
+/**
+ *  What kept a surface from being read, by shape rather than by parser
+ *  message: an empty file and a file with a stray comma are one parser
+ *  error and two different remedies.
+ */
+export type ScanProblem = 
+/**
+ *  A document was expected and the file holds nothing: zero bytes,
+ *  whitespace, or comments alone. Another tool leaves such a file
+ *  behind when it creates its config before writing to it.
+ */
+{ kind: "empty-file" } | 
+/**
+ *  The text is not the format the surface reads; the parser's own
+ *  message says where it stopped.
+ */
+{ kind: "invalid-json"; message: string } | { kind: "invalid-toml"; message: string } | 
+/**  A directory or file the scan could not read at all. */
+{ kind: "unreadable"; message: string } | 
+/**  A word in a document's tags that names no tag. */
+{ kind: "unknown-tag"; message: string };
+
 export type ScanResult = {
 	harnesses: DetectedHarness[],
 	items: ObservedItem[],
 	/**  Registered projects whose directory is gone — flagged, never dropped. */
 	missingProjects: string[],
 	/**  Unreadable or unparsable surfaces; truth the scan could not reach. */
-	warnings: string[],
+	warnings: ScanWarning[],
+};
+
+/**
+ *  One surface the scan could not read as the document it expects, with
+ *  the tool and kind the surface belongs to: a reader deciding what to do
+ *  about a broken file needs to know whose file it is, and the path alone
+ *  says that only to someone who already knows every tool's layout.
+ */
+export type ScanWarning = {
+	harness: HarnessId,
+	kind: ItemKind,
+	path: string,
+	problem: ScanProblem,
 };
 
 export type Scope = { scope: "global" } | { scope: "project"; root: string };

--- a/ui/src/components/home/attention-rows.test.ts
+++ b/ui/src/components/home/attention-rows.test.ts
@@ -91,6 +91,20 @@ describe("the edited packages row", () => {
     expect(onEditedPackages).not.toHaveBeenCalled();
   });
 
+  it("tells two same-named projects apart by their path", () => {
+    const rows = attentionRows(
+      source({
+        editedPackages: [
+          edited("gh", VG),
+          edited("dev", { scope: "project", root: "/other/vg" }),
+        ],
+      }),
+    );
+    expect(row(rows, "edited").detail).toContain(
+      "gh in /work/vg; dev in /other/vg.",
+    );
+  });
+
   it("is absent with nothing edited", () => {
     expect(attentionRows(source({})).some((r) => r.key === "edited")).toBe(
       false,

--- a/ui/src/components/home/attention-rows.test.ts
+++ b/ui/src/components/home/attention-rows.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ScanWarning, UpdateRow } from "@/bindings";
+import { EDITED_ATTENTION_ACTION, UPDATES_ATTENTION_DETAIL } from "@/lib/copy";
+import { SEE_PROBLEMS_LABEL } from "@/lib/copy-marketplaces";
+import { unreadablePlacesLabel } from "@/lib/copy-updates";
+import { type AttentionSource, attentionRows } from "./attention-rows";
+
+const HYPR = { scope: "project", root: "/work/hyprtrade" } as const;
+const VG = { scope: "project", root: "/work/vg" } as const;
+
+const edited = (name: string, scope: UpdateRow["scope"]): UpdateRow =>
+  ({
+    kind: "skill",
+    name,
+    scope,
+    blockedByLocalEdit: true,
+    editedHarnesses: ["claude"],
+  }) as unknown as UpdateRow;
+
+const warning = (problem: ScanWarning["problem"]): ScanWarning => ({
+  harness: "antigravity",
+  kind: "mcp-server",
+  path: "/h/.gemini/config/mcp_config.json",
+  problem,
+});
+
+const source = (over: Partial<AttentionSource>): AttentionSource => ({
+  editedPackages: [],
+  result: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+  updatesError: null,
+  auditError: null,
+  unreadable: [],
+  onProjects: vi.fn(),
+  onProblems: vi.fn(),
+  onUpdates: vi.fn(),
+  onEditedPackages: vi.fn(),
+  onPackage: vi.fn(),
+  onAuditRetry: vi.fn(),
+  ...over,
+});
+
+const row = (rows: ReturnType<typeof attentionRows>, key: string) => {
+  const found = rows.find((row) => row.key === key);
+  expect(found, key).toBeDefined();
+  return found as NonNullable<typeof found>;
+};
+
+// The row names the packages and where, says what "edited" is and what
+// the two ways out are, and its link lands on those packages alone.
+describe("the edited packages row", () => {
+  it("names each package by place and lands on the edited packages only", () => {
+    const onEditedPackages = vi.fn();
+    const onPackage = vi.fn();
+    const rows = attentionRows(
+      source({
+        editedPackages: [
+          edited("commit-guards", HYPR),
+          edited("second-opinion", HYPR),
+          edited("worktree", HYPR),
+          edited("gh", VG),
+        ],
+        onEditedPackages,
+        onPackage,
+      }),
+    );
+    const found = row(rows, "edited");
+    expect(found.title).toBe("4 installed packages were edited on disk");
+    expect(found.detail).toContain(
+      "commit-guards, second-opinion and worktree in hyprtrade; gh in vg.",
+    );
+    expect(found.detail).toContain("no longer matches its source");
+    expect(found.detail).toContain("Keep each as your own copy, or discard");
+    expect(found.action?.label).toBe(EDITED_ATTENTION_ACTION);
+    found.action?.onClick();
+    expect(onEditedPackages).toHaveBeenCalledTimes(1);
+    expect(onPackage).not.toHaveBeenCalled();
+  });
+
+  it("opens the one package's own page when there is one", () => {
+    const onEditedPackages = vi.fn();
+    const onPackage = vi.fn();
+    const only = edited("gh", VG);
+    const rows = attentionRows(
+      source({ editedPackages: [only], onEditedPackages, onPackage }),
+    );
+    const found = row(rows, "edited");
+    expect(found.title).toBe("1 installed package was edited on disk");
+    expect(found.action?.label).toBe("gh");
+    found.action?.onClick();
+    expect(onPackage).toHaveBeenCalledWith(only);
+    expect(onEditedPackages).not.toHaveBeenCalled();
+  });
+
+  it("is absent with nothing edited", () => {
+    expect(attentionRows(source({})).some((r) => r.key === "edited")).toBe(
+      false,
+    );
+  });
+});
+
+// One row per file the scan could not read. Each names the tool, the
+// shape of the problem, the path and the remedy, and lands on Problems,
+// which carries the same file with its buttons.
+describe("the unreadable file rows", () => {
+  const rows: [ScanWarning["problem"], string, string][] = [
+    [
+      { kind: "empty-file" },
+      "Antigravity's MCP servers file is empty",
+      "Delete it, or put {} in it, then scan again.",
+    ],
+    [
+      { kind: "invalid-json", message: "expected `,` at line 3 column 2" },
+      "Antigravity's MCP servers file isn't valid JSON",
+      "Fix it where the parser stopped: expected `,` at line 3 column 2. Then scan again.",
+    ],
+    [
+      { kind: "invalid-toml", message: "expected `]` at line 1" },
+      "Antigravity's MCP servers file isn't valid TOML",
+      "Fix it where the parser stopped: expected `]` at line 1. Then scan again.",
+    ],
+    [
+      { kind: "unreadable", message: "Permission denied (os error 13)" },
+      "Antigravity's MCP servers file can't be read",
+      "kendex couldn't open it: Permission denied (os error 13). Check its permissions, then scan again.",
+    ],
+    [
+      {
+        kind: "unknown-tag",
+        message: "`tests` is not a tag; did you mean `testing`?",
+      },
+      "A tag in Antigravity's MCP servers file isn't one kendex knows",
+      "`tests` is not a tag; did you mean `testing`? Fix the tags line, then scan again.",
+    ],
+  ];
+
+  it.each(rows)("says %j plainly", (problem, title, remedy) => {
+    const onProblems = vi.fn();
+    const found = row(
+      attentionRows(
+        source({
+          result: {
+            harnesses: [],
+            items: [],
+            missingProjects: [],
+            warnings: [warning(problem)],
+          },
+          onProblems,
+        }),
+      ),
+      "unreadable-file:/h/.gemini/config/mcp_config.json",
+    );
+    expect(found.title).toBe(title);
+    expect(found.detail).toBe(`/h/.gemini/config/mcp_config.json — ${remedy}`);
+    expect(found.action?.label).toBe(SEE_PROBLEMS_LABEL);
+    found.action?.onClick();
+    expect(onProblems).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives every file its own row rather than one row with a count", () => {
+    const first = warning({ kind: "empty-file" });
+    const second = { ...first, path: "/h/.claude/settings.json" };
+    const rows = attentionRows(
+      source({
+        result: {
+          harnesses: [],
+          items: [],
+          missingProjects: [],
+          warnings: [first, second],
+        },
+      }),
+    );
+    expect(
+      rows.filter((r) => r.key.startsWith("unreadable-file:")),
+    ).toHaveLength(2);
+    expect(rows.some((r) => r.key === "warnings")).toBe(false);
+  });
+});
+
+// The rows that stand as they are, pinned so a rewording that drops the
+// remedy is caught: what to do is part of each.
+describe("the other rows say what to do", () => {
+  it("sends a failed update check back to Updates to check again", () => {
+    const found = row(
+      attentionRows(source({ updatesError: "no network" })),
+      "updates-unchecked",
+    );
+    expect(found.detail).toBe(UPDATES_ATTENTION_DETAIL);
+    expect(UPDATES_ATTENTION_DETAIL).toContain("Check again from Updates");
+    expect(found.action?.label).toBe("Updates");
+  });
+
+  it("says a place's install record can't be read and where the reason is", () => {
+    const found = row(
+      attentionRows(
+        source({ unreadable: [{ scope: HYPR, message: "newer schema" }] }),
+      ),
+      "updates-unreadable",
+    );
+    expect(found.detail).toBe(unreadablePlacesLabel(["hyprtrade"]));
+    expect(found.detail).toContain(
+      "can't read the install record for hyprtrade",
+    );
+    expect(found.action?.label).toBe(SEE_PROBLEMS_LABEL);
+  });
+});

--- a/ui/src/components/home/attention-rows.ts
+++ b/ui/src/components/home/attention-rows.ts
@@ -22,7 +22,7 @@ import {
   UPDATES_UNREADABLE_TITLE,
   unreadablePlacesLabel,
 } from "@/lib/copy-updates";
-import { scopeName, scopeNames } from "@/lib/labels";
+import { scopeNames } from "@/lib/labels";
 import { scopeKey } from "@/lib/scope";
 
 /** Everything Home's attention list is derived from, with the way into
@@ -56,18 +56,21 @@ export interface AttentionSource {
  *  Grouped by place rather than listed flat, so three names in one
  *  project read as three and not as one package in three places. */
 export function editedPackagesByPlace(rows: UpdateRow[]): string {
-  const byPlace = new Map<string, { place: string; names: string[] }>();
+  const byPlace = new Map<
+    string,
+    { scope: UpdateRow["scope"]; names: string[] }
+  >();
   for (const row of rows) {
     const key = scopeKey(row.scope);
-    const entry = byPlace.get(key) ?? {
-      place: scopeName(row.scope),
-      names: [],
-    };
+    const entry = byPlace.get(key) ?? { scope: row.scope, names: [] };
     entry.names.push(row.name);
     byPlace.set(key, entry);
   }
-  return [...byPlace.values()]
-    .map(({ place, names }) => `${namesInWords(names)} in ${place}`)
+  const places = [...byPlace.values()];
+  // Two projects with one folder name are told apart by their path.
+  const labels = scopeNames(places.map((place) => place.scope));
+  return places
+    .map(({ names }, index) => `${namesInWords(names)} in ${labels[index]}`)
     .join("; ");
 }
 

--- a/ui/src/components/home/attention-rows.ts
+++ b/ui/src/components/home/attention-rows.ts
@@ -1,20 +1,29 @@
-import type { ScanResult, UnreadableScope, UpdateRow } from "@/bindings";
+import type {
+  ScanResult,
+  ScanWarning,
+  UnreadableScope,
+  UpdateRow,
+} from "@/bindings";
 import type { AttentionRow } from "@/components/home/attention-section";
 import {
   AUDIT_ATTENTION_DETAIL,
   AUDIT_ATTENTION_TITLE,
-  FORKED_ATTENTION_DETAIL,
-  forkedAttentionTitle,
+  EDITED_ATTENTION_ACTION,
+  editedAttentionDetail,
+  editedAttentionTitle,
+  namesInWords,
   TRY_AGAIN_LABEL,
   UPDATES_ATTENTION_DETAIL,
   UPDATES_ATTENTION_TITLE,
 } from "@/lib/copy";
 import { SEE_PROBLEMS_LABEL } from "@/lib/copy-marketplaces";
+import { unreadableFileDetail, unreadableFileTitle } from "@/lib/copy-scan";
 import {
   UPDATES_UNREADABLE_TITLE,
   unreadablePlacesLabel,
 } from "@/lib/copy-updates";
-import { scopeNames } from "@/lib/labels";
+import { scopeName, scopeNames } from "@/lib/labels";
+import { scopeKey } from "@/lib/scope";
 
 /** Everything Home's attention list is derived from, with the way into
  *  each row's destination handed in — the derivation emits the rows in a
@@ -37,9 +46,29 @@ export interface AttentionSource {
   onProjects: () => void;
   onProblems: () => void;
   onUpdates: () => void;
-  onLibrary: () => void;
+  /** The Library narrowed to the edited packages, and nothing wider. */
+  onEditedPackages: () => void;
   onPackage: (row: UpdateRow) => void;
   onAuditRetry: () => void;
+}
+
+/** The edited packages by place: "gh in vg; dev and orch in hyprtrade".
+ *  Grouped by place rather than listed flat, so three names in one
+ *  project read as three and not as one package in three places. */
+export function editedPackagesByPlace(rows: UpdateRow[]): string {
+  const byPlace = new Map<string, { place: string; names: string[] }>();
+  for (const row of rows) {
+    const key = scopeKey(row.scope);
+    const entry = byPlace.get(key) ?? {
+      place: scopeName(row.scope),
+      names: [],
+    };
+    entry.names.push(row.name);
+    byPlace.set(key, entry);
+  }
+  return [...byPlace.values()]
+    .map(({ place, names }) => `${namesInWords(names)} in ${place}`)
+    .join("; ");
 }
 
 export function attentionRows(source: AttentionSource): AttentionRow[] {
@@ -53,12 +82,15 @@ export function attentionRows(source: AttentionSource): AttentionRow[] {
     rows.push({
       key: "edited",
       tone: "warning",
-      title: forkedAttentionTitle(editedPackages.length),
-      detail: FORKED_ATTENTION_DETAIL,
+      title: editedAttentionTitle(editedPackages.length),
+      detail: editedAttentionDetail(editedPackagesByPlace(editedPackages)),
       action:
         editedPackages.length === 1 && first
           ? { label: first.name, onClick: () => source.onPackage(first) }
-          : { label: "Library", onClick: source.onLibrary },
+          : {
+              label: EDITED_ATTENTION_ACTION,
+              onClick: source.onEditedPackages,
+            },
     });
   }
   if (missing.length > 0) {
@@ -108,16 +140,23 @@ export function attentionRows(source: AttentionSource): AttentionRow[] {
       action: { label: SEE_PROBLEMS_LABEL, onClick: source.onProblems },
     });
   }
-  if (result && result.warnings.length > 0) {
-    rows.push({
-      key: "warnings",
-      tone: "warning",
-      title:
-        result.warnings.length === 1
-          ? "1 file couldn't be read"
-          : `${result.warnings.length} files couldn't be read`,
-      detail: result.warnings[0],
-    });
+  // One row per file, not one row for the count: each names its own tool,
+  // path and remedy, and Problems carries the same file with the buttons.
+  for (const warning of result?.warnings ?? []) {
+    rows.push(unreadableFileRow(warning, source.onProblems));
   }
   return rows;
+}
+
+function unreadableFileRow(
+  warning: ScanWarning,
+  onProblems: () => void,
+): AttentionRow {
+  return {
+    key: `unreadable-file:${warning.path}`,
+    tone: "warning",
+    title: unreadableFileTitle(warning),
+    detail: unreadableFileDetail(warning),
+    action: { label: SEE_PROBLEMS_LABEL, onClick: onProblems },
+  };
 }

--- a/ui/src/components/library/apply-library-view.test.ts
+++ b/ui/src/components/library/apply-library-view.test.ts
@@ -19,7 +19,13 @@ describe("applyLibraryView", () => {
 
   it("puts every part of a view where that part is kept", () => {
     applyLibraryView({
-      filters: { kind: "hook", harness: "claude", tag: "any", from: "any" },
+      filters: {
+        kind: "hook",
+        harness: "claude",
+        tag: "any",
+        from: "any",
+        edited: "any",
+      },
       search: "deploy",
       scope: { project: "/x" },
     });

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -4,7 +4,7 @@ import type { ObservedItem, Scope } from "@/bindings";
 import { InstalledView } from "@/components/library/installed-view";
 import { READ_LANDED, READ_PENDING } from "@/lib/read-state";
 import { useEditorStore } from "@/stores/editor";
-import { useLibraryViewStore } from "@/stores/library-view";
+import { NO_FILTERS, useLibraryViewStore } from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
 import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
@@ -58,12 +58,7 @@ describe("the Library's mark under a Where filter", () => {
         warnings: [],
       } as never,
     });
-    useLibraryViewStore.setState({
-      kind: "any",
-      harness: "any",
-      tag: "any",
-      from: "any",
-    });
+    useLibraryViewStore.setState({ ...NO_FILTERS });
   });
 
   const shown = (scope: "all" | { project: string }) => {
@@ -97,22 +92,30 @@ describe("the Library narrowed to packages edited on disk", () => {
     name: "orch",
     path: "/work/vg/.claude/skills/orch",
   };
-  const editedRow = {
-    kind: "skill",
-    name: "gh",
-    scope: VG,
-    blockedByLocalEdit: true,
-    editedHarnesses: ["claude"],
-  };
+  // orch has a row too, unedited: the facet must turn on the edit flag,
+  // not on whether the updates read spoke about the package at all.
+  const rows = [
+    {
+      kind: "skill",
+      name: "gh",
+      scope: VG,
+      blockedByLocalEdit: true,
+      editedHarnesses: ["claude"],
+    },
+    {
+      kind: "skill",
+      name: "orch",
+      scope: VG,
+      blockedByLocalEdit: false,
+      editedHarnesses: [],
+    },
+  ];
 
   beforeEach(() => {
     vi.spyOn(useProvenanceStore.getState(), "load").mockResolvedValue();
     vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
     useEditorStore.setState({ saved: {} });
-    useUpdatesStore.setState({
-      rows: [editedRow as never],
-      read: READ_LANDED,
-    });
+    useUpdatesStore.setState({ rows: rows as never, read: READ_LANDED });
     useScanStore.setState({
       result: {
         harnesses: [],
@@ -130,13 +133,7 @@ describe("the Library narrowed to packages edited on disk", () => {
     );
 
   it("shows the edited package and drops the rest", () => {
-    useLibraryViewStore.setState({
-      kind: "any",
-      harness: "any",
-      tag: "any",
-      from: "any",
-      edited: "edited",
-    });
+    useLibraryViewStore.setState({ ...NO_FILTERS, edited: "edited" });
     expect(names(mount(<InstalledView />))).toEqual(["gh"]);
   });
 
@@ -144,26 +141,14 @@ describe("the Library narrowed to packages edited on disk", () => {
   // table there would claim no package is edited.
   it("holds the skeleton until the updates read says which are edited", () => {
     useUpdatesStore.setState({ rows: [], read: READ_PENDING });
-    useLibraryViewStore.setState({
-      kind: "any",
-      harness: "any",
-      tag: "any",
-      from: "any",
-      edited: "edited",
-    });
+    useLibraryViewStore.setState({ ...NO_FILTERS, edited: "edited" });
     const host = mount(<InstalledView />);
     expect(names(host).filter((name) => name !== undefined)).toEqual([]);
     expect(host.querySelector('[data-slot="skeleton"]')).not.toBeNull();
   });
 
   it("shows every package when the facet is off", () => {
-    useLibraryViewStore.setState({
-      kind: "any",
-      harness: "any",
-      tag: "any",
-      from: "any",
-      edited: "any",
-    });
+    useLibraryViewStore.setState({ ...NO_FILTERS });
     expect(names(mount(<InstalledView />))).toEqual(["gh", "orch"]);
   });
 });

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -87,3 +87,67 @@ describe("the Library's mark under a Where filter", () => {
     expect(host.querySelectorAll("tbody tr")).toHaveLength(1);
   });
 });
+
+// Home's edited row lands here narrowed to the packages it counted: the
+// facet reads the same update rows, so a package edited on disk is on
+// the page and one that is not is off it.
+describe("the Library narrowed to packages edited on disk", () => {
+  const other = {
+    ...installed(VG),
+    name: "orch",
+    path: "/work/vg/.claude/skills/orch",
+  };
+  const editedRow = {
+    kind: "skill",
+    name: "gh",
+    scope: VG,
+    blockedByLocalEdit: true,
+    editedHarnesses: ["claude"],
+  };
+
+  beforeEach(() => {
+    vi.spyOn(useProvenanceStore.getState(), "load").mockResolvedValue();
+    vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
+    useEditorStore.setState({ saved: {} });
+    useUpdatesStore.setState({
+      rows: [editedRow as never],
+      read: READ_LANDED,
+    });
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [installed(VG), other],
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+    useNavStore.setState({ libraryScope: "all", search: "" });
+  });
+
+  const names = (host: HTMLElement) =>
+    [...host.querySelectorAll("tbody tr td:first-child")].map((cell) =>
+      cell.querySelector("button")?.textContent?.trim(),
+    );
+
+  it("shows the edited package and drops the rest", () => {
+    useLibraryViewStore.setState({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+      edited: "edited",
+    });
+    expect(names(mount(<InstalledView />))).toEqual(["gh"]);
+  });
+
+  it("shows every package when the facet is off", () => {
+    useLibraryViewStore.setState({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+      edited: "any",
+    });
+    expect(names(mount(<InstalledView />))).toEqual(["gh", "orch"]);
+  });
+});

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ObservedItem, Scope } from "@/bindings";
 import { InstalledView } from "@/components/library/installed-view";
-import { READ_LANDED } from "@/lib/read-state";
+import { READ_LANDED, READ_PENDING } from "@/lib/read-state";
 import { useEditorStore } from "@/stores/editor";
 import { useLibraryViewStore } from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
@@ -138,6 +138,22 @@ describe("the Library narrowed to packages edited on disk", () => {
       edited: "edited",
     });
     expect(names(mount(<InstalledView />))).toEqual(["gh"]);
+  });
+
+  // Before the updates read lands nothing has been counted: an empty
+  // table there would claim no package is edited.
+  it("holds the skeleton until the updates read says which are edited", () => {
+    useUpdatesStore.setState({ rows: [], read: READ_PENDING });
+    useLibraryViewStore.setState({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+      edited: "edited",
+    });
+    const host = mount(<InstalledView />);
+    expect(names(host).filter((name) => name !== undefined)).toEqual([]);
+    expect(host.querySelector('[data-slot="skeleton"]')).not.toBeNull();
   });
 
   it("shows every package when the facet is off", () => {

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -28,7 +28,6 @@ import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { isNarrowed, UNFILTERED } from "@/lib/library-handoff";
 import { useLibraryStandings } from "@/lib/library-standings";
 import { packageMark } from "@/lib/place-marks";
-import { sameScope } from "@/lib/scope";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import {
@@ -42,7 +41,6 @@ import {
   useProvenanceStore,
 } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
-import { useUpdatesStore } from "@/stores/updates";
 
 /** "Installed": everything on this machine, filterable. A row opens the
  *  package's own page; the filters and scroll position live in a store so
@@ -66,9 +64,7 @@ export function InstalledView() {
     setEdited,
     setScrollTop,
   } = useLibraryViewStore();
-  // The edited narrowing reads the same rows Home's edited row counts, so
-  // the row's link lands on exactly the packages it counted.
-  const updateRows = useUpdatesStore((s) => s.rows);
+
   const provenance = useProvenanceStore((s) => s.rows);
   const loadProvenance = useProvenanceStore((s) => s.load);
   // Kept in nav rather than here so leaving for a package page and coming
@@ -103,6 +99,16 @@ export function InstalledView() {
     return () => setScrollTop(node.scrollTop);
   }, [replaced, setScrollTop]);
 
+  // Every group the scan holds, before any narrowing.
+  const everywhere = useMemo(
+    () => (result ? groupItems(result.items) : []),
+    [result],
+  );
+  // Read from those, never from the filtered set: a mark answers for the
+  // package, so narrowing the table to one project must not change what it
+  // says. Read from `groups`, a package customized in two projects would
+  // say "Customized in vg" here and name both on its own page.
+  const { standingsFor, editedAnywhere } = useLibraryStandings(everywhere);
   const groups = useMemo(() => {
     if (!result) return [];
     const filtered = filterItems(result.items, {
@@ -121,16 +127,12 @@ export function InstalledView() {
           ) === from,
       );
     }
+    // The edited narrowing reads the same per-place fact Home's edited
+    // row counts, so the row's link lands on exactly those packages.
+    // Before the updates read lands the fact is unknown, and the table
+    // shows its skeleton rather than an empty list claiming none.
     if (edited === "edited") {
-      grouped = grouped.filter((group) =>
-        updateRows.some(
-          (row) =>
-            row.blockedByLocalEdit &&
-            row.kind === group.kind &&
-            row.name === group.name &&
-            groupScopes(group).some((where) => sameScope(where, row.scope)),
-        ),
-      );
+      grouped = editedAnywhere ? grouped.filter(editedAnywhere) : [];
     }
     return grouped;
   }, [
@@ -143,19 +145,9 @@ export function InstalledView() {
     edited,
     search,
     provenance,
-    updateRows,
+    editedAnywhere,
   ]);
 
-  // Every group the scan holds, before any narrowing.
-  const everywhere = useMemo(
-    () => (result ? groupItems(result.items) : []),
-    [result],
-  );
-  // Read from those, never from the filtered set: a mark answers for the
-  // package, so narrowing the table to one project must not change what it
-  // says. Read from `groups`, a package customized in two projects would
-  // say "Customized in vg" here and name both on its own page.
-  const standingsFor = useLibraryStandings(everywhere);
   // The count the filtered total is measured against: every row the table
   // could show, not the ones left after the current narrowing. Shared with
   // Home's Installed tile so the two can never disagree.
@@ -167,7 +159,10 @@ export function InstalledView() {
     [provenance],
   );
   // Nothing has been counted yet — distinct from "counted, found nothing".
-  const scanning = result === null;
+  // Narrowed to edited packages, the count also waits on the updates read
+  // that says which are edited.
+  const scanning =
+    result === null || (edited === "edited" && editedAnywhere === null);
   const hasAnyItems = (result?.items.length ?? 0) > 0;
   const filters: FilterSelection = { kind, harness, tag, from, edited };
   const filtered = isNarrowed({ filters, search, scope });

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -28,6 +28,7 @@ import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { isNarrowed, UNFILTERED } from "@/lib/library-handoff";
 import { useLibraryStandings } from "@/lib/library-standings";
 import { packageMark } from "@/lib/place-marks";
+import { sameScope } from "@/lib/scope";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import {
@@ -41,6 +42,7 @@ import {
   useProvenanceStore,
 } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
+import { useUpdatesStore } from "@/stores/updates";
 
 /** "Installed": everything on this machine, filterable. A row opens the
  *  package's own page; the filters and scroll position live in a store so
@@ -56,12 +58,17 @@ export function InstalledView() {
     harness,
     tag,
     from,
+    edited,
     setKind,
     setHarness,
     setTag,
     setFrom,
+    setEdited,
     setScrollTop,
   } = useLibraryViewStore();
+  // The edited narrowing reads the same rows Home's edited row counts, so
+  // the row's link lands on exactly the packages it counted.
+  const updateRows = useUpdatesStore((s) => s.rows);
   const provenance = useProvenanceStore((s) => s.rows);
   const loadProvenance = useProvenanceStore((s) => s.load);
   // Kept in nav rather than here so leaving for a package page and coming
@@ -105,15 +112,39 @@ export function InstalledView() {
       tag: tag === "any" ? undefined : (tag as Tag),
       search,
     });
-    const grouped = groupItems(filtered);
-    if (from === "any") return grouped;
-    return grouped.filter(
-      (group) =>
-        originLabel(
-          originFor(provenance, group.kind, group.name, groupScopes(group)),
-        ) === from,
-    );
-  }, [result, scope, kind, harness, tag, from, search, provenance]);
+    let grouped = groupItems(filtered);
+    if (from !== "any") {
+      grouped = grouped.filter(
+        (group) =>
+          originLabel(
+            originFor(provenance, group.kind, group.name, groupScopes(group)),
+          ) === from,
+      );
+    }
+    if (edited === "edited") {
+      grouped = grouped.filter((group) =>
+        updateRows.some(
+          (row) =>
+            row.blockedByLocalEdit &&
+            row.kind === group.kind &&
+            row.name === group.name &&
+            groupScopes(group).some((where) => sameScope(where, row.scope)),
+        ),
+      );
+    }
+    return grouped;
+  }, [
+    result,
+    scope,
+    kind,
+    harness,
+    tag,
+    from,
+    edited,
+    search,
+    provenance,
+    updateRows,
+  ]);
 
   // Every group the scan holds, before any narrowing.
   const everywhere = useMemo(
@@ -138,7 +169,7 @@ export function InstalledView() {
   // Nothing has been counted yet — distinct from "counted, found nothing".
   const scanning = result === null;
   const hasAnyItems = (result?.items.length ?? 0) > 0;
-  const filters: FilterSelection = { kind, harness, tag, from };
+  const filters: FilterSelection = { kind, harness, tag, from, edited };
   const filtered = isNarrowed({ filters, search, scope });
 
   const clearFilters = () => applyLibraryView(UNFILTERED);
@@ -157,6 +188,8 @@ export function InstalledView() {
         from={from}
         onFromChange={setFrom}
         fromOptions={fromOptions}
+        edited={edited}
+        onEditedChange={setEdited}
         scope={scope}
         onScopeChange={setScope}
         projects={projects}

--- a/ui/src/components/library/library-filters.tsx
+++ b/ui/src/components/library/library-filters.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TAGS_ROW_LABEL } from "@/lib/copy";
+import { EDITED_ON_DISK_LABEL, TAGS_ROW_LABEL } from "@/lib/copy";
 import type { ScopeSelection } from "@/lib/derive";
 import { harnessName, KINDS, kindLabel, TAG_LABELS } from "@/lib/labels";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
@@ -44,6 +44,8 @@ export function LibraryFilters({
   from,
   onFromChange,
   fromOptions,
+  edited,
+  onEditedChange,
   scope,
   onScopeChange,
   projects,
@@ -65,6 +67,8 @@ export function LibraryFilters({
   onFromChange: (value: string) => void;
   /** The origins the provenance join actually carries, already labelled. */
   fromOptions: string[];
+  edited: string;
+  onEditedChange: (value: string) => void;
   scope: ScopeSelection;
   onScopeChange: (scope: ScopeSelection) => void;
   projects: string[];
@@ -146,6 +150,13 @@ export function LibraryFilters({
             value={from}
             onChange={onFromChange}
             options={fromOptions.map((label) => [label, label])}
+          />
+          <FacetSelect
+            label="Files"
+            empty="Any files"
+            value={edited}
+            onChange={onEditedChange}
+            options={[["edited", EDITED_ON_DISK_LABEL]]}
           />
         </div>
         <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">

--- a/ui/src/components/problem-card.tsx
+++ b/ui/src/components/problem-card.tsx
@@ -3,6 +3,7 @@ import { commands } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { PlaceCard } from "@/components/place-card";
 import { Button } from "@/components/ui/button";
+import { RESCAN_LABEL, SHOW_IN_FILE_BROWSER_LABEL } from "@/lib/copy-scan";
 import {
   PROBLEM_HEADLINES,
   PROBLEM_LEADS,
@@ -51,7 +52,7 @@ export function ProblemCard({ problem }: { problem: Problem }) {
           variant="outline"
           onClick={() => void rescanEverything({ announce: true })}
         >
-          Rescan
+          {RESCAN_LABEL}
         </Button>
         {projectRoot ? (
           <Button
@@ -59,7 +60,7 @@ export function ProblemCard({ problem }: { problem: Problem }) {
             variant="outline"
             onClick={() => void commands.revealPath(projectRoot)}
           >
-            Show in file browser
+            {SHOW_IN_FILE_BROWSER_LABEL}
           </Button>
         ) : null}
         {projectRoot ? (

--- a/ui/src/components/status-footer.tsx
+++ b/ui/src/components/status-footer.tsx
@@ -10,7 +10,11 @@ import { problemsFooterLabel } from "@/lib/error-copy";
 import { exactTime, relativeTime } from "@/lib/relative-time";
 import { useNowTick } from "@/lib/use-now-tick";
 import { useNavStore } from "@/stores/nav";
-import { useBlockedPlaces, useProblems } from "@/stores/problems";
+import {
+  useBlockedPlaces,
+  useProblems,
+  useUnreadableFiles,
+} from "@/stores/problems";
 import { useScanStore } from "@/stores/scan";
 
 // A persistent strip across the whole window, not just the content pane —
@@ -25,7 +29,9 @@ export function StatusFooter() {
   // here too: the Problems page is where both are answered, and the count
   // is the only thing on screen that says so from anywhere in the app.
   const blocked = useBlockedPlaces();
-  const waiting = problems.length + blockedCount(blocked);
+  const unreadableFiles = useUnreadableFiles();
+  const waiting =
+    problems.length + unreadableFiles.length + blockedCount(blocked);
   const goTo = useNavStore((s) => s.goTo);
 
   // "Scanned Nm ago" goes stale on its own; nothing else re-renders this

--- a/ui/src/components/unreadable-file-card.tsx
+++ b/ui/src/components/unreadable-file-card.tsx
@@ -1,0 +1,56 @@
+import { toast } from "sonner";
+import { commands, type ScanWarning } from "@/bindings";
+import { PlaceCard } from "@/components/place-card";
+import { Button } from "@/components/ui/button";
+import { COPY_PATH_LABEL, PATH_COPIED_TOAST } from "@/lib/copy";
+import {
+  RESCAN_LABEL,
+  SHOW_IN_FILE_BROWSER_LABEL,
+  unreadableFileRemedy,
+  unreadableFileTitle,
+} from "@/lib/copy-scan";
+import { harnessName } from "@/lib/labels";
+import { rescanEverything } from "@/lib/rescan";
+
+/** One file the scan could not read: whose it is, where it is, what is
+ *  wrong and what to do. The remedy is the reader's — another tool's
+ *  file is not kendex's to rewrite — so the buttons get them to it: the
+ *  path to paste, the folder to open, and the rescan once it is fixed. */
+export function UnreadableFileCard({ warning }: { warning: ScanWarning }) {
+  return (
+    <PlaceCard
+      tone="warning"
+      headline={unreadableFileTitle(warning)}
+      name={harnessName(warning.harness)}
+      path={warning.path}
+    >
+      <p className="text-sm">{unreadableFileRemedy(warning)}</p>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void rescanEverything({ announce: true })}
+        >
+          {RESCAN_LABEL}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            void navigator.clipboard.writeText(warning.path);
+            toast.success(PATH_COPIED_TOAST);
+          }}
+        >
+          {COPY_PATH_LABEL}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void commands.revealPath(warning.path)}
+        >
+          {SHOW_IN_FILE_BROWSER_LABEL}
+        </Button>
+      </div>
+    </PlaceCard>
+  );
+}

--- a/ui/src/lib/copy-scan.ts
+++ b/ui/src/lib/copy-scan.ts
@@ -1,0 +1,59 @@
+// A file the scan could not read as the document its surface expects. The
+// core says whose file it is and the shape of what is wrong; the words
+// here turn that into what the reader sees and what they can do about it.
+import type { ScanWarning } from "@/bindings";
+import { harnessName, kindLabel } from "@/lib/labels";
+
+/** The kind's label mid-sentence: "hooks", "MCP servers". Lowercased
+ *  unless it opens with an acronym, which the second letter tells. */
+const kindNoun = (warning: ScanWarning): string => {
+  const label = kindLabel(warning.kind, 2);
+  const acronym = label.charAt(1) !== label.charAt(1).toLowerCase();
+  return acronym ? label : label.charAt(0).toLowerCase() + label.slice(1);
+};
+
+/** The file, named by the tool that reads it and what it holds — the one
+ *  phrase every line about it opens with. */
+const fileOf = (warning: ScanWarning): string =>
+  `${harnessName(warning.harness)}'s ${kindNoun(warning)} file`;
+
+/** What is wrong, as a title: which tool's file, and the shape of it. */
+export const unreadableFileTitle = (warning: ScanWarning): string => {
+  const file = fileOf(warning);
+  switch (warning.problem.kind) {
+    case "empty-file":
+      return `${file} is empty`;
+    case "invalid-json":
+      return `${file} isn't valid JSON`;
+    case "invalid-toml":
+      return `${file} isn't valid TOML`;
+    case "unreadable":
+      return `${file} can't be read`;
+    case "unknown-tag":
+      return `A tag in ${file} isn't one kendex knows`;
+  }
+};
+
+/** What to do about it. An empty file is another tool's leftover and the
+ *  remedy is the reader's; a malformed one names where the parser
+ *  stopped; an unreadable one is a permissions question. */
+export const unreadableFileRemedy = (warning: ScanWarning): string => {
+  switch (warning.problem.kind) {
+    case "empty-file":
+      return "Delete it, or put {} in it, then scan again.";
+    case "invalid-json":
+    case "invalid-toml":
+      return `Fix it where the parser stopped: ${warning.problem.message}. Then scan again.`;
+    case "unreadable":
+      return `kendex couldn't open it: ${warning.problem.message}. Check its permissions, then scan again.`;
+    case "unknown-tag":
+      return `${warning.problem.message} Fix the tags line, then scan again.`;
+  }
+};
+
+/** Home's one line for the file: where it is, then what to do. */
+export const unreadableFileDetail = (warning: ScanWarning): string =>
+  `${warning.path} — ${unreadableFileRemedy(warning)}`;
+
+export const SHOW_IN_FILE_BROWSER_LABEL = "Show in file browser";
+export const RESCAN_LABEL = "Rescan";

--- a/ui/src/lib/copy-updates.ts
+++ b/ui/src/lib/copy-updates.ts
@@ -168,7 +168,7 @@ export const UPDATES_ONE_AT_A_TIME_NOTE =
 // project would be a plain untruth about the one place that is not one.
 export const UPDATES_UNREADABLE_TITLE = "Some places couldn't be read";
 export const unreadablePlacesLabel = (names: string[]): string =>
-  `No update standing for ${names.join(", ")}.`;
+  `kendex can't read the install record for ${names.join(", ")}, so those packages aren't counted here.`;
 /** One place's line where there is room for the reason the read gave —
  * the note on the Updates page. The badge tooltip and Home's row have a
  * line each and name the places only. Which kind of failure it was is

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -98,7 +98,7 @@ export const SCAN_FAILED_TITLE = "Couldn't scan this machine";
 export const SCAN_STALE_TITLE = "These are the last figures kendex could check";
 export const UPDATES_ATTENTION_TITLE = "Couldn't check for updates";
 export const UPDATES_ATTENTION_DETAIL =
-  "Anything new since the last check isn't counted here.";
+  "Anything new since the last check isn't counted here. Check again from Updates.";
 export const AUDIT_ATTENTION_TITLE = "Couldn't check installed content";
 export const AUDIT_ATTENTION_DETAIL =
   "Problems and pending changes may be missing here.";
@@ -195,12 +195,20 @@ export const DISCARD_EDITS_CONFIRM_LABEL = "Discard edits";
 export const FORK_ERROR_TITLE = "Couldn't keep the edits";
 export const forkedToastLabel = (name: string): string =>
   `${name} is yours now — updates are paused`;
-export const forkedAttentionTitle = (count: number): string =>
+// Home's row for installs whose files no longer match what kendex wrote:
+// which packages, where, what that means, and the two ways out. The row
+// never says who edited them — a commit in the project's own repository
+// changes the files the same as a hand does.
+export const editedAttentionTitle = (count: number): string =>
   count === 1
-    ? "You've edited an installed package"
-    : `You've edited ${count} installed packages`;
-export const FORKED_ATTENTION_DETAIL =
-  "Your changes are safe — nothing will overwrite them. Decide whether to keep each as your own copy.";
+    ? "1 installed package was edited on disk"
+    : `${count} installed packages were edited on disk`;
+/** `named` is the packages by place: "gh in vg; dev and orch in hyprtrade". */
+export const editedAttentionDetail = (named: string): string =>
+  `${named}. A file kendex installed no longer matches its source, so updates are paused there. Keep each as your own copy, or discard the edits.`;
+export const EDITED_ATTENTION_ACTION = "Library";
+/** The Library's narrowing to those packages, in the filter strip. */
+export const EDITED_ON_DISK_LABEL = "Edited on disk";
 
 export const FOLLOW_SOURCE_TOAST = "Now following its source";
 

--- a/ui/src/lib/library-handoff.test.ts
+++ b/ui/src/lib/library-handoff.test.ts
@@ -7,7 +7,13 @@ import {
 } from "./library-handoff";
 
 const EVERYTHING: LibraryView = {
-  filters: { kind: "any", harness: "any", tag: "any", from: "any" },
+  filters: {
+    kind: "any",
+    harness: "any",
+    tag: "any",
+    from: "any",
+    edited: "any",
+  },
   search: "",
   scope: "all",
 };
@@ -27,6 +33,16 @@ describe("libraryViewFromHandoff", () => {
       ...EVERYTHING,
       filters: { ...EVERYTHING.filters, harness: "claude" },
     });
+  });
+
+  // Home's edited row lands on the edited packages and nothing wider; a
+  // link that asked for them must not open the whole Library.
+  it("narrows to edited packages when the link asked for those", () => {
+    expect(libraryViewFromHandoff({ edited: true })).toEqual({
+      ...EVERYTHING,
+      filters: { ...EVERYTHING.filters, edited: "edited" },
+    });
+    expect(libraryViewFromHandoff({ edited: false })).toEqual(EVERYTHING);
   });
 
   it("looks where the link asked", () => {
@@ -54,7 +70,7 @@ describe("isNarrowed", () => {
   });
 
   it("counts every picker on the strip", () => {
-    for (const name of ["kind", "harness", "tag", "from"] as const) {
+    for (const name of ["kind", "harness", "tag", "from", "edited"] as const) {
       expect(
         isNarrowed({
           ...EVERYTHING,

--- a/ui/src/lib/library-handoff.ts
+++ b/ui/src/lib/library-handoff.ts
@@ -49,6 +49,7 @@ export function libraryViewFromHandoff(
       ...NO_FILTERS,
       kind: handoff.kind ?? NO_FILTERS.kind,
       harness: handoff.harness ?? NO_FILTERS.harness,
+      edited: handoff.edited ? "edited" : NO_FILTERS.edited,
     },
     search: UNFILTERED.search,
     scope: handoff.scope ?? UNFILTERED.scope,

--- a/ui/src/lib/library-standings.ts
+++ b/ui/src/lib/library-standings.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
   type PlaceStanding,
+  placeFacts,
   placeStandings,
   placesSource,
 } from "@/lib/customized-places";
@@ -14,9 +15,15 @@ import { useUpdatesStore } from "@/stores/updates";
  *  Built once for the whole table rather than per row: reading a place's
  *  customizations walks its whole manifest, and the mark, the fork badges
  *  and the legend all ask the same question of the same rows. */
-export function useLibraryStandings(
-  groups: ItemGroup[],
-): (group: ItemGroup) => PlaceStanding[] {
+export function useLibraryStandings(groups: ItemGroup[]): {
+  standingsFor: (group: ItemGroup) => PlaceStanding[];
+  /** Whether the package's installed files were edited on disk in any
+   *  place — the same per-place fact the standings read, asked on its
+   *  own because a fork or a settings overlay outranks it in a standing.
+   *  Null until the updates read has landed: nothing has been counted
+   *  yet, which is not the same as nothing edited. */
+  editedAnywhere: ((group: ItemGroup) => boolean) | null;
+} {
   const saved = useEditorStore((s) => s.saved);
   const savedSettings = useEditorStore((s) => s.savedSettings);
   const updateRows = useUpdatesStore((s) => s.rows);
@@ -34,5 +41,20 @@ export function useLibraryStandings(
       );
     return out;
   }, [groups, places]);
-  return (group: ItemGroup) => byKey.get(group.key) ?? [];
+  const editedAnywhere = useMemo(
+    () =>
+      updatesLoaded
+        ? (group: ItemGroup) =>
+            groupScopes(group).some(
+              (scope) =>
+                placeFacts(places, group.kind, group.name, scope).edited ===
+                true,
+            )
+        : null,
+    [places, updatesLoaded],
+  );
+  return {
+    standingsFor: (group: ItemGroup) => byKey.get(group.key) ?? [],
+    editedAnywhere,
+  };
 }

--- a/ui/src/pages/overview.dom.test.tsx
+++ b/ui/src/pages/overview.dom.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateRow } from "@/bindings";
+import { commands } from "@/bindings";
+import { EDITED_ATTENTION_ACTION } from "@/lib/copy";
+import { READ_LANDED } from "@/lib/read-state";
+import { useAuditStore } from "@/stores/audit";
+import { useMarketplacesStore } from "@/stores/marketplaces";
+import { useNavStore } from "@/stores/nav";
+import { useScanStore } from "@/stores/scan";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount } from "@/test/dom";
+import { OverviewPage } from "./overview";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    auditAll: vi.fn(),
+    marketplacesOverview: vi.fn(),
+    scanMachine: vi.fn(),
+    updatesRefresh: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const HYPR = { scope: "project", root: "/work/hyprtrade" } as const;
+
+const edited = (name: string): UpdateRow =>
+  ({
+    kind: "skill",
+    name,
+    scope: HYPR,
+    blockedByLocalEdit: true,
+    editedHarnesses: ["claude"],
+  }) as unknown as UpdateRow;
+
+beforeEach(() => {
+  vi.mocked(commands.auditAll).mockResolvedValue({
+    status: "ok",
+    data: [],
+  } as never);
+  vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+    status: "ok",
+    data: { rows: [], warnings: [] },
+  } as never);
+  useScanStore.setState({
+    result: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    error: null,
+    scanning: false,
+  });
+  useAuditStore.setState({
+    views: [],
+    auditedAt: Date.now(),
+    read: READ_LANDED,
+  });
+  useMarketplacesStore.setState({ rows: [], read: READ_LANDED } as never);
+  useUpdatesStore.setState({
+    rows: [edited("commit-guards"), edited("worktree")],
+    read: READ_LANDED,
+    unreadable: [],
+  });
+  useNavStore.setState({ page: "home", libraryFilter: null });
+});
+
+// The three links of the landing chain are each pinned elsewhere; this is
+// the joint: the page hands the Library a narrowing to edited packages,
+// not a bare link to everything.
+describe("Home's edited row", () => {
+  it("opens the Library narrowed to the edited packages", async () => {
+    const host = mount(<OverviewPage />);
+    const button = [...host.querySelectorAll("button")].find((el) =>
+      el.textContent?.includes(EDITED_ATTENTION_ACTION),
+    );
+    expect(button).toBeDefined();
+    await act(async () => {
+      button?.click();
+    });
+    const nav = useNavStore.getState();
+    expect(nav.page).toBe("library");
+    expect(nav.libraryFilter).toEqual({ edited: true });
+  });
+});

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -122,7 +122,7 @@ export function OverviewPage() {
     onProjects: () => goTo("projects"),
     onProblems: () => goTo("problems"),
     onUpdates: () => setPage("updates"),
-    onLibrary: () => goToLibrary(),
+    onEditedPackages: () => goToLibrary({ edited: true }),
     onPackage: (row) =>
       goToPackage({ kind: row.kind, name: row.name, scope: row.scope }),
     onAuditRetry: () => void auditRefresh({ force: true }),

--- a/ui/src/pages/problems.dom.test.tsx
+++ b/ui/src/pages/problems.dom.test.tsx
@@ -1,10 +1,16 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AuditView, DriftRow, RowExits, Scope } from "@/bindings";
+import type {
+  AuditView,
+  DriftRow,
+  RowExits,
+  ScanWarning,
+  Scope,
+} from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
-import { AUDIT_ATTENTION_TITLE } from "@/lib/copy";
+import { AUDIT_ATTENTION_TITLE, COPY_PATH_LABEL } from "@/lib/copy";
 import {
   KEEP_FILES_LABEL,
   MANAGE_CONFIRM_BODY,
@@ -17,6 +23,7 @@ import {
 import { PROBLEMS_EMPTY } from "@/lib/error-copy";
 import { READ_LANDED, readFailed } from "@/lib/read-state";
 import { useAuditStore } from "@/stores/audit";
+import { useScanStore } from "@/stores/scan";
 import { mount, settle } from "@/test/dom";
 import { ProblemsPage } from "./problems";
 
@@ -413,5 +420,47 @@ describe("a check that failed", () => {
 
     expect(host.textContent).not.toContain(AUDIT_ATTENTION_TITLE);
     expect(button(host, REPLACE_FILES_LABEL)).toBeDefined();
+  });
+});
+
+// A file the scan could not read gets a card of its own: whose it is,
+// where, what is wrong and the buttons that get the reader to the fix.
+// Nothing on the audit knows about it, so the page reads it off the scan.
+describe("a file the scan could not read", () => {
+  const stageScan = (warnings: ScanWarning[]) =>
+    act(() => {
+      useScanStore.setState({
+        result: { harnesses: [], items: [], missingProjects: [], warnings },
+        error: null,
+      });
+    });
+
+  it("draws the card with the remedy and the path to copy", () => {
+    stage([]);
+    stageScan([
+      {
+        harness: "antigravity",
+        kind: "mcp-server",
+        path: "/h/.gemini/config/mcp_config.json",
+        problem: { kind: "empty-file" },
+      },
+    ]);
+    const host = mount(<ProblemsPage />);
+    expect(cards(host)).toHaveLength(1);
+    expect(host.textContent).toContain(
+      "Antigravity's MCP servers file is empty",
+    );
+    expect(host.textContent).toContain("/h/.gemini/config/mcp_config.json");
+    expect(host.textContent).toContain("Delete it, or put {} in it");
+    expect(button(host, COPY_PATH_LABEL)).toBeDefined();
+    expect(host.textContent).not.toContain(PROBLEMS_EMPTY);
+  });
+
+  it("draws no card and reports no problems once the scan reads clean", () => {
+    stage([]);
+    stageScan([]);
+    const host = mount(<ProblemsPage />);
+    expect(cards(host)).toHaveLength(0);
+    expect(host.textContent).toContain(PROBLEMS_EMPTY);
   });
 });

--- a/ui/src/pages/problems.tsx
+++ b/ui/src/pages/problems.tsx
@@ -5,6 +5,7 @@ import { PlaceCard } from "@/components/place-card";
 import { ProblemCard } from "@/components/problem-card";
 import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
+import { UnreadableFileCard } from "@/components/unreadable-file-card";
 import {
   AUDIT_ATTENTION_DETAIL,
   AUDIT_ATTENTION_TITLE,
@@ -16,7 +17,11 @@ import { scopeName, scopePath } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount, useAuditStore } from "@/stores/audit";
-import { useBlockedPlaces, useProblems } from "@/stores/problems";
+import {
+  useBlockedPlaces,
+  useProblems,
+  useUnreadableFiles,
+} from "@/stores/problems";
 
 export function ProblemsPage() {
   // Every problem on this page is something the audit or the scan found;
@@ -27,6 +32,7 @@ export function ProblemsPage() {
   // the reader's own files, so an unconfirmed reading is not one to draw
   // them from — and the page says so rather than reporting itself clean.
   const blocked = useBlockedPlaces();
+  const unreadableFiles = useUnreadableFiles();
   const busy = useAuditStore((s) => s.busy);
   const refresh = useAuditStore((s) => s.refresh);
   const adopt = useAuditStore((s) => s.adopt);
@@ -39,6 +45,9 @@ export function ProblemsPage() {
         <div className={cn("space-y-4", CONTENT_WIDTH)}>
           {problems.map((problem) => (
             <ProblemCard key={problem.key} problem={problem} />
+          ))}
+          {unreadableFiles.map((warning) => (
+            <UnreadableFileCard key={warning.path} warning={warning} />
           ))}
           {blocked === null ? (
             <StatusNote
@@ -83,7 +92,9 @@ export function ProblemsPage() {
               </PlaceCard>
             ))
           )}
-          {problems.length === 0 && blocked?.length === 0 ? (
+          {problems.length === 0 &&
+          unreadableFiles.length === 0 &&
+          blocked?.length === 0 ? (
             <div className="flex flex-col items-center gap-2 py-16 text-center">
               <CheckCircle2 className="size-8 text-muted-foreground" />
               <p className="font-medium">{PROBLEMS_EMPTY}</p>

--- a/ui/src/stores/library-view.test.ts
+++ b/ui/src/stores/library-view.test.ts
@@ -30,6 +30,7 @@ describe("library view store", () => {
       harness: "claude",
       tag: "any",
       from: "any",
+      edited: "any",
     });
 
     const state = useLibraryViewStore.getState();

--- a/ui/src/stores/library-view.ts
+++ b/ui/src/stores/library-view.ts
@@ -7,6 +7,9 @@ export interface FilterSelection {
   harness: string;
   tag: string;
   from: string;
+  /** "edited" narrows to packages whose installed files were edited on
+   *  disk somewhere — the rows Home's edited row counts. */
+  edited: string;
 }
 
 /** Narrowed by nothing. The one definition of an unfiltered strip, so the
@@ -17,6 +20,7 @@ export const NO_FILTERS: FilterSelection = {
   harness: "any",
   tag: "any",
   from: "any",
+  edited: "any",
 };
 
 /** The Installed table's view state, kept outside the component so opening
@@ -32,6 +36,7 @@ interface LibraryViewState extends FilterSelection {
   setHarness: (harness: string) => void;
   setTag: (tag: string) => void;
   setFrom: (from: string) => void;
+  setEdited: (edited: string) => void;
   setScrollTop: (scrollTop: number) => void;
   /** Adopt a whole narrowing at once — a link's, or the empty one behind
    * Clear. Taken as one object rather than field by field, so a filter the
@@ -46,6 +51,7 @@ export const useLibraryViewStore = create<LibraryViewState>((set) => ({
   setHarness: (harness) => set({ harness }),
   setTag: (tag) => set({ tag }),
   setFrom: (from) => set({ from }),
+  setEdited: (edited) => set({ edited }),
   setScrollTop: (scrollTop) => set({ scrollTop }),
   setFilters: (filters) => set(filters),
 }));

--- a/ui/src/stores/nav-types.ts
+++ b/ui/src/stores/nav-types.ts
@@ -38,6 +38,8 @@ export type MarketplacesTab = "subscribed" | "packages" | "community" | "mine";
  * count exactly the rows its own link lands on. */
 export interface LibraryFilter extends ItemPlace {
   kind?: ItemKind;
+  /** Only packages whose installed files were edited on disk. */
+  edited?: boolean;
 }
 
 /** The package a package page is showing — everything a backend query

--- a/ui/src/stores/problems.ts
+++ b/ui/src/stores/problems.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { create } from "zustand";
-import type { AuditView, Scope, ScopeErrorKind } from "@/bindings";
+import type { AuditView, ScanWarning, Scope, ScopeErrorKind } from "@/bindings";
 import { type BlockedPlace, blockedPlaces } from "@/lib/audit-counts";
 import { useAuditStore } from "./audit";
 import { useScanStore } from "./scan";
@@ -55,6 +55,15 @@ export function useProblems(): Problem[] {
   const views = useAuditStore((s) => s.views);
   const scanError = useScanStore((s) => s.error);
   return useMemo(() => deriveProblems(views, scanError), [views, scanError]);
+}
+
+const NO_WARNINGS: ScanWarning[] = [];
+
+/** Every file the scan could not read as the document its surface
+ *  expects. Read straight off the last scan: a file that is fixed is gone
+ *  from the next result, and one that is not is still there. */
+export function useUnreadableFiles(): ScanWarning[] {
+  return useScanStore((s) => s.result?.warnings ?? NO_WARNINGS);
 }
 
 /** Every place holding a declared item whose files were already on disk,


### PR DESCRIPTION
Closes KEN-1274.

## The three edited packages

They are hyprtrade's `commit-guards`, `second-opinion` and `worktree` skills, and they are real edits. Hyprtrade's own commits d74071f4 (#637), 018a5545 (#638) and d05a3226 (#640) rewrote test files and the second-opinion script inside the rendered `.agents/skills/…` trees, so the disk tree no longer hashes to what the lock recorded at the last apply. Found by running the app's own scan (`updates::updates` over every registered scope with `KENDEX_REAL_HOME=1`), which is what Home reads; no supported customization is involved and the detector is right.

Why the CLI disagreed: `kendex updates` only printed rows with a newer version, a mixed install or a package gone upstream, so an edited install with nothing newer was silent and an edited one with an update carried no note. `kendex check` reads the drift snapshot, which was written by the last apply before those commits landed; the app's scan re-derived it, and `kendex check` now reports the same three. `kendex verify` checks the lock against disk per file and does not judge edits.

## Changes

- `kendex updates` lists an edited install as a standing fact with the note `[edited on disk — keep it as a fork, or refresh with edits discarded]`, with or without a newer version.
- A warning is said once per file: Claude's settings.json is a hook surface and a plugin surface, and `~/.claude.json` an MCP surface per scope, so one empty file used to be warned about several times.
- Scan warnings are typed: `ScanWarning { harness, kind, path, problem }` with `ScanProblem` = empty file, invalid JSON, invalid TOML, unreadable, unknown tag. An empty or comment-only JSON file is said as empty rather than as the parser's "EOF at line 1 column 0". Bindings regenerated.
- Home draws one row per unreadable file naming the tool, the shape and the remedy, landing on Problems, which carries a card per file with Rescan, Copy path and Show in file browser. The footer's problem count includes them.
- Home's edited row names the packages by place and opens the Library narrowed to them through a new "Files: Edited on disk" facet, read from the same update rows Home counts.
- Core control: a package customized through `[skill-instructions]` and a saved setting value is never counted as edited; its must-fail is a hand edit beside the same customizations.

## Every problem state, with its copy

| Surface | State | Copy | Changed |
|---|---|---|---|
| Home | edited packages | title "3 installed packages were edited on disk"; detail "commit-guards, second-opinion and worktree in hyprtrade. A file kendex installed no longer matches its source, so updates are paused there. Keep each as your own copy, or discard the edits."; action: the package (one) or Library narrowed to edited packages (several) | yes — was "You've edited 3 installed packages / Your changes are safe — nothing will overwrite them. Decide whether to keep each as your own copy. › Library" (whole Library) |
| Home | unreadable file | title "Antigravity's MCP servers file is empty"; detail "/home/method/.gemini/config/mcp_config.json — Delete it, or put {} in it, then scan again."; action "See Problems". Invalid JSON/TOML: "… isn't valid JSON" / "Fix it where the parser stopped: <message>. Then scan again."; unreadable: "… can't be read" / "kendex couldn't open it: <message>. Check its permissions, then scan again."; unknown tag: "A tag in … isn't one kendex knows" / "<message> Fix the tags line, then scan again." | yes — was "1 file couldn't be read / <path>: EOF while parsing a value at line 1 column 0", no action |
| Home | missing project folders | "1 project folder can't be found / We can't find <path>. If you moved it, add it again. › Projects" | no; says what and what to do, lands on Projects |
| Home | audit failed | "Couldn't check installed content / Problems and pending changes may be missing here. › Try again" | no; the retry is the action |
| Home | update check failed | "Couldn't check for updates / Anything new since the last check isn't counted here. Check again from Updates. › Updates" | yes — detail gained "Check again from Updates." |
| Home, sidebar tooltip | unreadable places | "Some places couldn't be read / kendex can't read the install record for hyprtrade, so those packages aren't counted here. › See Problems" | yes — was "No update standing for hyprtrade." |
| Problems | unreadable file card | headline as the Home title; name: the tool; path; body: the remedy; buttons Rescan, Copy path, Show in file browser | new |
| Problems | lock-corrupt / manifest-outdated / schema-too-new / manifest-invalid / other / scan-failure | "A kendex file can't be read", "This manifest comes from an older version", "These kendex files come from a newer version", "This manifest has a problem", "Something went wrong here", "kendex couldn't scan this machine"; each with the lead ("The file is kendex's record of what it installed in <place>." / "The file is where <place> declares what it wants installed."), the engine message and the numbered steps ("Rescan to retry", "Move the file named above aside…", "Update kendex to the latest version", "Open the file named above and make the fix the message names"…); buttons Rescan, Show in file browser, Stop tracking this project… | no |
| Problems | audit failed | "Couldn't check installed content / Problems and pending changes may be missing here. › Try again" | no |
| Problems | blocked declarations | "Waiting on a decision from you / kendex didn't write these files, so it won't touch them until you decide." with Manage these files / Replace them per row | no |
| Updates | unreadable places | "Some places couldn't be read / hyprtrade — <reason> › See Problems" | no |
| Updates | blocked by local edit | tag "Edited by you" with help "You changed this package's files. Updating would overwrite them, so this copy stays as it is; Install as new package puts the newest version beside it."; per place "Can't be updated — you've edited this copy" with Preview changes or Open package, and Install as new package where possible | no; the fork-or-discard choice is on the package page, one click away |
| Package page | edited | "You've changed this package's files / Updates are paused so your edits stay. Keep it as your own copy, see what changed, or discard the edits and go back to the catalog's version." with Keep as my own, View changes, Discard edits…; where no fork is possible: "<tool>'s copy can't be kept as your own." / "Keeping one tool's copy would drop the other edits, so the choice here is to discard them all." / "<parents> require it, so it can't become your own copy." | no |
| Package page | forked | header badge "Forked" or "Forked · edited"; a fork is the reader's own package, so updates stop by design and nothing is asked of them, which is why the edited notice is not drawn over a fork | no |

## Review round

One local round (correctness and test reviewers). Fixed: one warning per file across surfaces; the edited facet reads the per-place fact the standings own and holds the skeleton until the updates read lands; the edited row tells two same-named projects apart by path; the facet fixture carries an unedited row so the flag decides; Home's handoff is pinned; the TOML shape has a producer-side row; the Library view store resets from `NO_FILTERS`.

## Tests and must-fail controls

- `scan::tests::a_malformed_toml_config_is_said_as_invalid_toml`: Codex's config.toml with an unclosed table is said as invalid TOML by Codex.
- `scan::tests::a_file_two_surfaces_read_is_warned_about_once`: an empty `.claude/settings.json` yields one warning. Must-fail: with the dedupe removed it counted two.
- `scan::tests::an_unreadable_config_names_its_tool_kind_path_and_problem_shape`: a table of empty, comment-only, malformed and well-formed files against the tool, kind, path and problem variant. Must-fail: with the empty check removed the empty rows read as invalid JSON and the test went red.
- `edits_and_forks::customized`: the settings-customized package is not edited, then a hand edit beside it is. The must-fail is the second half.
- `remote_e2e::an_edited_install_is_listed_even_with_nothing_newer`: went red with the listing filter restored.
- vitest: `attention-rows.test.ts` (edited row by place, same-named projects told apart by path, its landing, one row per unreadable file across every problem shape, the other rows' remedies, with absent-state controls), `library-handoff.test.ts` and `library-view.test.ts` (the edited narrowing), `installed-view.dom.test.tsx` (the facet shows the edited package and drops an unedited one that has its own row, holds the skeleton until the updates read lands, and shows everything when off), `overview.dom.test.tsx` (Home's edited row hands the Library a narrowing to edited packages; went red with the narrowing dropped), `problems.dom.test.tsx` (the card with Copy path, and none when the scan is clean).
- Deleted: `forkedAttentionTitle`, `FORKED_ATTENTION_DETAIL` and Home's "N files couldn't be read" row, replaced above.

https://claude.ai/code/session_01QSgbP7GQ5przYaqQktG9Dt
