### PR TITLE
test(KEN-1241): close the rendering hatch in the second-opinion libs

### DIFF
--- a/.agents/skills/second-opinion/tests/artifact-home.test.sh
+++ b/.agents/skills/second-opinion/tests/artifact-home.test.sh
@@ -25,7 +25,7 @@ HOME_OK="home=mode=700,review-claude-failed=$FAILED,ignore=*"
 
 # label|world|argv|rc|out|err|calls files home tmp [probes] dirty
 ROWS="
-the default home is created owner-only under --cwd, seeded with a * .gitignore, and dirties nothing||review|5|-|$IN_HOME|calls=1 files=- $HOME_OK tmp=0 dirty=-
+the default home is created owner-only under --cwd, seeded with a * .gitignore, and dirties nothing|-|review|5|-|$IN_HOME|calls=1 files=- $HOME_OK tmp=0 dirty=-
 a symlink at the home pointing inside the repo is rejected and nothing lands under its target|prepare:link-inside home:tmp/second-opinion|review|5|-|header:review home-rejected:inside $IN_TEMP|calls=1 files=- home=link tmp=1 elsewhere=1 dirty=-
 a relative path escaping --cwd is rejected lexically and nothing is created outside|home:../outside/second-opinion|review|5|-|header:review home-rejected:escape $IN_TEMP|calls=1 files=- home=absent tmp=1 dirty=-
 a symlinked parent pointing at a not-yet-existing outside path is rejected before mkdir could create it|prepare:link-parent home:tmp/link-parent/second-opinion|review|5|-|header:review home-rejected:parent $IN_TEMP|calls=1 files=- home=absent tmp=1 dirty=-

--- a/.agents/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/.agents/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -25,7 +25,7 @@ ROWS="
 a non-zero exit with the cause on stderr exits 5, preserves the record with the cause, names it on stderr, and does not retry|rc:1 stdout:- stderr:quota|review|5|-|header:review failed:exit:out:1 cause:stderr preserved:out|calls=1 files=out.failed.json=$FAILED_EXIT_STDERR $CLEAN
 an empty response on a zero exit is the same class, with the empty-response reason|rc:0 stdout:- stderr:quota|review|5|-|header:review failed:empty:out cause:stderr preserved:out|calls=1 files=out.failed.json=failed(returned an empty response on a zero exit — check CLI auth and configuration|claude stderr|quota) $CLEAN
 a timeout is a CLI failure too, with no cause block|sleep:5 timeout:1|review|5|-|header:review failed:timeout:out:1 preserved:out|calls=1 files=out.failed.json=failed(timed out after 1s|-|-) $CLEAN
-a valid response writes the artifact and no sidecar||review|0|<out>|header:review written|calls=1 files=out=review:external-claude:Clean $CLEAN
+a valid response writes the artifact and no sidecar|-|review|0|<out>|header:review written|calls=1 files=out=review:external-claude:Clean $CLEAN
 a failure reported on stdout with an empty stderr names the stdout cause|rc:1 stdout:quota stderr:-|review|5|-|header:review failed:exit:out:1 cause:stdout preserved:out|calls=1 files=out.failed.json=failed(exited with code 1|claude stdout|quota) $CLEAN
 audit carries the no-verdict contract too|rc:1 stdout:- stderr:quota|audit|5|-|header:audit failed:exit:out:1 cause:stderr preserved:out|calls=1 files=out.failed.json=$FAILED_EXIT_STDERR $CLEAN
 a quick-mode CLI failure keeps the generic exit 1 and writes no sidecar|rc:1 stdout:- stderr:quota|quick|1|-|header:quick generic:exit:1|calls=1 files=- $CLEAN

