### PR TITLE
docs(KEN-1290): define shared label maintenance

### DIFF
--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -74,7 +74,7 @@ The cache is `.cache/linear` under the physical worktree root ([README.md](READM
 
 Before changing a label definition, read its ID, team, parent and group status. An empty team means workspace scope. Read issue use across affected teams and check references in their manifests, scripts, gates and generated instructions. A team-restricted key cannot establish workspace-wide issue use.
 
-The workspace owner coordinates shared label changes with affected repository maintainers. A repository taxonomy names that owner. Keep generic labels shared and project-specific labels team-scoped. Obtain approval for the concrete affected set before a shared rename, scope change, replacement or deletion. Issue-label assignment authority does not authorize changing a shared label definition.
+The workspace owner coordinates shared label changes with affected repository maintainers. A repository taxonomy names that owner. Keep generic labels shared and project-specific labels team-scoped. Obtain approval for the concrete affected set and the exact proposed change before any shared-label definition change, replacement or deletion. Issue-label assignment authority does not authorize changing a shared label definition.
 
 Prepare dependent repository corrections before the label change. After an authorized change, refresh each affected inventory, render instructions from their source, and run its taxonomy and repository checks. Record the label IDs, issue assignments and repository commits together. If the API cannot change scope, prepare a replacement plan with history and recovery limits before requesting migration approval.
 

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -68,6 +68,16 @@ The cache is `.cache/linear` under the physical worktree root ([README.md](READM
 
 `LINEAR_API_KEY` belongs in `.env.local`; non-secret defaults in committed `kendex.settings.toml` `[env]`. A key from project files beats one inherited from the environment, and `auth-check` warns (fingerprints only) when it shadows a differing inherited key.
 
+## Shared label maintenance
+
+`LINEAR_TEAM` requires a target before writes; it does not restrict an API key or check a label's owning team. `auth-check` verifies authentication and the local target, not the key's permission mask. Inspect key permissions in Linear settings; report fingerprints only.
+
+Before changing a label definition, read its ID, team, parent and group status. An empty team means workspace scope. Read issue use across affected teams and check references in their manifests, scripts, gates and generated instructions. A team-restricted key cannot establish workspace-wide issue use.
+
+The workspace owner coordinates shared label changes with affected repository maintainers. A repository taxonomy names that owner. Keep generic labels shared and project-specific labels team-scoped. Obtain approval for the concrete affected set before a shared rename, scope change, replacement or deletion. Issue-label assignment authority does not authorize changing a shared label definition.
+
+Prepare dependent repository corrections before the label change. After an authorized change, refresh each affected inventory, render instructions from their source, and run its taxonomy and repository checks. Record the label IDs, issue assignments and repository commits together. If the API cannot change scope, prepare a replacement plan with history and recovery limits before requesting migration approval.
+
 ## Issue Creation Routing
 
 Never create a tracked issue directly from an orchestration or review session. Route it through the TPM pipeline (project-management skill), which owns labels, project, priority, estimate, and relations.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -25,7 +25,11 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 ### Project taxonomy
 
-The taxonomy the label preflight in `references/labels.md` validates every final label set against. `surface` names the one place a person meets the work, so app work sorts from package work: a create or a label update whose final set carries no `surface`, or more than one, fails § Validation before any mutation. A label outside these categories is legacy and is not assigned here. The `agent` names themselves stay in `LINEAR_AGENT_LABELS` (`kendex.settings.toml` `[env]`), which is what `issues create` refuses against; this category only maps them onto the contract.
+Require one agent and one surface label. Surface means where a person meets the work. Agent names are declared by LINEAR_AGENT_LABELS in kendex.settings.toml. Labels outside these categories are legacy and are not assigned.
+
+Scope: `cli`, `harness` and `skills` belong to team `kendex`. All other labels in this taxonomy have workspace scope. `1.0` identifies kendex’s release set and requires team scope in a separately approved migration.
+
+Brad Mahaffey owns shared label names and scope. Follow the Linear skill’s Shared label maintenance procedure for definition changes.
 
 ```json
 {
@@ -33,7 +37,8 @@ The taxonomy the label preflight in `references/labels.md` validates every final
   "categories": {
     "agent": {"required": true, "exclusive": true, "match": {"prefix": "agent:"}, "forbid_group_labels": true},
     "surface": {"required": true, "exclusive": true, "labels": ["app", "cli", "skills", "harness", "ci-infra", "docs", "releases"]},
-    "stack": {"required": false, "exclusive": false, "labels": ["rust-core", "iced", "test", "security", "macos", "windows", "linux"]},
+    "stack": {"required": false, "exclusive": false, "labels": ["rust-core", "iced", "test", "security"]},
+    "platform": {"required": false, "exclusive": true, "labels": ["macos", "windows", "linux"]},
     "classification": {"required": false, "exclusive": false, "labels": ["bug", "feature", "refactor", "design", "chore", "owner-gated", "1.0"]},
     "workflow": {"required": false, "exclusive": false, "labels": ["research", "needs-research", "baseline", "blocked"]}
   }

--- a/.agents/skills/project-management/references/labels.md
+++ b/.agents/skills/project-management/references/labels.md
@@ -30,6 +30,8 @@ Safe inventory row shape:
 
 If `is_group` is absent, refresh the cache. If it stays absent, treat any label that appears as another label's `parent` as a group label and never assign it.
 
+For Linear, match each label by ID and scope as well as name. The inventory's `team` is empty for a workspace label. A team label must belong to the issue's team. A project taxonomy states which labels are shared and which belong to its team; prose using this existing `team` representation is sufficient. If a name is ambiguous, resolve its ID before mutation. Definition changes follow [Linear shared label maintenance](../../linear/SKILL.md#shared-label-maintenance).
+
 ## Project Taxonomy Contract
 
 Storage may be TOML, JSON, or prose mapping unambiguously to this shape:

--- a/.agents/skills/project-management/references/labels.md
+++ b/.agents/skills/project-management/references/labels.md
@@ -30,7 +30,7 @@ Safe inventory row shape:
 
 If `is_group` is absent, refresh the cache. If it stays absent, treat any label that appears as another label's `parent` as a group label and never assign it.
 
-For Linear, match each label by ID and scope as well as name. The inventory's `team` is empty for a workspace label. A team label must belong to the issue's team. A project taxonomy states which labels are shared and which belong to its team; prose using this existing `team` representation is sufficient. If a name is ambiguous, resolve its ID before mutation. Definition changes follow [Linear shared label maintenance](../../linear/SKILL.md#shared-label-maintenance).
+For Linear, match each label by ID and scope as well as name. The inventory's `team` is empty for a workspace label. A team label must belong to the issue's team. A project taxonomy states which labels are shared and which belong to its team; prose using this existing `team` representation is sufficient. The CLI's `--labels` resolves names. If the mutation credential can see multiple labels with the same name, stop before mutation and report their IDs and scopes. Definition changes follow [Linear shared label maintenance](../../linear/SKILL.md#shared-label-maintenance).
 
 ## Project Taxonomy Contract
 

--- a/kendex-local.toml
+++ b/kendex-local.toml
@@ -13,7 +13,11 @@ all = "Problems with a kendex-owned skill go through `kendex report`; check owne
 project-management = '''
 ### Project taxonomy
 
-The taxonomy the label preflight in `references/labels.md` validates every final label set against. `surface` names the one place a person meets the work, so app work sorts from package work: a create or a label update whose final set carries no `surface`, or more than one, fails § Validation before any mutation. A label outside these categories is legacy and is not assigned here. The `agent` names themselves stay in `LINEAR_AGENT_LABELS` (`kendex.settings.toml` `[env]`), which is what `issues create` refuses against; this category only maps them onto the contract.
+Require one agent and one surface label. Surface means where a person meets the work. Agent names are declared by LINEAR_AGENT_LABELS in kendex.settings.toml. Labels outside these categories are legacy and are not assigned.
+
+Scope: `cli`, `harness` and `skills` belong to team `kendex`. All other labels in this taxonomy have workspace scope. `1.0` identifies kendex’s release set and requires team scope in a separately approved migration.
+
+Brad Mahaffey owns shared label names and scope. Follow the Linear skill’s Shared label maintenance procedure for definition changes.
 
 ```json
 {
@@ -21,7 +25,8 @@ The taxonomy the label preflight in `references/labels.md` validates every final
   "categories": {
     "agent": {"required": true, "exclusive": true, "match": {"prefix": "agent:"}, "forbid_group_labels": true},
     "surface": {"required": true, "exclusive": true, "labels": ["app", "cli", "skills", "harness", "ci-infra", "docs", "releases"]},
-    "stack": {"required": false, "exclusive": false, "labels": ["rust-core", "iced", "test", "security", "macos", "windows", "linux"]},
+    "stack": {"required": false, "exclusive": false, "labels": ["rust-core", "iced", "test", "security"]},
+    "platform": {"required": false, "exclusive": true, "labels": ["macos", "windows", "linux"]},
     "classification": {"required": false, "exclusive": false, "labels": ["bug", "feature", "refactor", "design", "chore", "owner-gated", "1.0"]},
     "workflow": {"required": false, "exclusive": false, "labels": ["research", "needs-research", "baseline", "blocked"]}
   }

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -60,6 +60,16 @@ The cache is `.cache/linear` under the physical worktree root ([README.md](READM
 
 `LINEAR_API_KEY` belongs in `.env.local`; non-secret defaults in committed `kendex.settings.toml` `[env]`. A key from project files beats one inherited from the environment, and `auth-check` warns (fingerprints only) when it shadows a differing inherited key.
 
+## Shared label maintenance
+
+`LINEAR_TEAM` requires a target before writes; it does not restrict an API key or check a label's owning team. `auth-check` verifies authentication and the local target, not the key's permission mask. Inspect key permissions in Linear settings; report fingerprints only.
+
+Before changing a label definition, read its ID, team, parent and group status. An empty team means workspace scope. Read issue use across affected teams and check references in their manifests, scripts, gates and generated instructions. A team-restricted key cannot establish workspace-wide issue use.
+
+The workspace owner coordinates shared label changes with affected repository maintainers. A repository taxonomy names that owner. Keep generic labels shared and project-specific labels team-scoped. Obtain approval for the concrete affected set before a shared rename, scope change, replacement or deletion. Issue-label assignment authority does not authorize changing a shared label definition.
+
+Prepare dependent repository corrections before the label change. After an authorized change, refresh each affected inventory, render instructions from their source, and run its taxonomy and repository checks. Record the label IDs, issue assignments and repository commits together. If the API cannot change scope, prepare a replacement plan with history and recovery limits before requesting migration approval.
+
 ## Issue Creation Routing
 
 Never create a tracked issue directly from an orchestration or review session. Route it through the TPM pipeline (project-management skill), which owns labels, project, priority, estimate, and relations.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -66,7 +66,7 @@ The cache is `.cache/linear` under the physical worktree root ([README.md](READM
 
 Before changing a label definition, read its ID, team, parent and group status. An empty team means workspace scope. Read issue use across affected teams and check references in their manifests, scripts, gates and generated instructions. A team-restricted key cannot establish workspace-wide issue use.
 
-The workspace owner coordinates shared label changes with affected repository maintainers. A repository taxonomy names that owner. Keep generic labels shared and project-specific labels team-scoped. Obtain approval for the concrete affected set before a shared rename, scope change, replacement or deletion. Issue-label assignment authority does not authorize changing a shared label definition.
+The workspace owner coordinates shared label changes with affected repository maintainers. A repository taxonomy names that owner. Keep generic labels shared and project-specific labels team-scoped. Obtain approval for the concrete affected set and the exact proposed change before any shared-label definition change, replacement or deletion. Issue-label assignment authority does not authorize changing a shared label definition.
 
 Prepare dependent repository corrections before the label change. After an authorized change, refresh each affected inventory, render instructions from their source, and run its taxonomy and repository checks. Record the label IDs, issue assignments and repository commits together. If the API cannot change scope, prepare a replacement plan with history and recovery limits before requesting migration approval.
 

--- a/skills/project-management/references/labels.md
+++ b/skills/project-management/references/labels.md
@@ -30,6 +30,8 @@ Safe inventory row shape:
 
 If `is_group` is absent, refresh the cache. If it stays absent, treat any label that appears as another label's `parent` as a group label and never assign it.
 
+For Linear, match each label by ID and scope as well as name. The inventory's `team` is empty for a workspace label. A team label must belong to the issue's team. A project taxonomy states which labels are shared and which belong to its team; prose using this existing `team` representation is sufficient. If a name is ambiguous, resolve its ID before mutation. Definition changes follow [Linear shared label maintenance](../../linear/SKILL.md#shared-label-maintenance).
+
 ## Project Taxonomy Contract
 
 Storage may be TOML, JSON, or prose mapping unambiguously to this shape:

--- a/skills/project-management/references/labels.md
+++ b/skills/project-management/references/labels.md
@@ -30,7 +30,7 @@ Safe inventory row shape:
 
 If `is_group` is absent, refresh the cache. If it stays absent, treat any label that appears as another label's `parent` as a group label and never assign it.
 
-For Linear, match each label by ID and scope as well as name. The inventory's `team` is empty for a workspace label. A team label must belong to the issue's team. A project taxonomy states which labels are shared and which belong to its team; prose using this existing `team` representation is sufficient. If a name is ambiguous, resolve its ID before mutation. Definition changes follow [Linear shared label maintenance](../../linear/SKILL.md#shared-label-maintenance).
+For Linear, match each label by ID and scope as well as name. The inventory's `team` is empty for a workspace label. A team label must belong to the issue's team. A project taxonomy states which labels are shared and which belong to its team; prose using this existing `team` representation is sufficient. The CLI's `--labels` resolves names. If the mutation credential can see multiple labels with the same name, stop before mutation and report their IDs and scopes. Definition changes follow [Linear shared label maintenance](../../linear/SKILL.md#shared-label-maintenance).
 
 ## Project Taxonomy Contract
 


### PR DESCRIPTION
A repository taxonomy task can change a workspace label used by other teams. The instructions now require an owner, affected-team checks, reference checks and approval of both the affected set and exact shared-label change. The label preflight checks IDs and team scope through the existing inventory fields. It stops on visible namesakes because the CLI accepts label names rather than selected IDs.

Kendex's local taxonomy names the shared-label owner and current scopes. It keeps the required agent and surface categories and separates the existing platform labels into an optional exclusive category. The generated instructions are included.

Part of [KEN-1290](https://linear.app/vanillagreen/issue/KEN-1290). Its audit report and unexecuted migration plan are attached to the issue. Consumer repository corrections remain separate. This PR makes no live label changes.

Validation:

- Source specialist review passed with no findings. The reviewed source diff hash remained unchanged through main-checkout rendering and replay.
- Full `tools/guard --full` passed with the handoff's `TMPDIR=/var/tmp/ken-c` and inherited Git directory/index overrides unset. The initial run's outside-project fixture failed under the inherited dev-tree temporary directory; no source fix was needed.
- Preflight, the commit guard chain and the taxonomy check passed. The taxonomy check includes its rejection control.
- Project-scope render verification passed on main before replay and after restoration: 140 checked, 140 OK. Main returned clean and its write slot was released before worktree validation.

## Size

The issue declares no expected-delta allowance. The size checker reports 26 production-category additions, 0 test additions and 12 render-mirror additions. All changed files contain instructions or their configuration.

The overseer approved reviewed head 0a31534e6013b47df6803df52639bd6f37608d0b plus exactly the two bot-triage corrections in 08d9c1b8278f1aabd6762fae4158080a740f2cbc. The original source-review fingerprints remain preserved; the correction diff is separate. Full validation and the commit checks also passed for the correction. Merge still requires current checks and resolved threads. Consumer work remains pending.
