### PR TITLE
test(KEN-1241): kendex-core refusals and records pinned [no-changelog]

### DIFF
--- a/crates/core/src/author/import/tests.rs
+++ b/crates/core/src/author/import/tests.rs
@@ -362,7 +362,7 @@ fn every_refusal_names_its_cause_and_the_folder_shows_what_it_left() {
                 said: Said::Around {
                     head: format!(
                         "writing {} failed (",
-                        target.join("skills/blocked/here/SKILL.md").display()
+                        target.join("skills").join("blocked/here").join("SKILL.md").display()
                     ),
                     tail: "). These are partly or wholly in the folder now: skills/mine, skills/blocked/here. Remove them before importing again.".to_owned(),
                 },
@@ -396,7 +396,7 @@ fn every_refusal_names_its_cause_and_the_folder_shows_what_it_left() {
                 ],
                 said: Said::Whole(format!(
                     "'mine' and 'mine/nested' both land at {} — give one of them a different destination name",
-                    target.join("skills/mine").display()
+                    target.join("skills").join("mine").display()
                 )),
                 leaves: vec![("skills", None)],
             }
@@ -417,7 +417,7 @@ fn every_refusal_names_its_cause_and_the_folder_shows_what_it_left() {
                 ],
                 said: Said::Whole(format!(
                     "{} already holds different bytes than 'stray' — rename the import destination or remove the existing file first",
-                    target.join("skills/stray").display()
+                    target.join("skills").join("stray").display()
                 )),
                 leaves: vec![
                     ("skills/mine", None),

--- a/crates/core/src/author/import/tests.rs
+++ b/crates/core/src/author/import/tests.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use super::*;
 use crate::env::FakeOs;
+use crate::error::CoreError;
 
 use crate::lock::{Lock, LockEntry};
 use crate::manifest::Method;
@@ -242,61 +243,6 @@ fn own_and_unmanaged_content_import_without_a_licence_question() {
     assert!(target.join("skills/stray/SKILL.md").exists());
 }
 
-/// A write that stops part-way leaves bytes behind, and the copy is not
-/// a transaction. The error has to name them: the next attempt reads
-/// them as somebody else's and tells the person to remove a file they
-/// never put there.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_write_that_stops_part_way_names_what_reached_the_folder() {
-    let (tmp, env, scope) = seeded();
-    let scopes = [scope];
-    let target = target(&env, &tmp, "mine-interrupted");
-    // A regular file where the second selection's tree needs a
-    // directory. Nothing sits at the destination itself, so this is not a
-    // refusal pass one can make; the write is what meets it.
-    fs::create_dir_all(target.join("skills")).unwrap();
-    fs::write(target.join("skills/blocked"), "not a directory").unwrap();
-
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut second = selection(find(&candidates, "stray"), false);
-    second.destination = "blocked/here".to_owned();
-    let selections = [selection(find(&candidates, "mine"), false), second];
-
-    let message = apply(&env, &scopes, &target, &selections)
-        .unwrap_err()
-        .to_string();
-    assert!(
-        message.contains("skills/blocked/here"),
-        "the error names the destination that failed: {message}"
-    );
-    assert!(
-        message.contains("skills/mine"),
-        "and what landed before it: {message}"
-    );
-    assert!(
-        message.contains("Remove them before importing again"),
-        "{message}"
-    );
-    // What the copy leaves, pinned rather than assumed: the selections
-    // before the failure are on disk, the one that failed is not, and
-    // nothing was rolled back. Per-package atomicity would need a staging
-    // directory.
-    assert!(
-        target.join("skills/mine/SKILL.md").is_file(),
-        "the earlier selection really is on disk"
-    );
-    assert!(
-        !target.join("skills/blocked/here").exists(),
-        "the selection that failed wrote nothing"
-    );
-    assert_eq!(
-        fs::read_to_string(target.join("skills/blocked")).unwrap(),
-        "not a directory",
-        "and what was in the way is untouched"
-    );
-}
-
 /// Two candidates with nothing to do with each other, one of them given
 /// a destination spelled under the other's. A nested destination name is
 /// ordinary and says nothing by itself about where the bytes land: these
@@ -331,143 +277,315 @@ fn a_nested_pair_whose_trees_do_not_meet_is_copied_whole() {
     );
 }
 
-/// Two legal destination names whose trees meet in a directory without
-/// sharing a single filename. `mine` carries `nested/notes.md` and the
-/// second selection is destined for `mine/nested`, so neither writes a
-/// path the other writes and one skill's file would still end up sitting
-/// in the other skill's directory, with the outcome reporting both as
-/// copied cleanly.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn two_selections_whose_trees_meet_refuse_and_write_nothing() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    let nested = root
-        .join(crate::source::LOCAL_SOURCE_DIR)
-        .join("skills/mine/nested");
-    fs::create_dir_all(&nested).unwrap();
-    fs::write(nested.join("notes.md"), "the parent tree's own file").unwrap();
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-overlap");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut under = selection(find(&candidates, "stray"), false);
-    under.destination = "mine/nested".to_owned();
-    let selections = [selection(find(&candidates, "mine"), false), under];
-
-    let message = apply(&env, &scopes, &target, &selections)
-        .unwrap_err()
-        .to_string();
-    assert!(message.contains("both land at"), "{message}");
-    assert!(message.contains("mine/nested"), "it names both: {message}");
-    assert!(
-        !target.join("skills").exists(),
-        "a refused apply writes nothing at all"
-    );
+/// What a refusal says. Every refusal `apply` makes is
+/// `CoreError::Authoring { message }`, so the words are the only thing
+/// telling the classes apart (a typed discriminant would be a production
+/// change): a message is pinned whole where this module composes every
+/// word of it, and by its head and tail where an OS error sits in the
+/// middle.
+enum Said {
+    Whole(String),
+    Around { head: String, tail: String },
 }
 