--- a/.agents/skills/second-opinion/tests/lib/lane-world.bash
+++ b/.agents/skills/second-opinion/tests/lib/lane-world.bash
@@ -12,7 +12,8 @@
 # words overriding earlier ones (the suite prepends its defaults); `build ROW
 # words...` makes it, `run` prints one line:
 #   rc=N out=<stdout> err=<the parent's own log> relay=<each lane's relayed outcome> art=<the artifact> files=<beside --output, with modes> home=<the artifact home> scratch=<what the sandbox holds> [probe=… state=…]
-# PROBE=1 prints every row's rendered line instead of asserting.
+# SECOND_OPINION_TABLE_PROBE=1 prints every row's rendered line instead of asserting it; a run
+# that asserted no row exits 2, and a row with an empty field is refused.
 
 set -euo pipefail
 
@@ -301,6 +302,8 @@ word() {
     # the single-lane control: roster codex, count 1
     single) W_SINGLE=1 ;;
     fs:dirsize) [[ "$DIR_HAS_SIZE" == true ]] || W_SKIP=dirsize ;;
+    # the world with nothing added
+    -) ;;
     *) echo "UNKNOWN-WORD: $1" >&2; exit 2 ;;
   esac
 }
@@ -590,10 +593,14 @@ unusable_reason() {
 
 # run_table TITLE DEFAULTS ROWS
 run_table() {
-  local title="$1" defaults="$2" rows="$3" n=0 label world rc out err want got
+  local title="$1" defaults="$2" rows="$3" n=0 label world rc out err want got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world rc out err want; do
-    [[ -n "$label$world$rc$out$err$want" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world rc out err want <<<"$row"
+    for field in "$label" "$world" "$rc" "$out" "$err" "$want"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $defaults $world
@@ -606,12 +613,14 @@ run_table() {
       continue
     fi
     got="$(run)"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err") $want" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 finish() {

--- a/.agents/skills/second-opinion/tests/lib/roster-world.bash
+++ b/.agents/skills/second-opinion/tests/lib/roster-world.bash
@@ -11,7 +11,8 @@
 # word list, later words overriding earlier ones (each suite prepends its own
 # defaults); `build ROW words...` makes it, `run COMMAND` prints one line:
 #   rc=N out=<stdout> err=<selection log> calls=<per lane> art=<artifact> files=<sidecars>
-# PROBE=1 prints every row's rendered line instead of asserting.
+# SECOND_OPINION_TABLE_PROBE=1 prints every row's rendered line instead of asserting it; a run
+# that asserted no row exits 2, and a row with an empty field is refused.
 
 set -euo pipefail
 
@@ -136,6 +137,8 @@ word() {
     codex:*) W_RESP_CODEX="${1#codex:}" ;;
     extra:*) W_RESP_EXTRA="${1#extra:}" ;;
     stale) W_STALE=1 ;;
+    # the world with nothing added
+    -) ;;
     *) echo "UNKNOWN-WORD: $1" >&2; exit 2 ;;
   esac
 }
@@ -375,20 +378,26 @@ declared_in() {
 
 # run_table TITLE DEFAULTS ROWS: every row's world is DEFAULTS then its own words.
 run_table() {
-  local title="$1" defaults="$2" rows="$3" n=0 label world command rc out err want got
+  local title="$1" defaults="$2" rows="$3" n=0 label world command rc out err want got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world command rc out err want; do
-    [[ -n "$label$world$command$rc$out$err$want" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world command rc out err want <<<"$row"
+    for field in "$label" "$world" "$command" "$rc" "$out" "$err" "$want"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $defaults $world
     got="$(run "$command")"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err") $want" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 finish() {

--- a/.agents/skills/second-opinion/tests/lib/stub-cli-world.bash
+++ b/.agents/skills/second-opinion/tests/lib/stub-cli-world.bash
@@ -13,7 +13,8 @@
 # later words overriding earlier ones (each suite prepends its own defaults);
 # `build ROW words...` makes it, `run ARGV` prints one line:
 #   rc=N out=<stdout> err=<record log> calls=N files=<the output dir> home=<the artifact home> tmp=N paths=<probes>
-# PROBE=1 prints every row's rendered line instead of asserting.
+# SECOND_OPINION_TABLE_PROBE=1 prints every row's rendered line instead of asserting it; a run
+# that asserted no row exits 2, and a row with an empty field is refused.
 #
 # Deliberate collapses: every caller-owned file renders as the class `mine`
 # (the sweep never rewrites a file it keeps, so byte identity adds nothing),
@@ -643,10 +644,14 @@ refused_candidates() {
 
 # run_table TITLE DEFAULTS ROWS
 run_table() {
-  local title="$1" defaults="$2" rows="$3" n=0 label world argv rc out err want got
+  local title="$1" defaults="$2" rows="$3" n=0 label world argv rc out err want got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world argv rc out err want; do
-    [[ -n "$label$world$argv$rc$out$err$want" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world argv rc out err want <<<"$row"
+    for field in "$label" "$world" "$argv" "$rc" "$out" "$err" "$want"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $defaults $world
@@ -659,12 +664,14 @@ run_table() {
       continue
     fi
     got="$(run "$argv")"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err") $want" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 finish() {

--- a/.agents/skills/second-opinion/tests/option-parsing.test.sh
+++ b/.agents/skills/second-opinion/tests/option-parsing.test.sh
@@ -16,20 +16,20 @@ NONE="calls=0 files=- home=absent tmp=0 dirty=-"
 ROWS="
 dash-leading --prompt and --cwd in the = form are accepted and the prompt reaches the CLI intact|cwd:dash|quick --prompt=-dash-prompt.txt --cwd=-dashcwd|0|prompt-echoed|header:quick|calls=1 files=- home=absent tmp=0 dirty=-
 --timeout followed by --output does not swallow it: a parse error, and the caller's file at that path is untouched|plant:report|review --timeout --output @out|1|-|requires:--timeout|calls=0 files=out=mine home=absent tmp=0 dirty=-
---prompt followed by a flag is rejected||review --prompt --range HEAD|1|-|requires:--prompt|$NONE
---prompt at the end of argv is rejected||review --prompt|1|-|requires:--prompt|$NONE
---output followed by a flag is rejected||review --output --range HEAD|1|-|requires:--output|$NONE
---output at the end of argv is rejected||review --output|1|-|requires:--output|$NONE
---target followed by a flag is rejected||review --target --range HEAD|1|-|requires:--target|$NONE
---target at the end of argv is rejected||review --target|1|-|requires:--target|$NONE
---provider followed by a flag is rejected||review --provider --range HEAD|1|-|requires:--provider|$NONE
---provider at the end of argv is rejected||review --provider|1|-|requires:--provider|$NONE
---range followed by a flag is rejected||review --range --range HEAD|1|-|requires:--range|$NONE
---range at the end of argv is rejected||review --range|1|-|requires:--range|$NONE
---cwd followed by a flag is rejected||review --cwd --range HEAD|1|-|requires:--cwd|$NONE
---cwd at the end of argv is rejected||review --cwd|1|-|requires:--cwd|$NONE
---timeout followed by a flag is rejected||review --timeout --range HEAD|1|-|requires:--timeout|$NONE
---timeout at the end of argv is rejected||review --timeout|1|-|requires:--timeout|$NONE
+--prompt followed by a flag is rejected|-|review --prompt --range HEAD|1|-|requires:--prompt|$NONE
+--prompt at the end of argv is rejected|-|review --prompt|1|-|requires:--prompt|$NONE
+--output followed by a flag is rejected|-|review --output --range HEAD|1|-|requires:--output|$NONE
+--output at the end of argv is rejected|-|review --output|1|-|requires:--output|$NONE
+--target followed by a flag is rejected|-|review --target --range HEAD|1|-|requires:--target|$NONE
+--target at the end of argv is rejected|-|review --target|1|-|requires:--target|$NONE
+--provider followed by a flag is rejected|-|review --provider --range HEAD|1|-|requires:--provider|$NONE
+--provider at the end of argv is rejected|-|review --provider|1|-|requires:--provider|$NONE
+--range followed by a flag is rejected|-|review --range --range HEAD|1|-|requires:--range|$NONE
+--range at the end of argv is rejected|-|review --range|1|-|requires:--range|$NONE
+--cwd followed by a flag is rejected|-|review --cwd --range HEAD|1|-|requires:--cwd|$NONE
+--cwd at the end of argv is rejected|-|review --cwd|1|-|requires:--cwd|$NONE
+--timeout followed by a flag is rejected|-|review --timeout --range HEAD|1|-|requires:--timeout|$NONE
+--timeout at the end of argv is rejected|-|review --timeout|1|-|requires:--timeout|$NONE
 "
 
 run_table "option parsing" "$DEFAULTS" "$ROWS"

--- a/.agents/skills/second-opinion/tests/startup.test.sh
+++ b/.agents/skills/second-opinion/tests/startup.test.sh
@@ -162,20 +162,26 @@ err_word() {
 }
 
 run_table() {
-  local title="$1" rows="$2" n=0 label world argv rc out err got
+  local title="$1" rows="$2" n=0 label world argv rc out err got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world argv rc out err; do
-    [[ -n "$label$world$argv$rc$out$err" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world argv rc out err <<<"$row"
+    for field in "$label" "$world" "$argv" "$rc" "$out" "$err"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $world
     got="$(run "$argv")"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err")" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 run_table "the startup" "\

--- a/.agents/skills/second-opinion/tests/target-selection.test.sh
+++ b/.agents/skills/second-opinion/tests/target-selection.test.sh
@@ -22,7 +22,7 @@ NONE="calls=claude:0,codex:0,extra:0 art=- files=-"
 
 # label|world|command|rc|out|err|calls art files
 ROWS="
-the default count is one opinion, the first eligible in priority order; none is the declared absence of a model, not a typo||review|0|<out>|single:codex:review:none written|calls=claude:0,codex:1,extra:0 art=external-codex/$OWN files=out
+the default count is one opinion, the first eligible in priority order; none is the declared absence of a model, not a typo|-|review|0|<out>|single:codex:review:none written|calls=claude:0,codex:1,extra:0 art=external-codex/$OWN files=out
 the session's own model is skipped and the next distinct model taken|current:codex|review|0|<out>|same:codex:codex single:claude:review:codex written|calls=claude:1,codex:0,extra:0 art=external-claude/$OWN files=out
 a forced target equal to the session model is refused with no artifact and no CLI spend, naming what the roster would pick|current:claude target:claude count:2|review|1|-|same:claude:claude refused:claude:1 hint:claude:codex|$NONE
 a --target flag refused the same way carries no settings hint|current:codex|review --target codex|1|-|same:codex:codex refused:codex:1|$NONE

--- a/skills/second-opinion/tests/artifact-home.test.sh
+++ b/skills/second-opinion/tests/artifact-home.test.sh
@@ -25,7 +25,7 @@ HOME_OK="home=mode=700,review-claude-failed=$FAILED,ignore=*"
 
 # label|world|argv|rc|out|err|calls files home tmp [probes] dirty
 ROWS="
-the default home is created owner-only under --cwd, seeded with a * .gitignore, and dirties nothing||review|5|-|$IN_HOME|calls=1 files=- $HOME_OK tmp=0 dirty=-
+the default home is created owner-only under --cwd, seeded with a * .gitignore, and dirties nothing|-|review|5|-|$IN_HOME|calls=1 files=- $HOME_OK tmp=0 dirty=-
 a symlink at the home pointing inside the repo is rejected and nothing lands under its target|prepare:link-inside home:tmp/second-opinion|review|5|-|header:review home-rejected:inside $IN_TEMP|calls=1 files=- home=link tmp=1 elsewhere=1 dirty=-
 a relative path escaping --cwd is rejected lexically and nothing is created outside|home:../outside/second-opinion|review|5|-|header:review home-rejected:escape $IN_TEMP|calls=1 files=- home=absent tmp=1 dirty=-
 a symlinked parent pointing at a not-yet-existing outside path is rejected before mkdir could create it|prepare:link-parent home:tmp/link-parent/second-opinion|review|5|-|header:review home-rejected:parent $IN_TEMP|calls=1 files=- home=absent tmp=1 dirty=-

--- a/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -25,7 +25,7 @@ ROWS="
 a non-zero exit with the cause on stderr exits 5, preserves the record with the cause, names it on stderr, and does not retry|rc:1 stdout:- stderr:quota|review|5|-|header:review failed:exit:out:1 cause:stderr preserved:out|calls=1 files=out.failed.json=$FAILED_EXIT_STDERR $CLEAN
 an empty response on a zero exit is the same class, with the empty-response reason|rc:0 stdout:- stderr:quota|review|5|-|header:review failed:empty:out cause:stderr preserved:out|calls=1 files=out.failed.json=failed(returned an empty response on a zero exit — check CLI auth and configuration|claude stderr|quota) $CLEAN
 a timeout is a CLI failure too, with no cause block|sleep:5 timeout:1|review|5|-|header:review failed:timeout:out:1 preserved:out|calls=1 files=out.failed.json=failed(timed out after 1s|-|-) $CLEAN
-a valid response writes the artifact and no sidecar||review|0|<out>|header:review written|calls=1 files=out=review:external-claude:Clean $CLEAN
+a valid response writes the artifact and no sidecar|-|review|0|<out>|header:review written|calls=1 files=out=review:external-claude:Clean $CLEAN
 a failure reported on stdout with an empty stderr names the stdout cause|rc:1 stdout:quota stderr:-|review|5|-|header:review failed:exit:out:1 cause:stdout preserved:out|calls=1 files=out.failed.json=failed(exited with code 1|claude stdout|quota) $CLEAN
 audit carries the no-verdict contract too|rc:1 stdout:- stderr:quota|audit|5|-|header:audit failed:exit:out:1 cause:stderr preserved:out|calls=1 files=out.failed.json=$FAILED_EXIT_STDERR $CLEAN
 a quick-mode CLI failure keeps the generic exit 1 and writes no sidecar|rc:1 stdout:- stderr:quota|quick|1|-|header:quick generic:exit:1|calls=1 files=- $CLEAN

--- a/skills/second-opinion/tests/lib/lane-world.bash
+++ b/skills/second-opinion/tests/lib/lane-world.bash
@@ -12,7 +12,8 @@
 # words overriding earlier ones (the suite prepends its defaults); `build ROW
 # words...` makes it, `run` prints one line:
 #   rc=N out=<stdout> err=<the parent's own log> relay=<each lane's relayed outcome> art=<the artifact> files=<beside --output, with modes> home=<the artifact home> scratch=<what the sandbox holds> [probe=… state=…]
-# PROBE=1 prints every row's rendered line instead of asserting.
+# SECOND_OPINION_TABLE_PROBE=1 prints every row's rendered line instead of asserting it; a run
+# that asserted no row exits 2, and a row with an empty field is refused.
 
 set -euo pipefail
 
@@ -301,6 +302,8 @@ word() {
     # the single-lane control: roster codex, count 1
     single) W_SINGLE=1 ;;
     fs:dirsize) [[ "$DIR_HAS_SIZE" == true ]] || W_SKIP=dirsize ;;
+    # the world with nothing added
+    -) ;;
     *) echo "UNKNOWN-WORD: $1" >&2; exit 2 ;;
   esac
 }
@@ -590,10 +593,14 @@ unusable_reason() {
 
 # run_table TITLE DEFAULTS ROWS
 run_table() {
-  local title="$1" defaults="$2" rows="$3" n=0 label world rc out err want got
+  local title="$1" defaults="$2" rows="$3" n=0 label world rc out err want got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world rc out err want; do
-    [[ -n "$label$world$rc$out$err$want" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world rc out err want <<<"$row"
+    for field in "$label" "$world" "$rc" "$out" "$err" "$want"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $defaults $world
@@ -606,12 +613,14 @@ run_table() {
       continue
     fi
     got="$(run)"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err") $want" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 finish() {

--- a/skills/second-opinion/tests/lib/roster-world.bash
+++ b/skills/second-opinion/tests/lib/roster-world.bash
@@ -11,7 +11,8 @@
 # word list, later words overriding earlier ones (each suite prepends its own
 # defaults); `build ROW words...` makes it, `run COMMAND` prints one line:
 #   rc=N out=<stdout> err=<selection log> calls=<per lane> art=<artifact> files=<sidecars>
-# PROBE=1 prints every row's rendered line instead of asserting.
+# SECOND_OPINION_TABLE_PROBE=1 prints every row's rendered line instead of asserting it; a run
+# that asserted no row exits 2, and a row with an empty field is refused.
 
 set -euo pipefail
 
@@ -136,6 +137,8 @@ word() {
     codex:*) W_RESP_CODEX="${1#codex:}" ;;
     extra:*) W_RESP_EXTRA="${1#extra:}" ;;
     stale) W_STALE=1 ;;
+    # the world with nothing added
+    -) ;;
     *) echo "UNKNOWN-WORD: $1" >&2; exit 2 ;;
   esac
 }
@@ -375,20 +378,26 @@ declared_in() {
 
 # run_table TITLE DEFAULTS ROWS: every row's world is DEFAULTS then its own words.
 run_table() {
-  local title="$1" defaults="$2" rows="$3" n=0 label world command rc out err want got
+  local title="$1" defaults="$2" rows="$3" n=0 label world command rc out err want got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world command rc out err want; do
-    [[ -n "$label$world$command$rc$out$err$want" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world command rc out err want <<<"$row"
+    for field in "$label" "$world" "$command" "$rc" "$out" "$err" "$want"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $defaults $world
     got="$(run "$command")"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err") $want" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 finish() {

--- a/skills/second-opinion/tests/lib/stub-cli-world.bash
+++ b/skills/second-opinion/tests/lib/stub-cli-world.bash
@@ -13,7 +13,8 @@
 # later words overriding earlier ones (each suite prepends its own defaults);
 # `build ROW words...` makes it, `run ARGV` prints one line:
 #   rc=N out=<stdout> err=<record log> calls=N files=<the output dir> home=<the artifact home> tmp=N paths=<probes>
-# PROBE=1 prints every row's rendered line instead of asserting.
+# SECOND_OPINION_TABLE_PROBE=1 prints every row's rendered line instead of asserting it; a run
+# that asserted no row exits 2, and a row with an empty field is refused.
 #
 # Deliberate collapses: every caller-owned file renders as the class `mine`
 # (the sweep never rewrites a file it keeps, so byte identity adds nothing),
@@ -643,10 +644,14 @@ refused_candidates() {
 
 # run_table TITLE DEFAULTS ROWS
 run_table() {
-  local title="$1" defaults="$2" rows="$3" n=0 label world argv rc out err want got
+  local title="$1" defaults="$2" rows="$3" n=0 label world argv rc out err want got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world argv rc out err want; do
-    [[ -n "$label$world$argv$rc$out$err$want" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world argv rc out err want <<<"$row"
+    for field in "$label" "$world" "$argv" "$rc" "$out" "$err" "$want"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $defaults $world
@@ -659,12 +664,14 @@ run_table() {
       continue
     fi
     got="$(run "$argv")"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err") $want" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 finish() {

--- a/skills/second-opinion/tests/option-parsing.test.sh
+++ b/skills/second-opinion/tests/option-parsing.test.sh
@@ -16,20 +16,20 @@ NONE="calls=0 files=- home=absent tmp=0 dirty=-"
 ROWS="
 dash-leading --prompt and --cwd in the = form are accepted and the prompt reaches the CLI intact|cwd:dash|quick --prompt=-dash-prompt.txt --cwd=-dashcwd|0|prompt-echoed|header:quick|calls=1 files=- home=absent tmp=0 dirty=-
 --timeout followed by --output does not swallow it: a parse error, and the caller's file at that path is untouched|plant:report|review --timeout --output @out|1|-|requires:--timeout|calls=0 files=out=mine home=absent tmp=0 dirty=-
---prompt followed by a flag is rejected||review --prompt --range HEAD|1|-|requires:--prompt|$NONE
---prompt at the end of argv is rejected||review --prompt|1|-|requires:--prompt|$NONE
---output followed by a flag is rejected||review --output --range HEAD|1|-|requires:--output|$NONE
---output at the end of argv is rejected||review --output|1|-|requires:--output|$NONE
---target followed by a flag is rejected||review --target --range HEAD|1|-|requires:--target|$NONE
---target at the end of argv is rejected||review --target|1|-|requires:--target|$NONE
---provider followed by a flag is rejected||review --provider --range HEAD|1|-|requires:--provider|$NONE
---provider at the end of argv is rejected||review --provider|1|-|requires:--provider|$NONE
---range followed by a flag is rejected||review --range --range HEAD|1|-|requires:--range|$NONE
---range at the end of argv is rejected||review --range|1|-|requires:--range|$NONE
---cwd followed by a flag is rejected||review --cwd --range HEAD|1|-|requires:--cwd|$NONE
---cwd at the end of argv is rejected||review --cwd|1|-|requires:--cwd|$NONE
---timeout followed by a flag is rejected||review --timeout --range HEAD|1|-|requires:--timeout|$NONE
---timeout at the end of argv is rejected||review --timeout|1|-|requires:--timeout|$NONE
+--prompt followed by a flag is rejected|-|review --prompt --range HEAD|1|-|requires:--prompt|$NONE
+--prompt at the end of argv is rejected|-|review --prompt|1|-|requires:--prompt|$NONE
+--output followed by a flag is rejected|-|review --output --range HEAD|1|-|requires:--output|$NONE
+--output at the end of argv is rejected|-|review --output|1|-|requires:--output|$NONE
+--target followed by a flag is rejected|-|review --target --range HEAD|1|-|requires:--target|$NONE
+--target at the end of argv is rejected|-|review --target|1|-|requires:--target|$NONE
+--provider followed by a flag is rejected|-|review --provider --range HEAD|1|-|requires:--provider|$NONE
+--provider at the end of argv is rejected|-|review --provider|1|-|requires:--provider|$NONE
+--range followed by a flag is rejected|-|review --range --range HEAD|1|-|requires:--range|$NONE
+--range at the end of argv is rejected|-|review --range|1|-|requires:--range|$NONE
+--cwd followed by a flag is rejected|-|review --cwd --range HEAD|1|-|requires:--cwd|$NONE
+--cwd at the end of argv is rejected|-|review --cwd|1|-|requires:--cwd|$NONE
+--timeout followed by a flag is rejected|-|review --timeout --range HEAD|1|-|requires:--timeout|$NONE
+--timeout at the end of argv is rejected|-|review --timeout|1|-|requires:--timeout|$NONE
 "
 
 run_table "option parsing" "$DEFAULTS" "$ROWS"

--- a/skills/second-opinion/tests/startup.test.sh
+++ b/skills/second-opinion/tests/startup.test.sh
@@ -162,20 +162,26 @@ err_word() {
 }
 
 run_table() {
-  local title="$1" rows="$2" n=0 label world argv rc out err got
+  local title="$1" rows="$2" n=0 label world argv rc out err got row field
   echo "=== $title ==="
-  while IFS='|' read -r label world argv rc out err; do
-    [[ -n "$label$world$argv$rc$out$err" ]] || continue
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    IFS='|' read -r label world argv rc out err <<<"$row"
+    for field in "$label" "$world" "$argv" "$rc" "$out" "$err"; do
+      [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
     n=$((n + 1))
     # shellcheck disable=SC2086
     build "row-$n" $world
     got="$(run "$argv")"
-    if [[ "${PROBE:-}" == 1 ]]; then
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${SECOND_OPINION_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
     assert_eq "$got" "rc=$rc out=$out err=$(err_text "$err")" "$label"
   done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 }
 
 run_table "the startup" "\

--- a/skills/second-opinion/tests/target-selection.test.sh
+++ b/skills/second-opinion/tests/target-selection.test.sh
@@ -22,7 +22,7 @@ NONE="calls=claude:0,codex:0,extra:0 art=- files=-"
 
 # label|world|command|rc|out|err|calls art files
 ROWS="
-the default count is one opinion, the first eligible in priority order; none is the declared absence of a model, not a typo||review|0|<out>|single:codex:review:none written|calls=claude:0,codex:1,extra:0 art=external-codex/$OWN files=out
+the default count is one opinion, the first eligible in priority order; none is the declared absence of a model, not a typo|-|review|0|<out>|single:codex:review:none written|calls=claude:0,codex:1,extra:0 art=external-codex/$OWN files=out
 the session's own model is skipped and the next distinct model taken|current:codex|review|0|<out>|same:codex:codex single:claude:review:codex written|calls=claude:1,codex:0,extra:0 art=external-claude/$OWN files=out
 a forced target equal to the session model is refused with no artifact and no CLI spend, naming what the roster would pick|current:claude target:claude count:2|review|1|-|same:claude:claude refused:claude:1 hint:claude:codex|$NONE
 a --target flag refused the same way carries no settings hint|current:codex|review --target codex|1|-|same:codex:codex refused:codex:1|$NONE


### PR DESCRIPTION
Closes the rendering hatch in the second-opinion table libs, the way #2344 closed it in the worktree suites. `tests/lib/stub-cli-world.bash`, `tests/lib/roster-world.bash` and `tests/lib/lane-world.bash`, and `startup.test.sh` with its own loop, printed every row under `PROBE=1` with none asserted, skipped a row with an empty field in silence, and their `finish` exited 0 on `pass: 0 fail: 0`; `tools/guard` and the CI shard run the suites under the ambient environment, so an exported `PROBE=1` zeroed eleven suites' coverage while they reported success.

The variable is now `SECOND_OPINION_TABLE_PROBE`; the row loop reads the raw line and refuses a row with an empty field (exit 1, naming the row); a table that asserted no row exits 2. The rows whose world was the defaults (one each in `artifact-home`, `cli-failure-gate` and `target-selection`, fourteen in `option-parsing`) spell it as the bare word `-`, which `roster-world` and `lane-world` gained (`stub-cli-world` had it).

Same-defect sibling of #2344, so no issue; `startup.test.sh` is folded in as the same defect in the same package.

The tracked renders under `.agents` are replayed with `patch`; the inventory is unchanged.

## Recorded kills

One suite per lib, run from the worktree with the probe exported (`mutants-ph.txt` in the lane's scratchpad):

| Lib | Suite | `SECOND_OPINION_TABLE_PROBE=1` | `PROBE=1` |
|---|---|---|---|
| stub-cli-world | cli-failure-gate | exit 2, `no row was asserted` | 13/13 |
| roster-world | target-selection | exit 2 | 37/37 |
| lane-world | lane-scratch-durability | exit 2 | 30/30 |
| (own loop) | startup | exit 2 | 8/8 |

Every table under `skills/second-opinion/tests` green from the worktree: artifact-home 20, cli-failure-gate 13, harness-identity 42, lane-scratch-durability 30, option-parsing 16, output-clearing 26, response-gate 15, review-prompt 9, review-union 12, startup 8, target-selection 37.

KEN-1241

https://claude.ai/code/session_019UCmT5EBWiug2xKdtXNpGv
