### PR TITLE
fix(KEN-1287): code-quality description triggers on any coding task

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Load before writing or modifying code."
+description: "Load for any coding or development task in any repository: writing, changing, fixing, refactoring, or testing code or scripts in any language."
 summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards, test shape."
 license: MIT
 user-invocable: true

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Load before writing or modifying code."
+description: "Load for any coding or development task in any repository: writing, changing, fixing, refactoring, or testing code or scripts in any language."
 summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards, test shape."
 license: MIT
 user-invocable: true


### PR DESCRIPTION
Closes KEN-1287.

The `code-quality` skill's frontmatter `description` named no trigger ("Load before writing or modifying code."), so a plain coding prompt in a consumer repository could start without the skill. It is now one trigger-shaped sentence: "Load for any coding or development task in any repository: writing, changing, fixing, refactoring, or testing code or scripts in any language." (142 characters, under the Codex cap the render validator enforces). No other frontmatter key changes; `summary` carries the rest. `dev`'s description is untouched: it names an issue workflow, which is the ruling.

The `.agents/skills/code-quality/SKILL.md` render lands in this commit; the source diff was replayed onto it with `patch`. `.claude/skills` is a symlink tree onto `.agents/skills`, so there is no third copy.

## Proof: skill selection for a plain coding prompt, before and after

Six fresh `claude -p` sessions (Claude Code 2.1.263, stream-json, no skill or workflow forced) in scratch repositories with the rendered skill installed under `.claude/skills/`, on the prompt "Add a median(xs) function to src/util.py and print it beside the mean in src/main.py." Every session edited the files. "loaded" is a `Skill` tool call with `skill: code-quality` in the transcript.

| Session | Skills installed | Model / effort | code-quality loaded |
|---|---|---|---|
| before | code-quality only, old description | Fable 5.1 / xhigh | yes |
| after | code-quality only, new description | Fable 5.1 / xhigh | yes |
| before | all 22 catalog skills, old description | Fable 5.1 / xhigh | yes |
| after | all 22 catalog skills, new description | Fable 5.1 / xhigh | yes |
| before | all 22 catalog skills, old description | Sonnet 5 / medium | no |
| after | all 22 catalog skills, new description | Sonnet 5 / medium | no |

What this shows and does not show: the harness has no deterministic trigger; the description is the text the model reads in its skill list, and the model decides. In these samples Fable loads the skill under either description and Sonnet 5 at medium effort loads it under neither, so the owner's miss (a fresh vgs worktree, model and effort not recorded) is not reproduced here and the new description does not flip a single-sample outcome. What was checked instead: the sentence names the work class and the "any repository" scope the ruling asks for, follows the catalog's "Load ..." shape, and passes the render validator, `preflight`, `doc-limits` and `tools/guard --full`.

Consumers receive the new description on their next `kendex refresh`; the consumer refresh wave carries it.

No new test: frontmatter is prose the structural check already covers.

Discovered, not in this PR: `crates/cli/tests/cli.rs::scope_project_outside_a_project_is_an_error` fails whenever `TMPDIR` sits under the real `$HOME` (the fixture home's ancestors then include `~/.claude`, which `project_root_from` reads as a project). It fails the same way on `main`; this run's guard passed with `TMPDIR` outside home.

Program tracking issue: KEN-1203.

https://claude.ai/code/session_013RtEEW9KZo2DhF9QU7NNHi