-/// Every refusal is decided before the first byte is written, so a
-/// second selection that cannot land takes the first one with it. Without
-/// that the import is half-done and there is nothing to say which half.
+/// One planted conflict: the selections that meet it, what the refusal
+/// says, and what the folder holds afterwards — `Some(bytes)` a file with
+/// exactly those bytes, `None` a path that does not exist.
+struct Refused {
+    selections: Vec<ImportSelection>,
+    said: Said,
+    leaves: Vec<(&'static str, Option<String>)>,
+}
+
+/// Every refusal `apply` makes, one row per planted conflict.
+///
+/// All but the first are decided before the first byte is written, so a
+/// later selection that cannot land takes the earlier one with it and the
+/// folder is untouched; without that the import is half-done and there
+/// is nothing to say which half. The first is the write that stops
+/// part-way: the copy is not a transaction, so what reached the folder is
+/// named, and pinned rather than assumed — the selections before the
+/// failure are on disk, the one that failed is not, and what was in the
+/// way is untouched (per-package atomicity would need a staging
+/// directory). The next attempt would otherwise read those bytes as
+/// somebody else's and tell the person to remove a file they never put
+/// there.
+///
+/// The rename rows: bytes no name can be written into — no frontmatter,
+/// or not text at all, which a skill's tree read as bytes never asked —
+/// refuse the whole apply rather than land a copy that still answers to
+/// the old name. The bidi row is the refusal spelling the name it quotes
+/// rather than replaying it: a candidate name is read off a directory on
+/// disk, so it can hold anything a filesystem accepts, and the inventory
+/// keeps illegal spellings on purpose so the wizard can offer them under
+/// a legal destination. U+202E is the override that would let one
+/// package read as another, and unlike a control character it is a
+/// filename every platform this runs on will create.
 #[test]
-#[allow(clippy::unwrap_used)]
-fn a_refusal_on_a_later_selection_writes_nothing_for_the_earlier_one() {
-    let (tmp, env, scope) = seeded();
-    let scopes = [scope];
-    let target = target(&env, &tmp, "mine-partial");
-    // The second selection's destination is occupied by other bytes.
-    skill(
-        &target.join("skills"),
-        "stray",
-        "different bytes already here",
-    );
-    let candidates = inventory(&env, &scopes).unwrap();
-    let selections = [
-        selection(find(&candidates, "mine"), false),
-        selection(find(&candidates, "stray"), false),
+#[allow(
+    clippy::unwrap_used,
+    clippy::too_many_lines,
+    reason = "one row per refusal"
+)]
+fn every_refusal_names_its_cause_and_the_folder_shows_what_it_left() {
+    fn renamed(candidates: &[ImportCandidate], name: &str, destination: &str) -> ImportSelection {
+        let mut chosen = selection(find(candidates, name), false);
+        chosen.destination = destination.to_owned();
+        chosen
+    }
+    fn uncarried(shown: &str, destination: &str, problem: &str) -> Said {
+        Said::Whole(format!(
+            "'{shown}' cannot be imported as '{destination}' — {problem} in 'SKILL.md', so the copy would still call itself '{shown}'. Import it under its own name: a copy is renamed only where the file it comes from carries a frontmatter block a name can be written into."
+        ))
+    }
+    type Row = (&'static str, fn(&Env, &Scope, &Path) -> Refused);
+    let rows: [Row; 8] = [
+        ("a write that stops part-way", |env, scope, target| {
+            // A regular file where the second selection's tree needs a
+            // directory. Nothing sits at the destination itself, so this
+            // is not a refusal pass one can make; the write is what meets
+            // it.
+            fs::create_dir_all(target.join("skills")).unwrap();
+            fs::write(target.join("skills/blocked"), "not a directory").unwrap();
+            let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+            let Scope::Project { root } = scope else {
+                unreachable!()
+            };
+            let mine = root
+                .join(crate::source::LOCAL_SOURCE_DIR)
+                .join("skills/mine/SKILL.md");
+            Refused {
+                selections: vec![
+                    selection(find(&candidates, "mine"), false),
+                    renamed(&candidates, "stray", "blocked/here"),
+                ],
+                said: Said::Around {
+                    head: format!(
+                        "writing {} failed (",
+                        target.join("skills/blocked/here/SKILL.md").display()
+                    ),
+                    tail: "). These are partly or wholly in the folder now: skills/mine, skills/blocked/here. Remove them before importing again.".to_owned(),
+                },
+                leaves: vec![
+                    ("skills/mine/SKILL.md", Some(fs::read_to_string(mine).unwrap())),
+                    ("skills/blocked/here", None),
+                    ("skills/blocked", Some("not a directory".to_owned())),
+                ],
+            }
+        }),
+        // Two legal destination names whose trees meet in a directory
+        // without sharing a single filename: `mine` carries
+        // `nested/notes.md` and the second selection is destined for
+        // `mine/nested`, so neither writes a path the other writes and one
+        // skill's file would still end up sitting in the other skill's
+        // directory, with the outcome reporting both as copied cleanly.
+        ("two selections whose trees meet", |env, scope, target| {
+            let Scope::Project { root } = scope else {
+                unreachable!()
+            };
+            let nested = root
+                .join(crate::source::LOCAL_SOURCE_DIR)
+                .join("skills/mine/nested");
+            fs::create_dir_all(&nested).unwrap();
+            fs::write(nested.join("notes.md"), "the parent tree's own file").unwrap();
+            let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+            Refused {
+                selections: vec![
+                    selection(find(&candidates, "mine"), false),
+                    renamed(&candidates, "stray", "mine/nested"),
+                ],
+                said: Said::Whole(format!(
+                    "'mine' and 'mine/nested' both land at {} — give one of them a different destination name",
+                    target.join("skills/mine").display()
+                )),
+                leaves: vec![("skills", None)],
+            }
+        }),
+        (
+            "a later selection's destination holding different bytes",
+            |env, scope, target| {
+                skill(
+                    &target.join("skills"),
+                    "stray",
+                    "different bytes already here",
+                );
+                let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+                Refused {
+                selections: vec![
+                    selection(find(&candidates, "mine"), false),
+                    selection(find(&candidates, "stray"), false),
+                ],
+                said: Said::Whole(format!(
+                    "{} already holds different bytes than 'stray' — rename the import destination or remove the existing file first",
+                    target.join("skills/stray").display()
+                )),
+                leaves: vec![
+                    ("skills/mine", None),
+                    (
+                        "skills/stray/SKILL.md",
+                        Some("---\nname: stray\ndescription: about stray\n---\ndifferent bytes already here\n".to_owned()),
+                    ),
+                ],
+            }
+            },
+        ),
+        // Refused before the copy, naming both, because the sibling
+        // occupies the destination on a case-insensitive filesystem — where
+        // the destination already exists under the sibling's spelling, so
+        // only the sibling is asked after.
+        (
+            "a sibling whose name folds to the destination's",
+            |env, scope, target| {
+                skill(&target.join("skills"), "MINE", "upper-case sibling");
+                let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+                Refused {
+                selections: vec![selection(find(&candidates, "mine"), false)],
+                said: Said::Whole(
+                    "'mine' would collide with existing 'MINE' on a case-insensitive filesystem — pick another destination name".to_owned(),
+                ),
+                leaves: vec![(
+                    "skills/MINE/SKILL.md",
+                    Some("---\nname: MINE\ndescription: about MINE\n---\nupper-case sibling\n".to_owned()),
+                )],
+            }
+            },
+        ),
+        // The preview goes stale: the local source's bytes change under it.
+        (
+            "bytes that changed since the preview",
+            |env, scope, _target| {
+                let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+                let Scope::Project { root } = scope else {
+                    unreachable!()
+                };
+                fs::write(
+                    root.join(crate::source::LOCAL_SOURCE_DIR)
+                        .join("skills/mine/SKILL.md"),
+                    "---\nname: mine\ndescription: about mine\n---\nedited since preview\n",
+                )
+                .unwrap();
+                Refused {
+                selections: vec![selection(find(&candidates, "mine"), false)],
+                said: Said::Whole(
+                    "the bytes of skill 'mine' changed since the preview — re-open the import to re-preview".to_owned(),
+                ),
+                leaves: vec![("skills", None)],
+            }
+            },
+        ),
+        (
+            "a rename of a tree with no frontmatter",
+            |env, scope, _target| {
+                let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+                Refused {
+                    selections: vec![
+                        selection(find(&candidates, "mine"), false),
+                        renamed(&candidates, "bare", "clothed"),
+                    ],
+                    said: uncarried("bare", "clothed", "it has no frontmatter"),
+                    leaves: vec![("skills", None)],
+                }
+            },
+        ),
+        (
+            "a rename of bytes that are not text",
+            |env, scope, _target| {
+                let Scope::Project { root } = scope else {
+                    unreachable!()
+                };
+                let dir = root.join(".claude/skills/binary");
+                fs::create_dir_all(&dir).unwrap();
+                fs::write(dir.join("SKILL.md"), [0xff, 0xfe, b'\n']).unwrap();
+                let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+                Refused {
+                    selections: vec![
+                        selection(find(&candidates, "mine"), false),
+                        renamed(&candidates, "binary", "textual"),
+                    ],
+                    said: uncarried("binary", "textual", "the file is not text"),
+                    leaves: vec![("skills", None)],
+                }
+            },
+        ),
+        (
+            "a rename quoting a name that carries a bidi override",
+            |env, scope, _target| {
+                let Scope::Project { root } = scope else {
+                    unreachable!()
+                };
+                raw_skill(
+                    &root.join(".claude/skills"),
+                    "ba\u{202e}re",
+                    "No frontmatter at all.\n",
+                );
+                let candidates = inventory(env, std::slice::from_ref(scope)).unwrap();
+                Refused {
+                    selections: vec![renamed(&candidates, "ba\u{202e}re", "clothed")],
+                    said: uncarried("ba\\u{202e}re", "clothed", "it has no frontmatter"),
+                    leaves: vec![("skills", None)],
+                }
+            },
+        ),
     ];
-
-    let refused = apply(&env, &scopes, &target, &selections);
-    let message = refused.unwrap_err().to_string();
-    assert!(message.contains("different bytes"), "{message}");
-    assert!(
-        !target.join("skills/mine").exists(),
-        "the selection before the refusal must not have been written"
-    );
-    assert!(
-        fs::read_to_string(target.join("skills/stray/SKILL.md"))
-            .unwrap()
-            .contains("different bytes already here"),
-        "the occupied destination is untouched"
-    );
+    for (label, plant) in rows {
+        let (tmp, env, scope) = seeded();
+        let target = target(&env, &tmp, "mine-refused");
+        let refused = plant(&env, &scope, &target);
+        let scopes = [scope];
+        let error = apply(&env, &scopes, &target, &refused.selections).unwrap_err();
+        let CoreError::Authoring { message } = &error else {
+            panic!("{label}: {error:?}");
+        };
+        match &refused.said {
+            Said::Whole(whole) => assert_eq!(message, whole, "{label}"),
+            Said::Around { head, tail } => assert!(
+                message.starts_with(head.as_str()) && message.ends_with(tail.as_str()),
+                "{label}: {message}"
+            ),
+        }
+        for (rel, bytes) in &refused.leaves {
+            let at = target.join(rel);
+            match bytes {
+                Some(bytes) => {
+                    assert_eq!(&fs::read_to_string(&at).unwrap(), bytes, "{label}: {rel}")
+                }
+                None => assert!(at.symlink_metadata().is_err(), "{label}: {rel} exists"),
+            }
+        }
+    }
 }
 
+/// The preview's hash is the only thing refusing a stale selection: a
+/// fresh inventory carries the current one and the copy proceeds, landing
+/// the bytes as they are now.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_destination_holding_different_bytes_is_a_refusal_naming_it() {
-    let (tmp, env, scope) = seeded();
-    let scopes = [scope];
-    let target = target(&env, &tmp, "mine-clash");
-    skill(
-        &target.join("skills"),
-        "mine",
-        "different bytes already here",
-    );
-    let candidates = inventory(&env, &scopes).unwrap();
-    let refused = apply(
-        &env,
-        &scopes,
-        &target,
-        &[selection(find(&candidates, "mine"), false)],
-    );
-    let message = refused.unwrap_err().to_string();
-    assert!(message.contains("different bytes"), "{message}");
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_case_folding_sibling_refuses_before_the_copy() {
-    let (tmp, env, scope) = seeded();
-    let scopes = [scope];
-    let target = target(&env, &tmp, "mine-fold");
-    skill(&target.join("skills"), "MINE", "upper-case sibling");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let refused = apply(
-        &env,
-        &scopes,
-        &target,
-        &[selection(find(&candidates, "mine"), false)],
-    );
-    let message = refused.unwrap_err().to_string();
-    assert!(message.contains("case-insensitive"), "{message}");
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_stale_hash_refuses_instead_of_copying_moved_bytes() {
+fn a_fresh_preview_after_a_stale_refusal_copies_the_bytes_as_they_are_now() {
     let (tmp, env, scope) = seeded();
     let scopes = [scope.clone()];
     let target = target(&env, &tmp, "mine-stale");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut chosen = selection(find(&candidates, "mine"), false);
-    // The preview goes stale: the local source's bytes change under it.
+    let mut chosen = selection(find(&inventory(&env, &scopes).unwrap(), "mine"), false);
     let Scope::Project { root } = &scope else {
         unreachable!()
     };
+    let edited = "---\nname: mine\ndescription: about mine\n---\nedited since preview\n";
     fs::write(
         root.join(crate::source::LOCAL_SOURCE_DIR)
             .join("skills/mine/SKILL.md"),
-        "---\nname: mine\ndescription: about mine\n---\nedited since preview\n",
+        edited,
     )
     .unwrap();
-    let refused = apply(&env, &scopes, &target, std::slice::from_ref(&chosen));
-    let message = refused.unwrap_err().to_string();
-    assert!(message.contains("changed since the preview"), "{message}");
-    // Re-previewing picks up the current hash and the copy proceeds.
-    let fresh = inventory(&env, &scopes).unwrap();
-    chosen.hash = find(&fresh, "mine").origins[0].hash.clone();
-    apply(&env, &scopes, &target, &[chosen]).unwrap();
+    apply(&env, &scopes, &target, std::slice::from_ref(&chosen)).unwrap_err();
+    chosen.hash = find(&inventory(&env, &scopes).unwrap(), "mine").origins[0]
+        .hash
+        .clone();
+
+    let outcome = apply(&env, &scopes, &target, &[chosen]).unwrap();
+    assert_eq!(outcome.written, ["skills/mine"]);
+    assert_eq!(
+        fs::read_to_string(target.join("skills/mine/SKILL.md")).unwrap(),
+        edited
+    );
 }
 
 mod format;

--- a/crates/core/src/author/import/tests/format.rs
+++ b/crates/core/src/author/import/tests/format.rs
@@ -12,6 +12,7 @@ use std::fs;
 
 use super::{entry, file_item, find, seeded, target};
 use crate::author::import::{ImportSelection, apply, inventory};
+use crate::error::CoreError;
 use crate::lock;
 use crate::model::{HarnessId, ItemKind, Scope};
 
@@ -29,78 +30,110 @@ fn selection(name: &str, destination: &str) -> ImportSelection {
     }
 }
 
-/// The unmanaged door, which is the silent one: both names refused before
-/// a byte is written, and the markdown agent beside it still offered.
+/// One row per door bytes that are not the markdown a catalog stores can
+/// arrive at: the unmanaged scan, which is the silent one (Codex keeps
+/// its agents as TOML); a file parked at `.claude/agents/<name>.md`,
+/// offered by its extension alone, whose bytes are not text — the reason
+/// says which of the two it is; and a local catalog already holding TOML
+/// at `agents/<name>.md`, judged by the same rule as any other origin
+/// because every read goes through `offered`, so re-importing from it
+/// cannot carry the breakage into another package.
+///
+/// The candidate is listed, so the person sees kendex found it, with no
+/// hash to select and the reason where the hash would be, and the place
+/// is a path and nothing else. Apply refuses under the candidate's own
+/// name, where a copy would land the bytes in a `.md` slot the catalog
+/// check calls clean, and under another one, where the rename would
+/// otherwise refuse only at apply with no way to finish it — the same
+/// words both times, and nothing written. The markdown agent in the same
+/// scan is untouched: this excludes a format, not a kind.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn an_agent_in_another_format_is_not_offered_under_either_name() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    file_item(
-        &root.join(".codex/agents"),
-        "codexer.toml",
-        "name = \"codexer\"\ndescription = \"about codexer\"\n",
-    );
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-codex");
-    let candidates = inventory(&env, &scopes).unwrap();
+fn bytes_a_catalog_cannot_store_are_listed_without_a_hash_and_refused_under_either_name() {
+    type Row<'a> = (&'a str, &'a str, &'a [u8], Option<&'a str>, &'a str);
+    let local = format!("{}/agents", crate::source::LOCAL_SOURCE_DIR);
+    let rows: [Row<'_>; 3] = [
+        (
+            ".codex/agents",
+            "codexer.toml",
+            b"name = \"codexer\"\ndescription = \"about codexer\"\n",
+            None,
+            "it has no frontmatter, and a catalog stores an agent as markdown",
+        ),
+        (
+            ".claude/agents",
+            "binary.md",
+            &[0xff, 0xfe, b'\n'],
+            None,
+            "the file is not text, and a catalog stores an agent as markdown",
+        ),
+        (
+            local.as_str(),
+            "poisoned.md",
+            b"name = \"poisoned\"\ndescription = \"about poisoned\"\n",
+            Some("local"),
+            "it has no frontmatter, and a catalog stores an agent as markdown",
+        ),
+    ];
+    for (dir, file, bytes, locked, problem) in rows {
+        let (tmp, env, scope) = seeded();
+        let Scope::Project { root } = &scope else {
+            unreachable!()
+        };
+        let name = file.split_once('.').unwrap().0;
+        fs::create_dir_all(root.join(dir)).unwrap();
+        fs::write(root.join(dir).join(file), bytes).unwrap();
+        if let Some(source) = locked {
+            let path = lock::lock_path(&env, &scope);
+            let mut held = lock::load(&path).unwrap();
+            held.entries.insert(
+                lock::entry_key(ItemKind::Agent, name, HarnessId::Claude),
+                entry(ItemKind::Agent, name, source, source),
+            );
+            lock::save(&path, &held).unwrap();
+        }
+        let scopes = [scope.clone()];
+        let target = target(&env, &tmp, "mine-unstorable");
+        let candidates = inventory(&env, &scopes).unwrap();
 
-    // Listed, so the person sees kendex found it, with no hash to select
-    // and the reason where the hash would be.
-    let codexer = find(&candidates, "codexer");
-    assert!(
-        codexer.origins.iter().all(|origin| origin.hash.is_empty()),
-        "nothing selectable: {:?}",
-        codexer.origins
-    );
-    let refused = &codexer.origins[0];
-    assert!(
-        refused.locations[0].contains("codexer.toml"),
-        "the place is a path and nothing else: {:?}",
-        refused.locations
-    );
-    let problem = refused.problem.as_deref().unwrap_or_default();
-    assert!(problem.contains("it has no frontmatter"), "{problem}");
-    assert!(
-        problem.contains("a catalog stores an agent as markdown"),
-        "{problem}"
-    );
-
-    // The markdown agent in the same scan is untouched by the rule: this
-    // excludes a format, not a kind.
-    assert!(
-        !find(&candidates, "drifter").origins[0].hash.is_empty(),
-        "{:?}",
-        find(&candidates, "drifter").origins
-    );
-
-    // Both paths: under its own name, where a copy would land TOML in a
-    // `.md` slot the catalog check calls clean, and under another one,
-    // where the rename would refuse at apply.
-    for chosen in [
-        selection("codexer", "codexer"),
-        selection("codexer", "settled"),
-    ] {
-        let destination = chosen.destination.clone();
-        let message = apply(&env, &scopes, &target, &[chosen])
-            .unwrap_err()
-            .to_string();
-        assert!(
-            message.contains("has no bytes kendex can import"),
-            "{destination}: {message}"
+        let place = crate::paths::slashed(&root.join(dir).join(file));
+        let listed: Vec<(Vec<&str>, &str, Option<&str>)> = find(&candidates, name)
+            .origins
+            .iter()
+            .map(|origin| {
+                (
+                    origin.locations.iter().map(String::as_str).collect(),
+                    origin.hash.as_str(),
+                    origin.problem.as_deref(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            listed,
+            [(vec![place.as_str()], "", Some(problem))],
+            "{file}"
         );
-        assert!(message.contains("codexer.toml"), "{destination}: {message}");
         assert!(
-            message.contains("it has no frontmatter"),
-            "and why, rather than a change nobody made — {destination}: {message}"
+            !find(&candidates, "drifter").origins[0].hash.is_empty(),
+            "{file}: the markdown agent beside it is still offered"
+        );
+
+        for destination in [name, "elsewhere"] {
+            let error = apply(&env, &scopes, &target, &[selection(name, destination)]).unwrap_err();
+            let CoreError::Authoring { message } = &error else {
+                panic!("{file} as {destination}: {error:?}");
+            };
+            assert_eq!(
+                message,
+                &format!("agent '{name}' has no bytes kendex can import: {place} — {problem}"),
+                "{file} as {destination}"
+            );
+        }
+        assert!(
+            target.join("agents").symlink_metadata().is_err(),
+            "{file}: a refused apply writes nothing at all"
         );
     }
-    assert!(
-        !target.join("agents").exists(),
-        "a refused apply writes nothing at all"
-    );
 }
 
 /// The other door: an agent installs as the file its harness reads, so the
@@ -140,10 +173,10 @@ fn the_edited_copy_of_a_marketplace_agent_is_judged_by_the_same_rule() {
         .iter()
         .partition(|origin| !origin.hash.is_empty());
     assert_eq!(offered.len(), 1, "{:?}", agentic.origins);
-    assert!(
-        offered[0].locations[0].contains("agents/agentic.md"),
-        "the catalog's own markdown is what stays offerable: {:?}",
-        offered[0].locations
+    assert_eq!(
+        offered[0].locations,
+        ["cat:agents/agentic.md"],
+        "the catalog's own markdown is what stays offerable"
     );
     // The TOML is claimed twice — as the edited copy of the marketplace
     // agent, and by the unmanaged scan of an install the lock does not
@@ -158,18 +191,15 @@ fn the_edited_copy_of_a_marketplace_agent_is_judged_by_the_same_rule() {
         "{:?}",
         agentic.origins
     );
-    assert!(
-        refused[0].locations[0].contains("agentic.toml"),
-        "{:?}",
-        refused[0].locations
+    assert_eq!(
+        refused[0].locations,
+        [crate::paths::slashed(
+            &root.join(".codex/agents/agentic.toml")
+        )]
     );
-    assert!(
-        refused[0]
-            .problem
-            .as_deref()
-            .is_some_and(|problem| problem.contains("a catalog stores an agent as markdown")),
-        "{:?}",
-        refused[0].problem
+    assert_eq!(
+        refused[0].problem.as_deref(),
+        Some("it has no frontmatter, and a catalog stores an agent as markdown")
     );
 
     // And the markdown half really does import, so the rule took away the
@@ -181,10 +211,9 @@ fn the_edited_copy_of_a_marketplace_agent_is_judged_by_the_same_rule() {
         ..selection("agentic", "agentic")
     };
     apply(&env, &scopes, &target, &[chosen]).unwrap();
-    assert!(
-        fs::read_to_string(target.join("agents/agentic.md"))
-            .unwrap()
-            .contains("name: agentic"),
+    assert_eq!(
+        fs::read_to_string(target.join("agents/agentic.md")).unwrap(),
+        "---\nname: agentic\ndescription: about agentic\n---\nAgent body.\n"
     );
 
     // A hash matching nothing, on a candidate that still holds a usable
@@ -196,125 +225,12 @@ fn the_edited_copy_of_a_marketplace_agent_is_judged_by_the_same_rule() {
         license_confirmed: true,
         ..selection("agentic", "agentic")
     };
-    let message = apply(&env, &scopes, &target, &[stale])
-        .unwrap_err()
-        .to_string();
-    assert!(message.contains("changed since the preview"), "{message}");
-    assert!(!message.contains("agentic.toml"), "{message}");
-    assert!(
-        !message.contains("has no bytes kendex can import"),
-        "{message}"
-    );
-}
-
-/// Bytes that are not text carry no frontmatter either, and the reason
-/// says which of the two it is. A file parked at `.claude/agents/<name>.md`
-/// is offered by its extension alone, so this is the shape that would
-/// otherwise land raw bytes in a catalog under a name the check calls
-/// clean.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_agent_whose_bytes_are_not_text_is_not_offered() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
+    let error = apply(&env, &scopes, &target, &[stale]).unwrap_err();
+    let CoreError::Authoring { message } = &error else {
+        panic!("{error:?}");
     };
-    let dir = root.join(".claude/agents");
-    fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("binary.md"), [0xff, 0xfe, b'\n']).unwrap();
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-binary-agent");
-    let candidates = inventory(&env, &scopes).unwrap();
-
-    let binary = find(&candidates, "binary");
-    assert!(
-        binary.origins.iter().all(|origin| origin.hash.is_empty()),
-        "nothing selectable: {:?}",
-        binary.origins
-    );
-    assert!(
-        binary.origins[0]
-            .problem
-            .as_deref()
-            .is_some_and(|problem| problem.contains("the file is not text")),
-        "{:?}",
-        binary.origins[0].problem
-    );
-
-    let message = apply(&env, &scopes, &target, &[selection("binary", "binary")])
-        .unwrap_err()
-        .to_string();
-    assert!(
-        message.contains("has no bytes kendex can import"),
-        "{message}"
-    );
-    assert!(message.contains("binary.md"), "{message}");
-    assert!(message.contains("the file is not text"), "{message}");
-    assert!(!target.join("agents").exists());
-}
-
-/// A local catalog can already hold TOML at `agents/<name>.md`, and
-/// re-importing from it would carry the breakage into another package.
-/// Judged by the same
-/// rule as any other origin, because every read goes through `offered`.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_local_catalog_already_holding_toml_is_not_offered_on() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    let toml = "name = \"poisoned\"\ndescription = \"about poisoned\"\n";
-    file_item(
-        &root.join(crate::source::LOCAL_SOURCE_DIR).join("agents"),
-        "poisoned.md",
-        toml,
-    );
-    let path = lock::lock_path(&env, &scope);
-    let mut held = lock::load(&path).unwrap();
-    held.entries.insert(
-        lock::entry_key(ItemKind::Agent, "poisoned", HarnessId::Claude),
-        entry(ItemKind::Agent, "poisoned", "local", "local"),
-    );
-    lock::save(&path, &held).unwrap();
-
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-poisoned");
-    let candidates = inventory(&env, &scopes).unwrap();
-
-    let poisoned = find(&candidates, "poisoned");
-    assert!(
-        poisoned
-            .origins
-            .iter()
-            .any(|origin| matches!(origin.group, crate::author::import::CandidateGroup::Own)),
-        "the local catalog is the origin under test: {:?}",
-        poisoned.origins
-    );
-    assert!(
-        poisoned.origins.iter().all(|origin| origin.hash.is_empty()),
-        "nothing selectable: {:?}",
-        poisoned.origins
-    );
-    assert!(
-        poisoned.origins[0]
-            .problem
-            .as_deref()
-            .is_some_and(|problem| problem.contains("it has no frontmatter")),
-        "{:?}",
-        poisoned.origins[0].problem
-    );
-
-    let message = apply(&env, &scopes, &target, &[selection("poisoned", "poisoned")])
-        .unwrap_err()
-        .to_string();
-    assert!(
-        message.contains("has no bytes kendex can import"),
-        "{message}"
-    );
-    assert!(message.contains("poisoned.md"), "{message}");
-    assert!(
-        !target.join("agents").exists(),
-        "a refused apply writes nothing at all"
+    assert_eq!(
+        message,
+        "the bytes of agent 'agentic' changed since the preview — re-open the import to re-preview"
     );
 }

--- a/crates/core/src/author/import/tests/rename.rs
+++ b/crates/core/src/author/import/tests/rename.rs
@@ -1,11 +1,11 @@
-//! What a copy taken under another name declares: the rename itself, the
-//! kinds carrying no name anything keys on, and the refusals that decide
-//! before the first byte is written.
+//! What a copy taken under another name declares: the rename itself and
+//! the kinds carrying no name anything keys on. The refusals that decide
+//! before the first byte is written are rows of the parent's table.
 
 use std::fs;
 use std::path::Path;
 
-use super::{file_item, find, raw_skill, seeded, selection, target};
+use super::{file_item, find, seeded, selection, target};
 use crate::author::import::{apply, inventory};
 use crate::model::Scope;
 
@@ -25,19 +25,165 @@ fn checked(target: &Path) -> (usize, Vec<String>) {
     (check.tally().items, breakage)
 }
 
-/// A copy taken under another name has to declare that name: a skill copied
-/// verbatim under a renamed destination lands a SKILL.md calling it
-/// something else, which the catalog check reports as breakage — run here
-/// over what the import wrote, so this holds only as long as it does.
-///
-/// Both shapes: the flat rename, and the nested destination it was
-/// reported against.
+/// What a copy taken under another name lands, one row per file form. A
+/// copy has to declare the name it lands under: a skill copied verbatim
+/// under a renamed destination would land a SKILL.md calling it something
+/// else, which the catalog check reports as breakage. So the file that
+/// declares the name is rewritten on its name line and nothing else
+/// changes — the flat rename and the nested destination it was reported
+/// against; an agent's own file, which carries the name its tool answers
+/// to; a parked agent, whose content sits at `<name>.md.disabled`, a
+/// suffix that is not a format at all, so the bytes are asked rather
+/// than the filename; a Cursor rule, `.mdc` with frontmatter, which
+/// lands in the catalog's markdown slot declaring the destination
+/// because what decides is the format, not the extension it wears. The
+/// rest of a skill's tree is a copy: a rewrite reaching a body file would
+/// refuse the whole import, since a file with no frontmatter has no line
+/// to carry a name, and a skill with a references/ directory could not be
+/// imported under another name at all. A command, a hook and an MCP
+/// server carry no name anything keys on and are copied byte for byte —
+/// real candidates, the last two reaching the wizard through a lock entry
+/// pointing at the local source.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_renamed_skill_declares_its_destination_and_leaves_the_catalog_whole() {
+#[allow(clippy::too_many_lines, reason = "one row per file form")]
+fn a_renamed_copy_declares_its_destination_and_a_name_less_kind_is_copied_verbatim() {
+    type Row = (
+        Option<(&'static str, &'static str, &'static str)>,
+        &'static str,
+        &'static str,
+        &'static str,
+        &'static [(&'static str, &'static str)],
+    );
+    let rows: [Row; 8] = [
+        (
+            None,
+            "stray",
+            "renamed",
+            "skills/renamed",
+            &[
+                (
+                    "skills/renamed/SKILL.md",
+                    "---\nname: renamed\ndescription: about stray\n---\nunmanaged bytes\n",
+                ),
+                (
+                    "skills/renamed/references/notes.md",
+                    "Body file. No frontmatter here.\n",
+                ),
+            ],
+        ),
+        (
+            None,
+            "mine",
+            "group/deep",
+            "skills/group/deep",
+            &[(
+                "skills/group/deep/SKILL.md",
+                "---\nname: deep\ndescription: about mine\n---\nmy own bytes\n",
+            )],
+        ),
+        (
+            None,
+            "drifter",
+            "settled",
+            "agents/settled.md",
+            &[(
+                "agents/settled.md",
+                "---\nname: settled\ndescription: about drifter\n---\nAgent body.\n",
+            )],
+        ),
+        (
+            Some((
+                ".claude/agents",
+                "parked.md.disabled",
+                "---\nname: parked\ndescription: about parked\n---\nAgent body.\n",
+            )),
+            "parked",
+            "roused",
+            "agents/roused.md",
+            &[(
+                "agents/roused.md",
+                "---\nname: roused\ndescription: about parked\n---\nAgent body.\n",
+            )],
+        ),
+        (
+            Some((
+                ".cursor/rules",
+                "ruler.mdc",
+                "---\ndescription: about ruler\nalwaysApply: false\n---\nRule body.\n",
+            )),
+            "ruler",
+            "measured",
+            "agents/measured.md",
+            &[(
+                "agents/measured.md",
+                "---\nname: measured\ndescription: about ruler\nalwaysApply: false\n---\nRule body.\n",
+            )],
+        ),
+        (
+            None,
+            "note",
+            "memo",
+            "commands/memo.md",
+            &[(
+                "commands/memo.md",
+                "---\ndescription: a note\n---\nCommand body.\n",
+            )],
+        ),
+        (
+            None,
+            "watcher",
+            "sentry",
+            "hooks/sentry.sh",
+            &[(
+                "hooks/sentry.sh",
+                "#!/bin/sh\n# ---\n# name: watcher\n# event: SessionStart\n# ---\necho watching\n",
+            )],
+        ),
+        (
+            None,
+            "server",
+            "relay",
+            "mcp/relay.toml",
+            &[("mcp/relay.toml", "command = \"serve\"\nargs = []\n")],
+        ),
+    ];
+    for (planted, name, destination, written, landed) in rows {
+        let (tmp, env, scope) = seeded();
+        let Scope::Project { root } = &scope else {
+            unreachable!()
+        };
+        if let Some((dir, file, bytes)) = planted {
+            file_item(&root.join(dir), file, bytes);
+        }
+        let scopes = [scope.clone()];
+        let target = target(&env, &tmp, "mine-renamed");
+        let candidates = inventory(&env, &scopes).unwrap();
+        let mut chosen = selection(find(&candidates, name), false);
+        chosen.destination = destination.to_owned();
+
+        let outcome = apply(&env, &scopes, &target, &[chosen]).unwrap();
+        assert_eq!(outcome.written, [written], "{name}");
+        for (rel, bytes) in landed {
+            assert_eq!(
+                fs::read_to_string(target.join(rel)).unwrap(),
+                *bytes,
+                "{name} as {destination}: {rel}"
+            );
+        }
+    }
+}
+
+/// The catalog check reads what a rename wrote as whole: run here over
+/// the import, so this holds only as long as it does. And the bytes on
+/// disk are what the same selection would write again, so a repeated
+/// import is already present rather than someone else's.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_renamed_import_passes_the_catalog_check_and_repeats_as_already_present() {
     let (tmp, env, scope) = seeded();
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-renamed");
+    let scopes = [scope];
+    let target = target(&env, &tmp, "mine-checked");
     fs::write(
         target.join("kendex.toml"),
         "[marketplace]\nname = \"mine\"\n",
@@ -48,39 +194,14 @@ fn a_renamed_skill_declares_its_destination_and_leaves_the_catalog_whole() {
     flat.destination = "renamed".to_owned();
     let mut nested = selection(find(&candidates, "mine"), false);
     nested.destination = "group/deep".to_owned();
-
     let selections = [flat, nested];
 
     let outcome = apply(&env, &scopes, &target, &selections).unwrap();
     assert_eq!(outcome.written, ["skills/renamed", "skills/group/deep"]);
-
-    let flat_md = fs::read_to_string(target.join("skills/renamed/SKILL.md")).unwrap();
-    assert!(flat_md.contains("name: renamed"), "{flat_md}");
-    assert!(
-        flat_md.contains("unmanaged bytes") && flat_md.contains("description: about stray"),
-        "only the name line changes: {flat_md}"
-    );
-    // The rest of the tree is a copy. A rewrite reaching a body file would
-    // refuse the whole import, because a file with no frontmatter has no
-    // line to carry a name, so a skill with a references/ directory could
-    // not be imported under another name at all.
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    assert_eq!(
-        fs::read(target.join("skills/renamed/references/notes.md")).unwrap(),
-        fs::read(root.join(".claude/skills/stray/references/notes.md")).unwrap(),
-        "the tree's body files are copied, not declared",
-    );
-    let nested_md = fs::read_to_string(target.join("skills/group/deep/SKILL.md")).unwrap();
-    assert!(nested_md.contains("name: deep"), "{nested_md}");
-
     let (items, breakage) = checked(&target);
     assert_eq!(items, 2, "the check read both imported trees");
     assert_eq!(breakage, Vec::<String>::new());
 
-    // The bytes on disk are what the same selection would write again, so
-    // a repeated import is already present rather than someone else's.
     let again = apply(&env, &scopes, &target, &selections).unwrap();
     assert_eq!(
         again.already_present,
@@ -120,71 +241,6 @@ fn an_import_that_keeps_the_leaf_copies_the_bytes_untouched() {
     );
 }
 
-/// The rename is decided with every other refusal, before the first byte:
-/// bytes no name can be written into refuse the whole apply rather than
-/// land a copy that still answers to the old name.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_rename_no_declaration_can_carry_refuses_and_writes_nothing() {
-    let (tmp, env, scope) = seeded();
-    let scopes = [scope];
-    let target = target(&env, &tmp, "mine-uncarried");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut renamed = selection(find(&candidates, "bare"), false);
-    renamed.destination = "clothed".to_owned();
-    let selections = [selection(find(&candidates, "mine"), false), renamed];
-
-    let message = apply(&env, &scopes, &target, &selections)
-        .unwrap_err()
-        .to_string();
-    assert!(message.contains("it has no frontmatter"), "{message}");
-    assert!(message.contains("'clothed'"), "{message}");
-    assert!(
-        message.contains("still call itself 'bare'"),
-        "and what the copy would have answered to: {message}"
-    );
-    assert!(
-        !target.join("skills").exists(),
-        "a refused apply writes nothing at all"
-    );
-}
-
-/// The refusal spells the names it quotes rather than replaying them. A
-/// candidate name is read off a directory on disk, so it can hold anything
-/// a filesystem accepts — a bidi override included — and the inventory
-/// keeps illegal spellings on purpose, so the wizard can offer them under
-/// a legal destination. That offer is the path into this refusal, and a
-/// raw override reaching a terminal is the terminal's to obey.
-///
-/// The name carries U+202E, the right-to-left override that would let one
-/// package read as another. It is the threat `names::shown` exists for,
-/// and unlike a control character it is a filename every platform this
-/// runs on will create, so the fixture is the same on all three.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_refusal_escapes_the_candidate_name_it_quotes() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    raw_skill(
-        &root.join(".claude/skills"),
-        "ba\u{202e}re",
-        "No frontmatter at all.\n",
-    );
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-escaped");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut renamed = selection(find(&candidates, "ba\u{202e}re"), false);
-    renamed.destination = "clothed".to_owned();
-
-    let message = apply(&env, &scopes, &target, &[renamed])
-        .unwrap_err()
-        .to_string();
-    assert!(message.contains("ba\\u{202e}re"), "{message}");
-    assert!(!message.contains('\u{202e}'), "{message:?}");
-}
-
 /// A namespaced candidate landing under its own name is no rename. What a
 /// file inside an item declares is the leaf — it knows nothing of the
 /// namespace it is installed under — so `kit/gadget` copied to
@@ -217,94 +273,6 @@ fn a_namespaced_candidate_kept_under_its_own_name_is_no_rename() {
         fs::read_to_string(target.join("agents/kit/gadget.md")).unwrap(),
         declared,
     );
-}
-
-/// Bytes that are not text carry no declaration either, and the refusal
-/// says so rather than landing a copy whose name line is a replacement
-/// character. A skill's tree is read as bytes, so nothing upstream has
-/// asked whether its declaration is text.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_rename_of_bytes_that_are_not_text_refuses() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    let dir = root.join(".claude/skills/binary");
-    fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("SKILL.md"), [0xff, 0xfe, b'\n']).unwrap();
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-binary");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut renamed = selection(find(&candidates, "binary"), false);
-    renamed.destination = "textual".to_owned();
-    // A selection that would have been written first, so the folder
-    // staying empty is the refusal beating the copy rather than there
-    // being nothing to copy.
-    let selections = [selection(find(&candidates, "mine"), false), renamed];
-
-    let message = apply(&env, &scopes, &target, &selections)
-        .unwrap_err()
-        .to_string();
-    assert!(message.contains("the file is not text"), "{message}");
-    assert!(
-        !target.join("skills").exists(),
-        "a refused apply writes nothing at all"
-    );
-}
-
-/// What every other kind does under a rename, as a fixture rather than a
-/// claim in a comment.
-///
-/// An agent's own file carries the name its tool answers to, so a renamed
-/// agent declares its destination. The other three carry no name anything
-/// keys on and are copied byte for byte.
-///
-/// All three are real candidates: a hook and an MCP server reach the
-/// wizard through a lock entry pointing at the local source, which is how
-/// they are seeded here.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_renamed_agent_declares_its_destination_and_the_name_less_kinds_are_copied_verbatim() {
-    let (tmp, env, scope) = seeded();
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-kinds");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let renamed_to = |name: &str, destination: &str| {
-        let mut chosen = selection(find(&candidates, name), false);
-        chosen.destination = destination.to_owned();
-        chosen
-    };
-    let selections = [
-        renamed_to("drifter", "settled"),
-        renamed_to("note", "memo"),
-        renamed_to("watcher", "sentry"),
-        renamed_to("server", "relay"),
-    ];
-
-    apply(&env, &scopes, &target, &selections).unwrap();
-
-    let written = fs::read_to_string(target.join("agents/settled.md")).unwrap();
-    assert!(written.contains("name: settled"), "{written}");
-    assert!(
-        written.contains("description: about drifter") && written.contains("Agent body."),
-        "only the name line changes: {written}"
-    );
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    let local = root.join(crate::source::LOCAL_SOURCE_DIR);
-    for (landed, origin) in [
-        ("commands/memo.md", root.join(".claude/commands/note.md")),
-        ("hooks/sentry.sh", local.join("hooks/watcher.sh")),
-        ("mcp/relay.toml", local.join("mcp/server.toml")),
-    ] {
-        assert_eq!(
-            fs::read(target.join(landed)).unwrap(),
-            fs::read(&origin).unwrap(),
-            "{landed} is a copy, not a declaration",
-        );
-    }
 }
 
 /// An illegal namespace is not a rename. The inventory keeps illegal names
@@ -350,70 +318,5 @@ fn an_illegal_namespace_over_the_same_leaf_is_no_rename() {
     assert_eq!(
         fs::read_to_string(target.join("agents/good/kept.md")).unwrap(),
         declared,
-    );
-}
-
-/// A parked agent keeps its content at `<name>.md.disabled`, so the file
-/// the bytes come from ends in a suffix that is not a format at all. The
-/// bytes are the frontmatter they always were, so it renames like any
-/// other agent — which is the whole reason the bytes are asked rather than
-/// the filename.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_renamed_parked_agent_declares_its_destination() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    file_item(
-        &root.join(".claude/agents"),
-        "parked.md.disabled",
-        "---\nname: parked\ndescription: about parked\n---\nAgent body.\n",
-    );
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-parked");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut renamed = selection(find(&candidates, "parked"), false);
-    renamed.destination = "roused".to_owned();
-
-    apply(&env, &scopes, &target, &[renamed]).unwrap();
-
-    let written = fs::read_to_string(target.join("agents/roused.md")).unwrap();
-    assert!(written.contains("name: roused"), "{written}");
-    assert!(
-        written.contains("description: about parked") && written.contains("Agent body."),
-        "only the name line changes: {written}"
-    );
-}
-
-/// What decides is the format, not the extension it wears. A Cursor rule
-/// is `.mdc` and carries frontmatter, so it is renamed like any other
-/// agent: it lands in the catalog's markdown slot declaring the
-/// destination, and refusing it would take away a rename that worked.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_renamed_cursor_agent_declares_its_destination() {
-    let (tmp, env, scope) = seeded();
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    file_item(
-        &root.join(".cursor/rules"),
-        "ruler.mdc",
-        "---\ndescription: about ruler\nalwaysApply: false\n---\nRule body.\n",
-    );
-    let scopes = [scope.clone()];
-    let target = target(&env, &tmp, "mine-cursor");
-    let candidates = inventory(&env, &scopes).unwrap();
-    let mut renamed = selection(find(&candidates, "ruler"), false);
-    renamed.destination = "measured".to_owned();
-
-    apply(&env, &scopes, &target, &[renamed]).unwrap();
-
-    let written = fs::read_to_string(target.join("agents/measured.md")).unwrap();
-    assert!(written.contains("name: measured"), "{written}");
-    assert!(
-        written.contains("description: about ruler") && written.contains("Rule body."),
-        "only the name line changes: {written}"
     );
 }

--- a/crates/core/src/drift/report/tests.rs
+++ b/crates/core/src/drift/report/tests.rs
@@ -125,6 +125,32 @@ fn held_only_and_ignored_only_drift_stays_silent() {
     assert_eq!(render_plain(&report), "");
 }
 
+/// Every section as its title and lines, each line as its class and
+/// typed remedy. The line's sentence is a diagnostic whose wording is
+/// authoring guidance, not a pin; what it must carry is the package
+/// name, asserted apart.
+type Sectioned<'a> = Vec<(&'a str, Vec<(Class, Option<&'a Remedy>)>)>;
+
+fn sections(report: &CheckReport) -> Sectioned<'_> {
+    report
+        .sections
+        .iter()
+        .map(|section| {
+            (
+                section.title.as_str(),
+                section
+                    .lines
+                    .iter()
+                    .map(|line| (line.class, line.remedy.as_ref()))
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+/// One package per classification, each landing in its own section with
+/// its own typed remedy, drift sections in their fixed order, every line
+/// naming its package.
 #[test]
 fn each_classification_lands_in_its_section_with_its_remedy() {
     let tmp = tempfile::tempdir().unwrap();
@@ -157,28 +183,38 @@ fn each_classification_lands_in_its_section_with_its_remedy() {
     let report = check(&env, std::slice::from_ref(&scope));
     assert_eq!(report.status, CheckStatus::Drift);
     assert_eq!(report.status.exit_code(), 1);
+    let refresh = Remedy::Refresh { global: false };
+    let fork = Remedy::Fork {
+        kind: ItemKind::Skill,
+        name: "edited-one".to_owned(),
+        global: false,
+    };
+    let remove = Remedy::Remove {
+        name: "gone-one".to_owned(),
+        global: false,
+    };
+    assert_eq!(
+        sections(&report),
+        [
+            ("stale", vec![(Class::Drift, Some(&refresh))]),
+            ("edited by hand", vec![(Class::Drift, Some(&fork))]),
+            (
+                "gone from their source",
+                vec![(Class::Drift, Some(&remove))]
+            ),
+            ("mixed installs", vec![(Class::Drift, Some(&refresh))]),
+        ]
+    );
+    let lines = report.sections.iter().flat_map(|section| &section.lines);
+    for (line, name) in lines.zip(["stale-one", "edited-one", "gone-one", "mixed-one"]) {
+        assert!(line.text.contains(&format!("'{name}'")), "{}", line.text);
+    }
+    // Drift before suggestions: the stale section renders before the age
+    // line.
     let text = render_plain(&report);
-    assert!(text.contains("stale:"), "{text}");
-    assert!(
-        text.contains("'stale-one' has a newer version on its source — fix: kendex refresh"),
-        "{text}"
-    );
-    assert!(
-        text.contains("'edited-one'") && text.contains("fix: kendex fork skill edited-one"),
-        "{text}"
-    );
-    assert!(
-        text.contains("'gone-one'") && text.contains("fix: kendex remove gone-one"),
-        "{text}"
-    );
-    assert!(
-        text.contains("mixed installs:") && text.contains("'mixed-one'"),
-        "{text}"
-    );
-    // Drift before suggestions: stale section renders before the age line.
     let stale_at = text.find("stale:").unwrap();
     let age_at = text.find("(checked against sources").unwrap();
-    assert!(stale_at < age_at);
+    assert!(stale_at < age_at, "{text}");
 }
 
 #[test]
@@ -197,9 +233,14 @@ fn edited_outranks_stale_for_one_package() {
         }],
     );
 
-    let text = render_plain(&check(&env, std::slice::from_ref(&scope)));
-    assert!(text.contains("edited by hand:"), "{text}");
-    assert!(!text.contains("stale:"), "one package, one line: {text}");
+    let report = check(&env, std::slice::from_ref(&scope));
+    let titles: Vec<&str> = report
+        .sections
+        .iter()
+        .map(|section| section.title.as_str())
+        .collect();
+    assert_eq!(titles, ["edited by hand"], "one package, one line");
+    assert_eq!(report.sections[0].lines.len(), 1);
 }
 
 #[test]

--- a/crates/core/src/lock/tests.rs
+++ b/crates/core/src/lock/tests.rs
@@ -103,10 +103,11 @@ fn recording(path: &Path, key: &str, emitted: &Path, wrote_it: Option<&Path>) {
 
 /// What a record's version gets it: read, refused as a record this build
 /// cannot read (its `LockCorrupt` message, or the JSON reader's own words
-/// where the text is not JSON), or refused as a future kendex's.
+/// passed through whole where the text is not JSON), or refused as a
+/// future kendex's.
 enum Gate {
     Loads,
-    Corrupt(Option<String>),
+    Corrupt(String),
     TooNew(i64),
 }
 
@@ -128,10 +129,13 @@ enum Gate {
 fn only_a_record_naming_this_builds_version_loads() {
     let ahead = i64::from(LOCK_VERSION) + 1;
     let older = |version: i64| {
-        Gate::Corrupt(Some(format!(
+        Gate::Corrupt(format!(
             "it is a version {version} record, and this kendex writes version {LOCK_VERSION}"
-        )))
+        ))
     };
+    let readers_words = serde_json::from_str::<serde_json::Value>("{not json")
+        .unwrap_err()
+        .to_string();
     let rows: [(String, Gate); 8] = [
         (format!(r#"{{"version":{LOCK_VERSION},"root":ROOT,"entries":{{}}}}"#), Gate::Loads),
         (
@@ -146,12 +150,12 @@ fn only_a_record_naming_this_builds_version_loads() {
         ),
         (
             r#"{"root":ROOT,"entries":{}}"#.to_owned(),
-            Gate::Corrupt(Some(
+            Gate::Corrupt(
                 "it names no version, so nothing here can say what shape it is".to_owned(),
-            )),
+            ),
         ),
         (format!(r#"{{"version":{ahead},"root":ROOT,"entries":{{}}}}"#), Gate::TooNew(ahead)),
-        ("{not json".to_owned(), Gate::Corrupt(None)),
+        ("{not json".to_owned(), Gate::Corrupt(readers_words)),
     ];
     for (record, gate) in rows {
         let tmp = tempfile::tempdir().unwrap();
@@ -169,10 +173,7 @@ fn only_a_record_naming_this_builds_version_loads() {
                 for refused in [load_file(&path).unwrap_err(), load(&path).unwrap_err()] {
                     match &refused {
                         CoreError::LockCorrupt { path: at, message } => {
-                            assert_eq!(at, &path, "{label}");
-                            if let Some(why) = &why {
-                                assert_eq!(message, why, "{label}");
-                            }
+                            assert_eq!((at, message), (&path, &why), "{label}");
                         }
                         other => panic!("{label}: expected a corrupt lock, got {other:?}"),
                     }
@@ -358,17 +359,17 @@ fn a_record_a_project_cannot_call_its_own_is_refused() {
                 Refused::Outside("skill:gh:claude", wrote_it.clone(), wrote_it),
             )
         }),
+        // The root as the record spells it, canonical, so the refusal
+        // names the containment clause on every platform: where the temp
+        // path is not canonical (macOS's /var), a record spelling it
+        // otherwise takes the rejoin path and names the spelling it has.
         ("a position under another tree", |tmp| {
-            let root = tmp.join("here");
+            let root = crate::paths::canonical(&tmp.join("here")).unwrap();
             let elsewhere = tmp.join("there/.agents/skills/gh");
             (
                 elsewhere.clone(),
                 Some(root.clone()),
-                Refused::Outside(
-                    "skill:gh:claude",
-                    elsewhere,
-                    crate::paths::canonical(&root).unwrap(),
-                ),
+                Refused::Outside("skill:gh:claude", elsewhere, root),
             )
         }),
         ("no project named", |tmp| {
@@ -392,8 +393,8 @@ fn a_record_a_project_cannot_call_its_own_is_refused() {
             Refused::Outside(key, recorded, named) => assert!(
                 matches!(
                     &got,
-                    CoreError::LockOutsideProject { key: k, recorded: r, root: n, .. }
-                        if k == key && r == &recorded && n == &named
+                    CoreError::LockOutsideProject { path: at, key: k, recorded: r, root: n }
+                        if at == &path && k == key && r == &recorded && n == &named
                 ),
                 "{label}: {got:?}"
             ),

--- a/crates/core/src/lock/tests.rs
+++ b/crates/core/src/lock/tests.rs
@@ -74,135 +74,6 @@ fn timestamps_are_iso8601() {
     assert!(ts.starts_with("20"));
 }
 
-/// A v1 lock (bare-name keys, a `harnesses` array, no singular
-/// `harness`) is a shape this build does not read. Nothing converts it:
-/// the load fails, and the message names the path out — move it aside and
-/// install fresh.
-#[test]
-fn a_v1_lock_fails_to_load_and_names_the_fresh_install() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join(".kendex-lock.json");
-    std::fs::write(
-        &path,
-        r#"{"version":1,"entries":{"gh":{"name":"gh","kind":"skill","source":"kendex","source_repo":"vanillagreencom/kendex","harnesses":["claude-code"],"method":"symlink","installed_at":"2026-01-01T00:00:00Z","source_hash":"abc"}}}"#,
-    )
-    .unwrap();
-    let error = load_file(&path).unwrap_err();
-    assert!(matches!(error, CoreError::LockCorrupt { .. }), "{error}");
-    let said = error.to_string();
-    assert!(said.contains("install fresh"), "{said}");
-    // Two things this message must keep saying. It names the pi files
-    // beside a scope root, because this record is the only thing naming
-    // them and nothing in this build looks there — a person who threw the
-    // lock away alone would be left with the hook registered twice. And
-    // it asks for them to be moved, never deleted: this refusal covers a
-    // damaged current lock as much as an older one, and an older one may
-    // record that the move out of the reserved name already finished,
-    // after which those files are the person's own. Nothing here can tell
-    // the two apart, so nothing here tells anyone to delete anything.
-    assert!(said.contains("hooks.json"), "{said}");
-    assert!(
-        !said.contains("delet"),
-        "no remedy of ours is destructive: {said}"
-    );
-    assert!(matches!(load(&path), Err(CoreError::LockCorrupt { .. })));
-}
-
-/// The same refusal reaches Personal and a project alike, and the two
-/// scopes keep their locks under different names: `lock.json` under the
-/// app's config directory, `.kendex-lock.json` in a project. So the
-/// message names the path it was handed and nothing else, which is a rule
-/// that stays true for both. The app's steps for this kind carry the same
-/// rule beside their own copy, in ui/src/lib/error-copy.test.ts.
-#[test]
-fn the_lock_refusal_names_no_path_of_its_own() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("lock.json");
-    std::fs::write(&path, "{not json").unwrap();
-    let said = load_file(&path).unwrap_err().to_string();
-    assert!(said.contains("install fresh"), "{said}");
-    for named in [".kendex-lock.json", "kendex.toml", ".pi"] {
-        assert!(!said.contains(named), "names {named}: {said}");
-    }
-}
-
-/// Malformed JSON is reported as a damaged lock, distinct from the v1
-/// and future-version cases.
-#[test]
-fn unparseable_json_is_reported_as_corrupt() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join(".kendex-lock.json");
-    std::fs::write(&path, "{not json").unwrap();
-    assert!(matches!(
-        load_file(&path),
-        Err(CoreError::LockCorrupt { .. })
-    ));
-    assert!(matches!(load(&path), Err(CoreError::LockCorrupt { .. })));
-}
-
-/// A lock a future kendex wrote refuses to load rather than being
-/// silently misread or corrupted by an older build. That refusal is what
-/// every bump buys, so it is held at exactly one version above this
-/// build's — the version the next bump hands to the build before it — and
-/// against a record this project could otherwise adopt, leaving the
-/// version as the only thing refusing it.
-#[test]
-fn a_newer_lock_refuses_to_load() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join(".kendex-lock.json");
-    let ahead = i64::from(LOCK_VERSION) + 1;
-    std::fs::write(
-        &path,
-        format!(
-            r#"{{"version":{ahead},"root":{},"entries":{{}}}}"#,
-            json(tmp.path())
-        ),
-    )
-    .unwrap();
-    let refused = load_file(&path).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::SchemaTooNew { found, .. } if found == ahead),
-        "{refused}"
-    );
-    let refused = load(&path).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::SchemaTooNew { found, .. } if found == ahead),
-        "{refused}"
-    );
-}
-
-/// The version is the whole gate: a record naming this build's number
-/// loads whatever else it holds, and one naming any other number — or
-/// none — is refused, because every field a later version introduced is a fact
-/// this build reads and an older record does not carry.
-#[test]
-fn only_this_builds_version_loads() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join(".kendex-lock.json");
-    let write = |version: &str| {
-        std::fs::write(
-            &path,
-            format!(r#"{{{version}"root":{},"entries":{{}}}}"#, json(tmp.path())),
-        )
-        .unwrap();
-    };
-
-    write(&format!(r#""version":{LOCK_VERSION},"#));
-    assert!(matches!(load_file(&path).unwrap(), LockFile::Current(_)));
-
-    for older in ["1", "2", &(LOCK_VERSION - 1).to_string()] {
-        write(&format!(r#""version":{older},"#));
-        let error = load_file(&path).unwrap_err();
-        assert!(matches!(error, CoreError::LockCorrupt { .. }), "{error}");
-        assert!(error.to_string().contains("install fresh"), "{error}");
-    }
-
-    write("");
-    let error = load_file(&path).unwrap_err();
-    assert!(matches!(error, CoreError::LockCorrupt { .. }), "{error}");
-    assert!(error.to_string().contains("names no version"), "{error}");
-}
-
 /// A path as JSON data rather than text spliced into a literal: a
 /// backslash in one is an escape JSON has to be told about.
 fn json(path: &Path) -> String {
@@ -230,175 +101,308 @@ fn recording(path: &Path, key: &str, emitted: &Path, wrote_it: Option<&Path>) {
     .unwrap();
 }
 
-/// Containment cannot answer whose record this is: a checkout nested below
-/// this root sits inside it, so every path a lock carried out of that
-/// checkout names passes the boundary and the nested tree is what a
-/// refresh would then take back. The record says which root wrote it, so
-/// each position is read as a remainder of that root and resolves onto the
-/// one reading — which is this project's own tree, never the writer's.
-#[test]
-fn a_project_lock_another_project_wrote_resolves_onto_the_project_reading_it() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("here");
-    let nested = root.join("vendor/thing");
-    std::fs::create_dir_all(&nested).unwrap();
-    let path = root.join(LOCK_FILE);
-    recording(
-        &path,
-        "skill:gh:claude",
-        &nested.join(".agents/skills/gh"),
-        Some(&nested),
-    );
-
-    let lock = load(&path).unwrap();
-    assert_eq!(
-        lock.entries["skill:gh:claude"]
-            .emitted
-            .as_ref()
-            .unwrap()
-            .paths,
-        vec![
-            crate::paths::canonical(&root)
-                .unwrap()
-                .join(".agents/skills/gh")
-        ],
-        "the remainder lands under the root reading, not the one that wrote it"
-    );
-    assert_eq!(
-        lock.root,
-        Some(crate::paths::canonical(&root).unwrap()),
-        "and the record is this project's from here on"
-    );
+/// What a record's version gets it: read, refused as a record this build
+/// cannot read (its `LockCorrupt` message, or the JSON reader's own words
+/// where the text is not JSON), or refused as a future kendex's.
+enum Gate {
+    Loads,
+    Corrupt(Option<String>),
+    TooNew(i64),
 }
 
-/// A record whose writing root is no path on this machine — a clone at
-/// another path, a tree copied off another box, a main checkout since
-/// moved. Resolution turns on the record naming the root it went down
-/// under, never on that root still being reachable, and a read that
-/// required it would refuse exactly the copies this exists for.
+/// One row per version a record can name, and the gate's answer, through
+/// `load_file` and `load` alike. The version is the whole gate: a record
+/// naming this build's number loads whatever else it holds, and one naming
+/// any other number — or none — is refused, because every field a later
+/// version introduced is a fact this build reads and an older record does
+/// not carry. A v1 lock (bare-name keys, a `harnesses` array, no singular
+/// `harness`) is a shape this build does not read and nothing converts.
+/// Malformed JSON is a damaged lock, distinct from the older and newer
+/// cases. A lock a future kendex wrote refuses to load rather than being
+/// silently misread or corrupted by an older build; that refusal is what
+/// every bump buys, so it is held at exactly one version above this
+/// build's — the version the next bump hands to the build before it — and
+/// against a record this project could otherwise adopt, leaving the
+/// version as the only thing refusing it.
 #[test]
-fn a_project_lock_a_root_that_is_gone_wrote_still_resolves() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("here");
-    std::fs::create_dir_all(&root).unwrap();
-    let gone = tmp.path().join("was/here");
-    assert!(!gone.exists(), "the writing root is not on this machine");
-    let path = root.join(LOCK_FILE);
-    recording(
-        &path,
-        "skill:gh:claude",
-        &gone.join(".agents/skills/gh"),
-        Some(&gone),
-    );
-
-    let lock = load(&path).unwrap();
-    assert_eq!(
-        lock.entries["skill:gh:claude"]
-            .emitted
-            .as_ref()
-            .unwrap()
-            .paths,
-        vec![
-            crate::paths::canonical(&root)
-                .unwrap()
-                .join(".agents/skills/gh")
-        ],
-        "the remainder lands under the root reading"
-    );
-    assert_eq!(
-        lock.root,
-        Some(crate::paths::canonical(&root).unwrap()),
-        "and the record is this project's from here on"
-    );
-}
-
-/// A position stating no remainder of the root the record went down under
-/// is refused, not left to the containment check: it never was a position
-/// that project wrote, and under the root reading it there is a whole tree
-/// of places it could land inside and still not be this scope's.
-#[test]
-fn a_travelled_record_claiming_a_position_its_own_root_never_held_is_refused() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("here");
-    let wrote_it = tmp.path().join("there");
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::create_dir_all(&wrote_it).unwrap();
-    let path = root.join(LOCK_FILE);
-
-    // Inside the project reading the record, so containment waves it
-    // through, and outside the one that wrote it, so the record never
-    // stated it as anywhere of its own.
-    let inside = root.join("vendor/somebody-elses/link");
-    recording(&path, "skill:gh:claude", &inside, Some(&wrote_it));
-    let refused = load(&path).unwrap_err();
-    assert!(
-        matches!(
-            &refused,
-            CoreError::LockOutsideProject { key, recorded, root: named, .. }
-                if key == "skill:gh:claude" && recorded == &inside && named == &wrote_it
+fn only_a_record_naming_this_builds_version_loads() {
+    let ahead = i64::from(LOCK_VERSION) + 1;
+    let older = |version: i64| {
+        Gate::Corrupt(Some(format!(
+            "it is a version {version} record, and this kendex writes version {LOCK_VERSION}"
+        )))
+    };
+    let rows: [(String, Gate); 8] = [
+        (format!(r#"{{"version":{LOCK_VERSION},"root":ROOT,"entries":{{}}}}"#), Gate::Loads),
+        (
+            r#"{"version":1,"entries":{"gh":{"name":"gh","kind":"skill","source":"kendex","source_repo":"vanillagreencom/kendex","harnesses":["claude-code"],"method":"symlink","installed_at":"2026-01-01T00:00:00Z","source_hash":"abc"}}}"#.to_owned(),
+            older(1),
         ),
-        "{refused:?}"
-    );
-
-    // The root itself states no remainder at all, and rejoined it would
-    // name the reading project's whole directory as a place this scope
-    // owns.
-    recording(&path, "skill:gh:claude", &wrote_it, Some(&wrote_it));
-    let refused = load(&path).unwrap_err();
-    assert!(
-        matches!(
-            &refused,
-            CoreError::LockOutsideProject { key, recorded, root: named, .. }
-                if key == "skill:gh:claude" && recorded == &wrote_it && named == &wrote_it
+        (r#"{"version":1,"root":ROOT,"entries":{}}"#.to_owned(), older(1)),
+        (r#"{"version":2,"root":ROOT,"entries":{}}"#.to_owned(), older(2)),
+        (
+            format!(r#"{{"version":{},"root":ROOT,"entries":{{}}}}"#, LOCK_VERSION - 1),
+            older(i64::from(LOCK_VERSION - 1)),
         ),
-        "{refused:?}"
-    );
+        (
+            r#"{"root":ROOT,"entries":{}}"#.to_owned(),
+            Gate::Corrupt(Some(
+                "it names no version, so nothing here can say what shape it is".to_owned(),
+            )),
+        ),
+        (format!(r#"{{"version":{ahead},"root":ROOT,"entries":{{}}}}"#), Gate::TooNew(ahead)),
+        ("{not json".to_owned(), Gate::Corrupt(None)),
+    ];
+    for (record, gate) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".kendex-lock.json");
+        std::fs::write(&path, record.replace("ROOT", &json(tmp.path()))).unwrap();
+        let label = record.as_str();
+        match gate {
+            Gate::Loads => {
+                assert!(
+                    matches!(load_file(&path).unwrap(), LockFile::Current(_)),
+                    "{label}"
+                );
+            }
+            Gate::Corrupt(why) => {
+                for refused in [load_file(&path).unwrap_err(), load(&path).unwrap_err()] {
+                    match &refused {
+                        CoreError::LockCorrupt { path: at, message } => {
+                            assert_eq!(at, &path, "{label}");
+                            if let Some(why) = &why {
+                                assert_eq!(message, why, "{label}");
+                            }
+                        }
+                        other => panic!("{label}: expected a corrupt lock, got {other:?}"),
+                    }
+                }
+            }
+            Gate::TooNew(found) => {
+                for refused in [load_file(&path).unwrap_err(), load(&path).unwrap_err()] {
+                    assert!(
+                        matches!(&refused, CoreError::SchemaTooNew { path: at, found: seen } if at == &path && *seen == found),
+                        "{label}: {refused:?}"
+                    );
+                }
+            }
+        }
+    }
 }
 
-/// One directory reached through two spellings is still two prefixes.
-///
-/// A record written under `via`, a link to `real`, spells every position it
-/// holds under `via` as well. Read at `real` the two roots resolve to one
-/// directory, so a comparison asking that question skips the strip and
-/// leaves every position spelled under `via` — outside the root reading,
-/// and refused. What settles it is the spelling, because the spelling is
-/// what comes off the front of each position.
+/// What the corrupt-lock refusal must keep saying, and what it must not.
+/// It asks for a fresh install. It names the pi files beside a scope
+/// root, because this record is the only thing naming them and nothing
+/// in this build looks there — a person who threw the lock away alone
+/// would be left with the hook registered twice. And it asks for them to
+/// be moved, never deleted: this refusal covers a damaged current lock as
+/// much as an older one, and an older one may record that the move out
+/// of the reserved name already finished, after which those files are the
+/// person's own; nothing here can tell the two apart, so nothing here
+/// tells anyone to delete anything. The same refusal reaches Personal and
+/// a project alike, and the two scopes keep their locks under different
+/// names (`lock.json` under the app's config directory, `.kendex-lock.json`
+/// in a project), so the message names the path it was handed and nothing
+/// else, a rule that stays true for both; the app's steps for this kind
+/// carry the same rule beside their own copy, in
+/// ui/src/lib/error-copy.test.ts.
 #[test]
-#[cfg(unix)]
-fn a_record_rooted_through_a_link_resolves_onto_the_spelling_reading_it() {
+fn the_corrupt_lock_refusal_asks_for_a_move_and_names_no_path_of_its_own() {
     let tmp = tempfile::tempdir().unwrap();
-    let real = tmp.path().join("real");
-    std::fs::create_dir(&real).unwrap();
-    let via = tmp.path().join("via");
-    std::os::unix::fs::symlink(&real, &via).unwrap();
-    assert_eq!(
-        crate::paths::canonical(&via).unwrap(),
-        crate::paths::canonical(&real).unwrap(),
-        "the two spellings are one directory, which is what makes this the case"
+    let path = tmp.path().join("lock.json");
+    std::fs::write(&path, "{not json").unwrap();
+    let said = load_file(&path).unwrap_err().to_string();
+    assert!(said.contains("install fresh"), "{said}");
+    assert!(said.contains("hooks.json"), "{said}");
+    assert!(
+        !said.contains("delet"),
+        "no remedy of ours is destructive: {said}"
     );
+    for named in [".kendex-lock.json", "kendex.toml", ".pi"] {
+        assert!(!said.contains(named), "names {named}: {said}");
+    }
+}
 
-    // Written under `via`, positions and root alike, and read at `real`.
-    recording(
-        &real.join(LOCK_FILE),
-        "skill:gh:claude",
-        &via.join(".agents/skills/gh"),
-        Some(&via),
-    );
-    let lock = load(&real.join(LOCK_FILE)).unwrap();
-    assert_eq!(
-        lock.entries["skill:gh:claude"]
-            .emitted
-            .as_ref()
-            .unwrap()
-            .paths,
-        vec![
-            crate::paths::canonical(&real)
+/// One row per root a travelled record can name as its own, every one
+/// resolving onto the project reading it: the remainder of each position
+/// lands under the reading root, and the record is that project's from
+/// here on. Containment cannot answer whose record this is: a checkout
+/// nested below this root sits inside it, so every path a lock carried
+/// out of that checkout names passes the boundary and the nested tree is
+/// what a refresh would then take back; the record says which root wrote
+/// it, so each position is read as a remainder of that root. A writing
+/// root that is no path on this machine — a clone at another path, a tree
+/// copied off another box, a main checkout since moved — resolves the
+/// same way, since resolution turns on the record naming the root it
+/// went down under, never on that root still being reachable, and a read
+/// that required it would refuse exactly the copies this exists for. The
+/// project's own root loads as itself. And one directory reached through
+/// two spellings is still two prefixes: a record written under `via`, a
+/// link to `real`, spells every position under `via`, and read at `real`
+/// a comparison that resolved the two roots to one directory would skip
+/// the strip and leave every position outside the root reading; what
+/// settles it is the spelling, because the spelling is what comes off the
+/// front of each position.
+#[test]
+fn a_travelled_record_resolves_onto_the_root_reading_it() {
+    /// The reading root and the root the record names as its own.
+    type Plant = fn(&Path) -> (PathBuf, PathBuf);
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, Plant)> = vec![
+        ("a checkout nested below this root", |tmp| {
+            let root = tmp.join("here");
+            let nested = root.join("vendor/thing");
+            std::fs::create_dir_all(&nested).unwrap();
+            (root, nested)
+        }),
+        ("a root that is no path on this machine", |tmp| {
+            let root = tmp.join("here");
+            std::fs::create_dir_all(&root).unwrap();
+            let gone = tmp.join("was/here");
+            assert!(!gone.exists(), "the writing root is not on this machine");
+            (root, gone)
+        }),
+        ("its own root", |tmp| {
+            let root = tmp.join("here");
+            std::fs::create_dir_all(&root).unwrap();
+            (root.clone(), root)
+        }),
+    ];
+    #[cfg(unix)]
+    rows.push(("a link to the root reading", |tmp| {
+        let real = tmp.join("real");
+        std::fs::create_dir(&real).unwrap();
+        let via = tmp.join("via");
+        std::os::unix::fs::symlink(&real, &via).unwrap();
+        assert_eq!(
+            crate::paths::canonical(&via).unwrap(),
+            crate::paths::canonical(&real).unwrap(),
+            "the two spellings are one directory, which is what makes this the case"
+        );
+        (real, via)
+    }));
+    for (label, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, wrote_it) = plant(tmp.path());
+        let path = root.join(LOCK_FILE);
+        recording(
+            &path,
+            "skill:gh:claude",
+            &wrote_it.join(".agents/skills/gh"),
+            Some(&wrote_it),
+        );
+
+        let lock = load(&path).unwrap();
+        let here = crate::paths::canonical(&root).unwrap();
+        assert_eq!(
+            lock.entries["skill:gh:claude"]
+                .emitted
+                .as_ref()
                 .unwrap()
-                .join(".agents/skills/gh")
-        ],
-        "the position comes off `via` and lands under the spelling reading it"
-    );
-    assert_eq!(lock.root, Some(crate::paths::canonical(&real).unwrap()));
+                .paths,
+            vec![here.join(".agents/skills/gh")],
+            "{label}: the remainder lands under the root reading"
+        );
+        assert_eq!(
+            lock.root,
+            Some(here),
+            "{label}: the record is this project's from here on"
+        );
+    }
+}
+
+/// Why a project record is refused at the read.
+enum Refused {
+    /// A position outside the root that wrote the record: the key, the
+    /// position, and the root the record names.
+    Outside(&'static str, PathBuf, PathBuf),
+    /// No root named at all.
+    WithoutProject,
+}
+
+/// One row per record a project refuses to read as its own. A position
+/// stating no remainder of the root the record went down under is refused,
+/// not left to the containment check: it never was a position that project
+/// wrote, and under the root reading it there is a whole tree of places it
+/// could land inside and still not be this scope's — a position inside the
+/// reading project but outside the writing one, and the writing root
+/// itself, which states no remainder at all and rejoined would name the
+/// reading project's whole directory as a place this scope owns. A project
+/// lock may claim only what sits under its own root: the paths a refresh
+/// reads back are the ones it takes off disk, and past the root those
+/// belong to another project. A record naming no project is refused rather
+/// than adopted: nothing knows who wrote it, and reading it as this
+/// project's is the guess the refusal exists to stop.
+#[test]
+fn a_record_a_project_cannot_call_its_own_is_refused() {
+    /// The position recorded, the root the record names, and the refusal.
+    type Plant = fn(&Path) -> (PathBuf, Option<PathBuf>, Refused);
+    let rows: [(&str, Plant); 4] = [
+        ("a position inside the reader, outside the writer", |tmp| {
+            let root = tmp.join("here");
+            let wrote_it = tmp.join("there");
+            std::fs::create_dir_all(&wrote_it).unwrap();
+            let inside = root.join("vendor/somebody-elses/link");
+            (
+                inside.clone(),
+                Some(wrote_it.clone()),
+                Refused::Outside("skill:gh:claude", inside, wrote_it),
+            )
+        }),
+        ("the writing root itself", |tmp| {
+            let wrote_it = tmp.join("there");
+            std::fs::create_dir_all(&wrote_it).unwrap();
+            (
+                wrote_it.clone(),
+                Some(wrote_it.clone()),
+                Refused::Outside("skill:gh:claude", wrote_it.clone(), wrote_it),
+            )
+        }),
+        ("a position under another tree", |tmp| {
+            let root = tmp.join("here");
+            let elsewhere = tmp.join("there/.agents/skills/gh");
+            (
+                elsewhere.clone(),
+                Some(root.clone()),
+                Refused::Outside(
+                    "skill:gh:claude",
+                    elsewhere,
+                    crate::paths::canonical(&root).unwrap(),
+                ),
+            )
+        }),
+        ("no project named", |tmp| {
+            (
+                tmp.join("here/.agents/skills/gh"),
+                None,
+                Refused::WithoutProject,
+            )
+        }),
+    ];
+    for (label, plant) in rows {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("here");
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join(LOCK_FILE);
+        let (emitted, wrote_it, refused) = plant(tmp.path());
+        recording(&path, "skill:gh:claude", &emitted, wrote_it.as_deref());
+
+        let got = load(&path).unwrap_err();
+        match refused {
+            Refused::Outside(key, recorded, named) => assert!(
+                matches!(
+                    &got,
+                    CoreError::LockOutsideProject { key: k, recorded: r, root: n, .. }
+                        if k == key && r == &recorded && n == &named
+                ),
+                "{label}: {got:?}"
+            ),
+            Refused::WithoutProject => assert!(
+                matches!(&got, CoreError::LockWithoutProject { path: at } if at == &path),
+                "{label}: {got:?}"
+            ),
+        }
+    }
 }
 
 /// Provenance is resolved wherever the record keeps it, not only on the
@@ -442,28 +446,6 @@ fn a_travelled_record_resolves_the_provenance_it_keeps_beside_the_entries() {
     );
 }
 
-/// A record naming no project is refused rather than adopted: nothing knows
-/// who wrote it, and reading it as this project's is the guess the refusal
-/// exists to stop.
-#[test]
-fn a_project_lock_naming_no_project_is_refused() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("here");
-    std::fs::create_dir(&root).unwrap();
-    let path = root.join(LOCK_FILE);
-    recording(
-        &path,
-        "skill:gh:claude",
-        &root.join(".agents/skills/gh"),
-        None,
-    );
-
-    assert!(matches!(
-        load(&path),
-        Err(CoreError::LockWithoutProject { .. })
-    ));
-}
-
 /// A root has one spelling (invariant 17), and neither end holds it: the
 /// record goes down canonical while a caller may name the same directory
 /// through a link — which is the spelling macOS hands every temp path,
@@ -505,46 +487,20 @@ fn a_project_lock_is_never_written_naming_another_project() {
 
     let lock = Lock {
         version: LOCK_VERSION,
-        root: Some(nested),
+        root: Some(nested.clone()),
         ..Lock::default()
     };
 
-    assert!(matches!(
-        save(&path, &lock),
-        Err(CoreError::LockFromAnotherProject { .. })
-    ));
-    assert!(!path.exists(), "and nothing is left at the path");
-}
-
-/// A project lock may claim only what sits under its own root: the paths a
-/// refresh reads back are the ones it takes off disk, and past the root
-/// those belong to another project.
-#[test]
-fn a_project_lock_claiming_another_tree_is_refused() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("here");
-    std::fs::create_dir(&root).unwrap();
-    let path = root.join(LOCK_FILE);
-    let elsewhere = tmp.path().join("there/.agents/skills/gh");
-    recording(&path, "skill:gh:claude", &elsewhere, Some(&root));
-
-    let refused = load(&path).unwrap_err();
+    let refused = save(&path, &lock).unwrap_err();
     assert!(
         matches!(
             &refused,
-            CoreError::LockOutsideProject { key, recorded, .. }
-                if key == "skill:gh:claude" && recorded == &elsewhere
+            CoreError::LockFromAnotherProject { path: at, recorded, root: named }
+                if at == &path && recorded == &nested && named == &crate::paths::canonical(&root).unwrap()
         ),
         "{refused:?}"
     );
-
-    recording(
-        &path,
-        "skill:gh:claude",
-        &root.join(".agents/skills/gh"),
-        Some(&root),
-    );
-    assert_eq!(load(&path).unwrap().entries.len(), 1, "its own root loads");
+    assert!(!path.exists(), "and nothing is left at the path");
 }
 
 /// The record is refused at the writing end too: what a project lock cannot
@@ -586,10 +542,15 @@ fn a_project_lock_is_never_written_claiming_another_tree() {
         },
     );
 
-    assert!(matches!(
-        save(&path, &lock),
-        Err(CoreError::LockOutsideProject { .. })
-    ));
+    let refused = save(&path, &lock).unwrap_err();
+    assert!(
+        matches!(
+            &refused,
+            CoreError::LockOutsideProject { key, recorded, root: named, .. }
+                if key == "skill:gh:claude" && recorded == &elsewhere && named == &crate::paths::canonical(&root).unwrap()
+        ),
+        "{refused:?}"
+    );
     assert!(!path.exists(), "and nothing is left at the path");
 }
 

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -154,11 +154,15 @@ fn a_cached_pin_resolves_offline_and_an_uncached_one_is_a_hard_error() {
     assert!(offline.warning.is_none());
 
     let error = sync(&f.env, REPO, Some(&never_fetched)).unwrap_err();
-    let CoreError::PinUnavailable { pin, .. } = &error else {
+    let CoreError::PinUnavailable { repo, pin, reason } = &error else {
         panic!("expected a pin error, got {error}");
     };
-    assert_eq!(pin, &never_fetched);
-    assert!(error.to_string().contains(&never_fetched));
+    assert_eq!(
+        (repo.as_str(), pin.as_str()),
+        (REPO, never_fetched.as_str())
+    );
+    // The reason is git's own account of the fetch, not ours to pin.
+    assert!(!reason.is_empty(), "{error}");
 }
 
 /// A tag that moved upstream is followed on the next refresh, and the
@@ -451,14 +455,15 @@ fn a_commit_id_of_no_known_object_format_is_refused() {
 
     let error = store::publish(&f.env, &key, &mirror, abbreviated).unwrap_err();
 
-    let refusal = error.to_string();
-    assert!(
-        refusal.starts_with(&format!("materializing {abbreviated} failed:")),
-        "the refusal names something other than what kendex declined: {refusal}"
-    );
-    assert!(
-        refusal.contains("attribute source"),
-        "refused for some other reason: {refusal}"
+    // Refused by kendex, before any git call: the command named is the
+    // materialization, and the reason is this module's own.
+    let CoreError::GitFailed { command, stderr } = &error else {
+        panic!("{error:?}");
+    };
+    assert_eq!(command, &format!("materializing {abbreviated}"));
+    assert_eq!(
+        stderr,
+        "no object format has ids of 7 characters, so the attribute source this checkout must be written under cannot be named"
     );
     assert!(!store::checkout_dir(&f.env, &key, abbreviated).exists());
 }

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -463,7 +463,10 @@ fn a_commit_id_of_no_known_object_format_is_refused() {
     assert_eq!(command, &format!("materializing {abbreviated}"));
     assert_eq!(
         stderr,
-        "no object format has ids of 7 characters, so the attribute source this checkout must be written under cannot be named"
+        &format!(
+            "no object format has ids of {} characters, so the attribute source this checkout must be written under cannot be named",
+            abbreviated.len()
+        )
     );
     assert!(!store::checkout_dir(&f.env, &key, abbreviated).exists());
 }

--- a/crates/core/src/settings_file/tests.rs
+++ b/crates/core/src/settings_file/tests.rs
@@ -203,14 +203,15 @@ fn an_edit_on_an_unreadable_key_refuses_and_names_the_lines() {
         Path::new("/w/kendex.settings.toml"),
     )
     .unwrap_err();
-    let CoreError::SettingsRefused(SettingsRefusal::Ambiguous { lines, .. }) = &refused else {
+    let CoreError::SettingsRefused(SettingsRefusal::Ambiguous {
+        path, key, lines, ..
+    }) = &refused
+    else {
         panic!("{refused:?}");
     };
-    assert_eq!(lines, &[2, 3]);
-    assert!(refused.to_string().contains("lines 2, 3"), "{refused}");
-    assert!(
-        refused.to_string().contains("/w/kendex.settings.toml"),
-        "{refused}"
+    assert_eq!(
+        (path.as_path(), key.as_str(), lines.as_slice()),
+        (Path::new("/w/kendex.settings.toml"), "MODE", &[2, 3][..])
     );
 }
 
@@ -426,15 +427,13 @@ fn two_edits_on_one_key_agree_or_the_save_refuses() {
 
     let differing = [set("noise", "MODE", "mine"), set("other", "MODE", "theirs")];
     let refused = apply_edits(FILE, &differing, &templates, Path::new("/w/f.toml")).unwrap_err();
-    let CoreError::SettingsRefused(SettingsRefusal::Contested { key, wanted, .. }) = &refused
+    let CoreError::SettingsRefused(SettingsRefusal::Contested { key, by, wanted }) = &refused
     else {
         panic!("{refused:?}");
     };
     assert_eq!(key, "MODE");
+    assert_eq!(by, &["noise".to_owned(), "other".to_owned()]);
     assert_eq!(wanted, &["mine".to_owned(), "theirs".to_owned()]);
-    // And nothing is written: the file is not half-saved.
-    assert!(refused.to_string().contains("noise"), "{refused}");
-    assert!(refused.to_string().contains("other"), "{refused}");
 
     // A reset resolves against each skill's own default, so two resets on
     // one key disagree exactly when the skills ship different defaults.

--- a/crates/core/src/source/plugin_registry/tests.rs
+++ b/crates/core/src/source/plugin_registry/tests.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+/// Every finding as the pair that tells it apart, in the order the
+/// registry was read; the fix is asserted for presence, never its words.
+fn said(registry: &Registry) -> Vec<(&str, &str)> {
+    for finding in &registry.findings {
+        assert!(!finding.fix.is_empty(), "{finding} needs a fix");
+    }
+    registry
+        .findings
+        .iter()
+        .map(|finding| (finding.location.as_str(), finding.problem.as_str()))
+        .collect()
+}
+
 /// A catalog root holding whatever registry text the test wants.
 fn catalog(registry: &str, dirs: &[&str]) -> (tempfile::TempDir, SealedSource) {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -60,13 +73,13 @@ fn local_entries_are_consumed_and_entries_elsewhere_are_named() {
 
     // The skipped entry is named, with what to do about it — never dropped
     // in silence.
-    let skipped = registry
-        .findings
-        .iter()
-        .find(|f| f.problem.contains("upstream"))
-        .expect("a finding naming the entry");
-    assert!(skipped.problem.contains("another repository"));
-    assert!(!skipped.fix.is_empty());
+    assert_eq!(
+        said(&registry),
+        [(
+            ".claude-plugin/marketplace.json: upstream",
+            "`upstream` lives in another repository, which this version does not fetch"
+        )]
+    );
 }
 
 #[test]
@@ -74,9 +87,22 @@ fn a_registry_that_does_not_parse_says_so_and_offers_nothing() {
     let (_tmp, sealed) = catalog("{ not json", &[]);
     let registry = read(&sealed).expect("read").expect("recognized");
     assert!(registry.plugins.is_empty());
-    assert!(registry.findings[0].problem.contains("not readable JSON"));
+    let [(at, problem)] = said(&registry)[..] else {
+        panic!("{:?}", registry.findings);
+    };
+    assert_eq!(at, ".claude-plugin/marketplace.json");
+    // The JSON reader's own words follow the dash and are not ours to pin.
+    assert!(
+        problem.starts_with("this catalog's registry is not readable JSON — "),
+        "{problem}"
+    );
 }
 
+/// One row per defect an entry can carry, each tied to its own finding:
+/// a path that climbs out, an absolute one, a URL, a name that is a
+/// directory, a directory that is not there, and no source at all. One
+/// defect producing two findings while another produced none would be
+/// six findings too.
 #[test]
 fn entries_that_lie_about_where_their_files_are_get_refused() {
     let registry = r#"{
@@ -93,10 +119,35 @@ fn entries_that_lie_about_where_their_files_are_get_refused() {
     let (_tmp, sealed) = catalog(registry, &["plugins/dots"]);
     let registry = read(&sealed).expect("read").expect("recognized");
     assert!(registry.plugins.is_empty());
-    assert_eq!(registry.findings.len(), 6);
-    for finding in &registry.findings {
-        assert!(!finding.fix.is_empty(), "{finding} needs a fix");
-    }
+    assert_eq!(
+        said(&registry),
+        [
+            (
+                ".claude-plugin/marketplace.json: escape",
+                "`escape` points at `../../../etc`, which leads out of the catalog"
+            ),
+            (
+                ".claude-plugin/marketplace.json: absolute",
+                "`absolute` points at `/etc`, which leads out of the catalog"
+            ),
+            (
+                ".claude-plugin/marketplace.json: url",
+                "`url` lives in another location on the web, which this version does not fetch"
+            ),
+            (
+                ".claude-plugin/marketplace.json: ..",
+                "this plugin cannot be installed under its name: `..` names a directory, not an item"
+            ),
+            (
+                ".claude-plugin/marketplace.json: missing",
+                "`plugins/gone` is not a directory in this catalog"
+            ),
+            (
+                ".claude-plugin/marketplace.json: nameless-source",
+                "`nameless-source` says nowhere where its files are"
+            ),
+        ]
+    );
 }
 
 #[test]
@@ -111,7 +162,13 @@ fn two_plugins_a_filesystem_cannot_tell_apart_are_a_finding() {
     let (_tmp, sealed) = catalog(registry, &["plugins/review", "plugins/review-upper"]);
     let registry = read(&sealed).expect("read").expect("recognized");
     assert_eq!(registry.plugins.len(), 1);
-    assert!(registry.findings[0].problem.contains("folded case"));
+    assert_eq!(
+        said(&registry),
+        [(
+            ".claude-plugin/marketplace.json: Review",
+            "`Review` and `review` are the same name once a filesystem has folded case and trailing dots — one would overwrite the other"
+        )]
+    );
 }
 
 #[test]
@@ -119,5 +176,11 @@ fn a_registry_with_no_owner_is_read_and_told_about_it() {
     let registry = r#"{"name": "bare", "plugins": []}"#;
     let (_tmp, sealed) = catalog(registry, &[]);
     let registry = read(&sealed).expect("read").expect("recognized");
-    assert!(registry.findings.iter().any(|f| f.problem.contains("owns")));
+    assert_eq!(
+        said(&registry),
+        [(
+            ".claude-plugin/marketplace.json",
+            "the catalog says who owns it nowhere, and some tools refuse a catalog without an owner"
+        )]
+    );
 }


### PR DESCRIPTION
Third of the `crates/core/src` PRs of the tests audit (KEN-1241), part one: nine in-crate suites judged against code-quality § Tests. Test code only, no production change, hence `[no-changelog]`.

## Folded and deleted cases, with the surviving row

`crates/core/src/lock/tests.rs`

- `a_v1_lock_fails_to_load_and_names_the_fresh_install`, `unparseable_json_is_reported_as_corrupt`, `a_newer_lock_refuses_to_load`, `only_this_builds_version_loads` → `only_a_record_naming_this_builds_version_loads`: eight records (this build's version loads; v1 with bare-name keys, v1, v2 and the version before this one are `LockCorrupt` with the whole message; no version is `LockCorrupt` with its message; one version ahead is `SchemaTooNew { path, found }`; `{not json` is `LockCorrupt` with the path and the reader's words passed through whole), each through `load_file` and `load`.
- `the_lock_refusal_names_no_path_of_its_own` → `the_corrupt_lock_refusal_asks_for_a_move_and_names_no_path_of_its_own` (the must-say and must-not-name clauses as one case).
- `a_project_lock_another_project_wrote_resolves_onto_the_project_reading_it`, `a_project_lock_a_root_that_is_gone_wrote_still_resolves`, `a_record_rooted_through_a_link_resolves_onto_the_spelling_reading_it` → `a_travelled_record_resolves_onto_the_root_reading_it` (four writing roots, the link row under unix).
- `a_travelled_record_claiming_a_position_its_own_root_never_held_is_refused`, `a_project_lock_claiming_another_tree_is_refused`, `a_project_lock_naming_no_project_is_refused` → `a_record_a_project_cannot_call_its_own_is_refused` (`LockOutsideProject { path, key, recorded, root }`, `LockWithoutProject { path }`).
- `a_project_lock_is_never_written_naming_another_project` and `a_project_lock_is_never_written_claiming_another_tree` pin the refusal's fields.

`crates/core/src/author/import/tests.rs` and `tests/rename.rs`

- `a_write_that_stops_part_way_names_what_reached_the_folder`, `two_selections_whose_trees_meet_refuse_and_write_nothing`, `a_refusal_on_a_later_selection_writes_nothing_for_the_earlier_one`, `a_destination_holding_different_bytes_is_a_refusal_naming_it`, `a_case_folding_sibling_refuses_before_the_copy`, `a_stale_hash_refuses_instead_of_copying_moved_bytes`, `rename::a_rename_no_declaration_can_carry_refuses_and_writes_nothing`, `rename::a_rename_of_bytes_that_are_not_text_refuses`, `rename::a_refusal_escapes_the_candidate_name_it_quotes` → `every_refusal_names_its_cause_and_the_folder_shows_what_it_left`: eight rows, the `Authoring { message }` whole (the interrupted write by its head and tail around the OS error), and what the folder holds after as exact bytes or absence. `a_destination_holding_different_bytes_is_a_refusal_naming_it` is the later-selection row (same message, same planted bytes, the earlier selection unwritten as well). The bidi row pins the escaped spelling inside the whole message.
- The re-preview half of `a_stale_hash_refuses_instead_of_copying_moved_bytes` → `a_fresh_preview_after_a_stale_refusal_copies_the_bytes_as_they_are_now`, pinning `written` and the landed bytes.
- `rename::a_renamed_skill_declares_its_destination_and_leaves_the_catalog_whole`, `rename::a_renamed_agent_declares_its_destination_and_the_name_less_kinds_are_copied_verbatim`, `rename::a_renamed_parked_agent_declares_its_destination`, `rename::a_renamed_cursor_agent_declares_its_destination` → `rename::a_renamed_copy_declares_its_destination_and_a_name_less_kind_is_copied_verbatim`: eight file forms (flat and nested skill, agent, parked agent, Cursor rule, command, hook, MCP server), `written` and every landed file's whole bytes; the former `contains("name: x")` and "only the name line changes" fragments are whole-file pins. The catalog-check and repeat-import halves of the skill case → `rename::a_renamed_import_passes_the_catalog_check_and_repeats_as_already_present`.

`crates/core/src/author/import/tests/format.rs`

- `an_agent_in_another_format_is_not_offered_under_either_name`, `an_agent_whose_bytes_are_not_text_is_not_offered`, `a_local_catalog_already_holding_toml_is_not_offered_on` → `bytes_a_catalog_cannot_store_are_listed_without_a_hash_and_refused_under_either_name`: three doors, the whole origin list as `(locations, hash, problem)`, the drifter control, the refusal whole under the own name and another, nothing written. Loss named: the poisoned case's `any(Own)` group assert; the row pins the one origin's location, which is the local source path.
- `the_edited_copy_of_a_marketplace_agent_is_judged_by_the_same_rule` keeps its shape; its four `contains` pins are whole (locations, problem, landed bytes, the stale message).

`crates/core/src/source/plugin_registry/tests.rs`

- `entries_that_lie_about_where_their_files_are_get_refused`: `findings.len() == 6` is the whole `(location, problem)` list in read order, one pair per planted defect; every other finding assert in the file is a whole list too (the JSON case by its head, serde's words unpinned); `said()` asserts each fix's presence.

`crates/core/src/drift/report/tests.rs`

- `each_classification_lands_in_its_section_with_its_remedy` pins `report.sections` as `(title, [(class, typed remedy)])`, each line's package name apart, and the render only for the drift-before-suggestions order. The whole remedy sentences it grepped (`fix: kendex refresh`, `fix: kendex fork skill edited-one`, `fix: kendex remove gone-one`) are dropped: a remedy's wording is authoring guidance, its typed value is the pin.
- `edited_outranks_stale_for_one_package` pins the section titles instead of grepping the render.

`crates/core/src/settings_file/tests.rs` and `crates/core/src/remote/tests.rs`

- Four refusals pin their fields instead of grepping `to_string()`: `Ambiguous { path, key, lines }`, `Contested { key, by, wanted }`, `PinUnavailable { repo, pin }` (the reason is git's, asserted present), `GitFailed { command, stderr }` whole.

## Must-fail controls

One mutant per surviving table, eight tables, all killed (`mutate-pins.py`): a newer lock read as this build's (gate); a travelled record keeping its writing root; a rootless project record accepted; trees that never meet (import refusals); the description line renamed instead of the name line (rename); every kind judged as an agent (format); a missing plugin directory listed (registry); a mixed install remedied by a plan (drift sections). The reviewer's twelve extra mutants, one per row its mutant did not reach: eleven killed on the first head, the twelfth (a JSON syntax error reclassified as a missing version) survived and is killed by the third commit, which pins the not-JSON row to the reader's words passed through whole.

## Review

One reviewer-test round: ACCEPT WITH FIXES. Two blockers, both applied in the third commit: the lock refusal row under another tree pinned the canonical root where the producer spells the root the record spells, which differ where the temp path is not canonical (macOS's /var), so the row now records the canonical root; three import rows pinned a path joined with `/` where the producer joins segment by segment, so on Windows the separator differed, and the rows now join the same way. Three suggestions applied: every `LockOutsideProject` row pins its path; the remote refusal derives the id length from the fixture; the not-JSON row above.

## Checks

`cargo test -p kendex-core --lib` 1019/1019, and the same under a symlinked TMPDIR (the macOS /var class) after the fixes; clippy `-D warnings` clean; fmt clean; the Windows check target gains no warning; `tools/guard --full` exit 0 on f972af57b (the third commit changes three test files; clippy and fmt clean after it).

KEN-1241

https://claude.ai/code/session_01HrTLSGugqFmA5t3ZBmGXrt
