### PR TITLE
test(KEN-1241): the writer suite as tables over the post log

### DIFF
--- a/.agents/skills/review-gate/tests/review-writer.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer.test.sh
@@ -84,28 +84,6 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  fi
-}
-
-assert_not_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        must not contain: %s\n' "$name" "$needle"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
-
 # Sandbox: the real writer + its real settings lib, next to a stubbed
 # predicate.
 mkdir -p "$TMP_ROOT/scripts/lib" "$TMP_ROOT/bin"
@@ -121,6 +99,7 @@ cat > "$TMP_ROOT/scripts/review-predicate.sh" <<'EOF'
 # hands down (the override-context cases).
 if [[ -n "${STUB_PREDICATE_ENV_LOG:-}" ]]; then
   printf 'OVERRIDE=%s\n' "${REVIEW_GATE_OVERRIDE_CONTEXT-<unset>}" >> "$STUB_PREDICATE_ENV_LOG"
+  printf 'AUTHOR=%s\n' "${PR_AUTHOR-<unset>}" >> "$STUB_PREDICATE_ENV_LOG"
 fi
 if [[ "${STUB_PREDICATE_RC:-0}" != "0" ]]; then
   echo "::error::stubbed predicate failure" >&2
@@ -167,6 +146,7 @@ case "$args" in
       echo "HTTP 500" >&2
       exit 1
     fi
+    if [[ "$guard" == "whitespace" ]]; then printf '   \n'; exit 0; fi
     printf '%s\n' "$guard"
     if [[ -n "${STUB_GUARD_HISTORY_PAGE2:-}" ]]; then printf '%s\n' "$STUB_GUARD_HISTORY_PAGE2"; fi
     ;;
@@ -213,375 +193,236 @@ fi
 EOF
 chmod +x "$TMP_ROOT/bin/date"
 
-# run_writer [ENV=val ...] — runs the writer under the stubs in the
-# single-head recursive contract (PR_NUMBER + HEAD_SHA set) with fresh
-# POST/rerun logs; prints stdout+stderr, returns its exit code. EVENT_NAME
-# defaults to pull_request_target; only merge_group changes behavior.
-# Settings resolve from /dev/null (built-in defaults) unless a case
-# overrides REVIEW_GATE_SETTINGS_FILE.
-POST_LOG="$TMP_ROOT/post.log"
-RERUN_LOG="$TMP_ROOT/rerun.log"
-ATTEMPT_LOG="$TMP_ROOT/rerun-attempts.log"
-run_writer() {
-  : > "$POST_LOG"
-  : > "$RERUN_LOG"
-  : > "$ATTEMPT_LOG"
-  env PATH="$TMP_ROOT/bin:$PATH" \
-    GH_REPO=acme/widgets PR_NUMBER=7 HEAD_SHA=headsha PR_AUTHOR=pr-author \
-    EVENT_NAME=pull_request_target \
-    REVIEW_GATE_SETTINGS_FILE=/dev/null \
-    STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
-    STUB_RERUN_ATTEMPT_LOG="$ATTEMPT_LOG" \
-    "$@" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1
-}
-
-# The pending status text the predicate emits for this verdict. The
-# writer is idempotent on state+description, so the fixture histories
-# below reuse this exact string.
+# The verdict lines the stubbed predicate answers with. The writer is
+# idempotent on state+description, so the fixture histories below reuse the
+# awaiting detail exactly.
 AWAITING_DETAIL="no review evidence at headsha yet"
 AWAITING="verdict=awaiting detail=$AWAITING_DETAIL"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
 CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
 THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
-UNREASONED_DETAIL="1 decline(s) name no mechanism — give a passing state, a false premise, or an excluded class with the fact that puts it there"
-UNREASONED="verdict=unreasoned-decline detail=$UNREASONED_DETAIL"
-UNTRACKED_DETAIL="1 tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
-UNTRACKED="verdict=untracked-claim detail=$UNTRACKED_DETAIL"
+UNREASONED="verdict=unreasoned-decline detail=1 decline names no mechanism"
+UNTRACKED="verdict=untracked-claim detail=1 tracking claim names no issue"
 
-# created_at anchors: OLD predates every stub run's start (RUN_START =
-# OLD and every evaluation instant; LATE lands after RUN_START but
-# before now; FUTURE postdates every evaluation instant.
+# created_at anchors: OLD predates every evaluation instant; FUTURE postdates
+# every one; SAME is the instant a `date` shim pins the evaluation to.
 OLD="2020-01-01T00:00:00Z"
-# RECENT is five minutes ago: inside the stall bound (so markers dated with
-# it exercise the WAITING path) but strictly BEFORE this run's evaluation
-# instant, so it does not also trip the ordering guard. Markers dated
-# OLD are past the bound and exercise the self-heal path.
-RECENT="$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-  || date -u -v-5M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
-LATE="2020-12-31T00:00:00Z"
 FUTURE="2999-01-01T00:00:00Z"
+SAME="2026-06-15T12:00:00Z"
+entry() { # state, description, created_at -> one gate status row
+  printf '{"context":"Review gate","state":"%s","description":"%s","created_at":"%s"}' "$1" "$2" "$3"
+}
+H_PENDING_OLD="[$(entry pending "$AWAITING_DETAIL" "$OLD")]"
+H_PENDING_OLD_X="[$(entry pending x "$OLD")]"
+H_SUCCESS_OLD="[$(entry success "reviewed at head with no unresolved threads" "$OLD")]"
+H_PENDING_REVIEWED_OLD="[$(entry pending "reviewed at head with no unresolved threads" "$OLD")]"
+H_FAILURE_OLD="[$(entry failure "standing review changes requested" "$OLD")]"
+H_SUCCESS_FUTURE="[$(entry success ok "$FUTURE")]"
+G_PENDING_FUTURE="[$(entry pending "newer writer run" "$FUTURE")]"
+G_PENDING_SAME="[$(entry pending "same-second write" "$SAME")]"
+G_SUCCESS_FUTURE="[$(entry success "operator override (ctx) : real reason" "$FUTURE")]"
+G_FAILURE_FUTURE="[$(entry failure newer "$FUTURE")]"
+OPEN2='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}},{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]'
+OPEN7='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}}]'
+OPEN8='[{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]'
+OPEN_GHOST='[{"number":9,"head":{"sha":"sha9"},"user":null}]'
+ERROR_PAGE='{"message":"Server Error"}'
 
-echo "=== downward transitions are direct posts, idempotent, never deferred ==="
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w1: awaiting exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=pending" "w1: awaiting posts pending"
-assert_contains "$(cat "$POST_LOG")" "context=Review gate" "w1: post carries the default gate context"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w1: no rerun on a downward transition"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "w2: the idempotent no-op exits 0"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w2: second evaluation of an unchanged state posts nothing (one entry total)"
-assert_contains "$out" "nothing to do" "w2: reports the no-op"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$CR" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w3: changes-requested exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w3: posts failure over a newer success — downward posts never defer"
-assert_not_contains "$out" "deferring" "w3: no deferral on the downward path"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w3: no rerun on changes-requested"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$THREADS" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w4: threads-open exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=pending" "w4: threads-open posts pending"
-
-# w8: a decline naming no mechanism is a failure, not a pending — the gate
-# must go red rather than wait for something to converge. Driven through
-# the writer, because the mapping line alone reads the same whether the
-# verdict is spelled right or not.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNREASONED" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w8: unreasoned-decline exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w8: unreasoned-decline posts failure"
-assert_contains "$(cat "$POST_LOG")" "$UNREASONED_DETAIL" "w8: the remedy reaches the status description"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNREASONED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w8b: unreasoned-decline over a newer success exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w8b: posts failure over it — a downward post never defers"
-assert_not_contains "$out" "deferring" "w8b: no deferral on the downward path"
-
-# w9: a reply claiming tracking that names no issue is the other red verdict.
-# Driven through the writer for the same reason w8 is: the mapping line reads
-# the same whether the verdict is spelled right or not, and an unmapped
-# verdict exits 1 on "unknown verdict" instead of posting anything.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w9: untracked-claim exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w9: untracked-claim posts failure"
-assert_contains "$(cat "$POST_LOG")" "$UNTRACKED_DETAIL" "w9: the remedy reaches the status description"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w9b: untracked-claim over a newer success exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w9b: posts failure over it — a downward post never defers"
-assert_not_contains "$out" "deferring" "w9b: no deferral on the downward path"
-
-echo "=== approved converges to success ==="
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"reviewed at head with no unresolved threads","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "w5: approved with the same success entry exits 0"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w5: unchanged success posts nothing (idempotent)"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "w6: approved over pending exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=success" "w6: a reviewed head opens the gate"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w6: the writer never re-runs CI (branch protection owns that)"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"failure","description":"standing review changes requested","created_at":"'"$OLD"'"}]') || rc=$?
-assert_contains "$(cat "$POST_LOG")" "state=success" "w7: a dismissed objection reopens the gate"
-
-echo "=== VST-65 ordering guard (success posts only) ==="
-
-PENDING_OLD='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]'
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer writer run","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w10: stale success defers with exit 0"
-assert_contains "$out" "deferring the success post" "w10: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w10: deferred success posts nothing"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_DATE_FIXED="2026-06-15T12:00:00Z" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"same-second write","created_at":"2026-06-15T12:00:00Z"}]') || rc=$?
-assert_eq "$rc" "0" "w10b: same-second non-success write exits 0"
-assert_contains "$out" "deferring the success post" "w10b: equality defers (one-second resolution)"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w10b: no post on the equal-second boundary"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"success","description":"operator override (ctx) : real reason","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w10c: a newer SUCCESS entry also defers (exit 0)"
-assert_contains "$out" "deferring the success post" "w10c: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w10c: the stale run must not overwrite the newer success's description"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY=fail) || rc=$?
-assert_eq "$rc" "0" "w11: failed guard re-read defers with exit 0 (fail-safe side)"
-assert_contains "$out" "deferring the success post" "w11: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11: no post on an unreadable re-read"
-
-# A MALFORMED re-read must land on the same fail-safe side as a failed one:
-# a whitespace-only success slurps to [] and an error-object page collapses
-# through `add` — both would report newer=0 and permit exactly the stale
-# success the guard exists to block.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY=$' \n  \n') || rc=$?
-assert_eq "$rc" "0" "w11b: whitespace-only guard re-read defers with exit 0"
-assert_contains "$out" "deferring the success post" "w11b: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11b: no post past a vacuous guard re-read"
-
-# EMPTY object, deliberately: `{"message":...}` would have deferred under
-# the OLD filter too (`.[]` yields the string, `.context` on a string is a
-# jq error → guard_newer="" → defer), proving nothing. `{}` collapses
-# through the old `add // [] | .[]` to zero rows → newer=0 → stale success
-# POSTS under the old code; only the all-arrays validation defers it.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='{}') || rc=$?
-assert_eq "$rc" "0" "w11c: empty-object guard re-read defers with exit 0 (the old filter posted through it)"
-assert_contains "$out" "deferring the success post" "w11c: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11c: no post past a malformed guard re-read"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$CR" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w12: downward posts never consult the guard"
-assert_not_contains "$out" "deferring" "w12: and never defer"
-
-echo "=== fail loud, act never ==="
-
-set +e
-out=$(run_writer STUB_PREDICATE_RC=2 STUB_GATE_HISTORY='[]')
-rc=$?
-set -e
-assert_eq "$rc" "1" "w21: predicate failure exits 1"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w21: no POST and no rerun on predicate failure"
-
-set +e
-out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=fail)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w22: status-history read failure exits 1"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w22: no action on history read failure"
-
-# A SUCCESSFUL read that produced zero bytes is a broken read, not an empty
-# page (`[]`) — slurped silently it would misread current state (here) or
-# report a green zero-PR convergence (w22c below).
-set +e
-out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=emptybytes)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w22b: zero-byte status-history read exits 1"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22b: no POST past a zero-byte read"
-
-set +e
-out=$(env -u HEAD_SHA PATH="$TMP_ROOT/bin:$PATH" \
-  GH_REPO=acme/widgets PR_NUMBER=7 EVENT_NAME=pull_request_target \
-  REVIEW_GATE_SETTINGS_FILE=/dev/null \
-  STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
-  STUB_VERDICT_LINE="$AWAITING" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w23: PR_NUMBER without HEAD_SHA exits 1 (recursive contract)"
-
-echo "=== leg routing: converge-all on every leg ==="
-
-# A broken predicate (RC=2) proves these legs never consult it: if the
-# guard regressed and the predicate ran, the exit code would flip to 1.
-rc=0; out=$(run_writer STUB_PREDICATE_RC=2 WRITER_READ_ONLY=1) || rc=$?
-assert_eq "$rc" "0" "w24: fork pull_request_review (read-only token) exits 0"
-assert_contains "$out" "no-op" "w24: names the no-op"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w24: read-only run posts and reruns nothing"
-
-rc=0; out=$(run_writer STUB_PREDICATE_RC=2 EVENT_NAME=merge_group) || rc=$?
-assert_eq "$rc" "0" "w25: merge_group leg exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=success" "w25: merge-group sha gets the unconditional success"
-assert_contains "$(cat "$POST_LOG")" "merge-queue entry" "w25: post says why"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w25: queue leg never reruns"
-
-# Converge-all enumeration (binding F2: EVERY leg, not just
-# schedule/dispatch). `env -u` scrubs the single-PR identifiers so the
-# top-level invocation enumerates.
-run_writer_all() {
-  : > "$POST_LOG"
-  : > "$RERUN_LOG"
-  : > "$ATTEMPT_LOG"
-  local event="$1"; shift
-  local -a runner=()
-  command -v timeout >/dev/null 2>&1 && runner=(timeout 90)
-  env -u PR_NUMBER -u HEAD_SHA -u PR_AUTHOR \
-    PATH="$TMP_ROOT/bin:$PATH" \
-    GH_REPO=acme/widgets EVENT_NAME="$event" \
-    REVIEW_GATE_SETTINGS_FILE=/dev/null \
-    STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
-    STUB_RERUN_ATTEMPT_LOG="$ATTEMPT_LOG" \
-    "$@" "${runner[@]+"${runner[@]}"}" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1
+# run_writer MODE ENV — runs the writer under the stubs. MODE is `single`
+# (the single-head recursive contract: PR_NUMBER and HEAD_SHA set), `nohead`
+# (PR_NUMBER without HEAD_SHA), or `all:<event>` (the identifiers scrubbed
+# so the top-level invocation enumerates every open PR). ENV is a
+# semicolon-separated list of `env` arguments, applied after the defaults so
+# a row may override any of them. Every run gets its own post log and
+# predicate-environment log under $RUN. OUT is stdout and stderr together;
+# RC the exit status. Settings resolve from /dev/null (built-in defaults)
+# unless a row overrides REVIEW_GATE_SETTINGS_FILE.
+RUN_SEQ=0
+run_writer() {
+  local mode="$1" env_list="$2" env_args=() unset=() ids=() runner=()
+  [[ -z "$env_list" ]] || IFS=';' read -ra env_args <<<"$env_list"
+  RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"
+  mkdir -p "$RUN"
+  : > "$RUN/post.log"
+  : > "$RUN/predicate-env.log"
+  case "$mode" in
+    single) ids=(PR_NUMBER=7 HEAD_SHA=headsha PR_AUTHOR=pr-author) ;;
+    nohead) unset=(-u HEAD_SHA); ids=(PR_NUMBER=7) ;;
+    all:*)  unset=(-u PR_NUMBER -u HEAD_SHA -u PR_AUTHOR); ids=("EVENT_NAME=${mode#all:}")
+            # A converge-all pass forks the writer once per PR; the bound is
+            # what turns a hang there into a red rather than a stuck shard.
+            command -v timeout >/dev/null 2>&1 && runner=(timeout 90) ;;
+    *) printf 'run_writer: unknown mode %s\n' "$mode" >&2; exit 1 ;;
+  esac
+  set +e
+  OUT=$(env ${unset[@]+"${unset[@]}"} PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets \
+    EVENT_NAME=pull_request_target REVIEW_GATE_SETTINGS_FILE=/dev/null \
+    STUB_POST_LOG="$RUN/post.log" STUB_PREDICATE_ENV_LOG="$RUN/predicate-env.log" \
+    "${ids[@]}" ${env_args[@]+"${env_args[@]}"} \
+    ${runner[@]+"${runner[@]}"} bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1)
+  RC=$?
+  set -e
 }
 
-OPEN2='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}},{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]'
+# observe EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order, so a row fails on the field it names:
+#   rc         exit status
+#   posts      every status POST in order as `<state>@<sha>`, or none
+#   context    the distinct gate contexts posted, `+` for a space
+#   desc       the last post's description, `+` for a space
+#   desc~<t>   whether the last post's description carries <t>
+#   says~<t>   whether the output carries <t>, `+` read as a space
+#   override   the REVIEW_GATE_OVERRIDE_CONTEXT the predicate saw: unset, its
+#              value, or none when the predicate never ran
+#   author     the PR_AUTHOR values the predicate saw, `-` for an empty one
+observe() {
+  local got="" token name value line needle
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) value="$RC" ;;
+      posts)
+        value=""
+        while IFS= read -r line; do
+          [[ -n "$line" ]] || continue
+          line="${line#post:-X POST repos/acme/widgets/statuses/}"
+          value="$value,${line#* -f state=}"
+          value="${value%% -f *}@${line%% -f *}"
+        done <"$RUN/post.log"
+        value="${value#,}"; value="${value:-none}" ;;
+      context)
+        value="$(sed -n 's/.* -f context=\(.*\) -f description=.*/\1/p' "$RUN/post.log" | sort -u | paste -sd, - | tr ' ' '+')"
+        value="${value:-none}" ;;
+      desc)
+        value="$(sed -n '$s/.* -f description=\(.*\) -f target_url=.*/\1/p; $s/.* -f description=\(.*\)$/\1/p' "$RUN/post.log" | tr ' ' '+')"
+        value="${value:-none}" ;;
+      desc~*)
+        needle="${name#desc~}"; needle="${needle//+/ }"
+        line="$(sed -n '$p' "$RUN/post.log")"
+        value="$(grep -qF -- "-f description=${needle}" <<<"$line" || grep -qF -- "$needle" <<<"${line#* -f description=}" && echo true || echo false)" ;;
+      says~*)
+        needle="${name#says~}"; needle="${needle//+/ }"
+        value="$(grep -qF -- "$needle" <<<"$OUT" && echo true || echo false)" ;;
+      override)
+        value="$(sed -n 's/^OVERRIDE=//p' "$RUN/predicate-env.log" | sort -u | paste -sd, -)"
+        value="${value//</}"; value="${value//>/}"; value="${value:-none}" ;;
+      author)
+        value="$(sed -n 's/^AUTHOR=//p; s/^AUTHOR=$/-/p' "$RUN/predicate-env.log" | sed 's/^$/-/' | paste -sd, -)"
+        value="${value//</}"; value="${value//>/}"; value="${value:-none}" ;;
+      *) value=UNKNOWN_FIELD ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
+}
 
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w26: all-PRs pass over two PRs exits 0"
-assert_contains "$out" "converging 2 open PR(s)" "w26: reports the enumeration"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "2" "w26: one post per open PR"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha7" "w26: converged PR #7's head"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "w26: converged PR #8's head"
+# table ROW... — one run and one assertion per row: `label|mode|env|expect`.
+table() {
+  local row label mode env expect
+  for row in "$@"; do
+    IFS='|' read -r label mode env expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    run_writer "$mode" "$env"
+    assert_eq "$(observe "$expect")" "$expect" "$label"
+  done
+}
 
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w27b: all-PRs approved pass exits 0"
-assert_eq "$(grep -c 'state=success' "$POST_LOG")" "2" "w27b: both approved heads open"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w27b: and the writer re-runs nothing"
+echo "=== downward transitions are direct posts, idempotent, never deferred ==="
+# A decline naming no mechanism and a tracking claim naming no issue are
+# failures, not pendings: the gate goes red rather than waiting for something
+# to converge. Both are driven through the writer because the mapping line
+# alone reads the same whether the verdict is spelled right or not, and an
+# unmapped verdict exits 1 on "unknown verdict" instead of posting.
+table \
+  "w1: awaiting with no gate status posts pending under the default gate context|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=[]|rc=0 posts=pending@headsha context=Review+gate" \
+  "w2: a second evaluation of an unchanged state posts nothing and reports the no-op|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=$H_PENDING_OLD|rc=0 posts=none says~nothing+to+do=true" \
+  "w2b: the same state under a different description is re-posted|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=$H_PENDING_OLD_X|rc=0 posts=pending@headsha desc=no+review+evidence+at+headsha+yet" \
+  "w3: changes-requested posts failure over a newer success without deferring|single|STUB_VERDICT_LINE=$CR;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false" \
+  "w4: threads-open posts pending|single|STUB_VERDICT_LINE=$THREADS;STUB_GATE_HISTORY=[]|rc=0 posts=pending@headsha" \
+  "w8: unreasoned-decline posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+decline+names+no+mechanism" \
+  "w8b: unreasoned-decline over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false" \
+  "w9: untracked-claim posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+tracking+claim+names+no+issue" \
+  "w9b: untracked-claim over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false"
 
-set +e
-out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]' STUB_PREDICATE_FAIL_PR=7)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w27: one failing PR fails the pass"
-assert_contains "$out" "convergence failed for PR #7" "w27: names the failing PR"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "w27: the other PR is still converged"
+echo "=== approved converges to success ==="
+table \
+  "w5: approved with the same success entry posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "w5b: the same description under a different state is re-posted|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_REVIEWED_OLD|rc=0 posts=success@headsha" \
+  "w6: a reviewed head over pending opens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD|rc=0 posts=success@headsha" \
+  "w7: a dismissed objection reopens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_FAILURE_OLD|rc=0 posts=success@headsha"
 
-# Binding F2's teeth: an EVENT leg (here workflow_run) also enumerates every
-# open PR — the payload sha is deliberately unused, so a pending run evicted
-# by a burst strands nothing (whichever run survives converges everyone).
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$AWAITING" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w28: event leg exits 0"
-assert_contains "$out" "converging 2 open PR(s)" "w28: event legs converge ALL open PRs, not the payload head"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha7" "w28: converged PR #7"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "w28: converged PR #8"
+echo "=== the ordering guard (success posts only) ==="
+# The guard re-reads before a success post and defers, exit 0 and no POST,
+# to any entry at or after this run's evaluation instant: a newer
+# non-success, a same-second write (>=, one-second resolution), and a newer
+# SUCCESS too, whose description carries the audit detail a stale run must
+# not overwrite. A re-read that fails or is malformed lands on the same
+# fail-safe side: a whitespace-only page slurps to [] and an empty object
+# collapses through `add`, and both would report newer=0 and permit exactly
+# the stale success the guard exists to block. Downward posts never consult
+# it.
+table \
+  "w10: a newer non-success entry defers the success post|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=$G_PENDING_FUTURE|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w10b: a same-second non-success write still defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_DATE_FIXED=$SAME;STUB_GUARD_HISTORY=$G_PENDING_SAME|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w10c: a newer SUCCESS entry also defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=$G_SUCCESS_FUTURE|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w11: a failed guard re-read defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=fail|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w11b: a whitespace-only guard re-read defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=whitespace|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w11c: an empty-object guard re-read defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY={}|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w12: a downward post never consults the guard and never defers|single|STUB_VERDICT_LINE=$CR;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=$G_PENDING_FUTURE|rc=0 posts=failure@headsha says~deferring=false"
 
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS='[]') || rc=$?
-assert_eq "$rc" "0" "w29: zero open PRs exits 0"
-assert_contains "$out" "converging 0 open PR(s)" "w29: names the empty pass"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w29: posts nothing (a superseded sha's completion converges nothing, naturally)"
+echo "=== fail loud, act never ==="
+# A read the writer cannot trust is exit 1 and no POST: a failed predicate, a
+# failed or zero-byte status read (a SUCCESSFUL call producing zero bytes is
+# a broken read, not the empty page `[]`), a status page that is not an
+# array (an error object, or whitespace that slurps to []), and the
+# recursive contract's missing HEAD_SHA. The gh stub answers any endpoint the
+# writer is not meant to touch with exit 1, so a rerun or run read would
+# surface here as a red too.
+table \
+  "w21: a predicate failure exits 1 and posts nothing|single|STUB_PREDICATE_RC=2;STUB_GATE_HISTORY=[]|rc=1 posts=none" \
+  "w22: a failed status-history read exits 1 and posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=fail|rc=1 posts=none" \
+  "w22b: a zero-byte status-history read exits 1 and posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=emptybytes|rc=1 posts=none says~zero+bytes=true" \
+  "w22f: an error-object status page exits 1 naming the shape violation|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$ERROR_PAGE|rc=1 posts=none says~not+arrays=true" \
+  "w22g: a whitespace-only status-history read exits 1 naming the shape violation|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=whitespace|rc=1 posts=none says~not+arrays=true" \
+  "w23: PR_NUMBER without HEAD_SHA exits 1 (recursive contract)|nohead|STUB_VERDICT_LINE=$AWAITING|rc=1 posts=none"
 
-# w22c: the empty-page case above is exactly why zero BYTES must fail loud —
-# the two are adjacent shapes with opposite meanings (`[]` = truly no open
-# PRs; nothing at all = a broken read that would strand every gate green).
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS=emptybytes 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22c: zero-byte open-PR listing exits 1"
-assert_contains "$out" "zero bytes" "w22c: names the broken read"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22c: posts nothing on a broken listing"
-
-# The two adjacent shapes the -z guard cannot see: whitespace-only slurps to
-# [] and an error-object page to {} — both would read as "zero open PRs"
-# and exit green.
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS=whitespace 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22d: whitespace-only open-PR listing exits 1"
-assert_contains "$out" "not arrays" "w22d: names the shape violation"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22d: posts nothing"
-
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS='{"message":"Server Error"}' 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22e: an error-object page exits 1"
-assert_contains "$out" "not arrays" "w22e: names the shape violation"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22e: posts nothing"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='{"message":"Server Error"}' 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22f: an error-object status page exits 1"
-assert_contains "$out" "not arrays" "w22f: names the shape violation (a red for another reason is not this guard)"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22f: no post past a malformed status page"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=$' \n  \n' 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22g: a whitespace-only status-history read exits 1 (slurps to [], not an empty status set)"
-assert_contains "$out" "not arrays" "w22g: names the shape violation"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22g: posts nothing"
-
-# A ghost-authored PR (user serialized null) enumerates with an empty
-# author; the predicate resolves the real author itself downstream.
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" \
-  STUB_OPEN_PRS='[{"number":9,"head":{"sha":"sha9"},"user":null}]' \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w26c: ghost-authored PR exits 0"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha9" "w26c: ghost-authored PR still converges (empty PR_AUTHOR handed down)"
+echo "=== leg routing: converge-all on every leg ==="
+# A broken predicate (exit 2) proves the read-only and merge-group legs never
+# consult it: if the guard regressed and the predicate ran, the exit would
+# flip to 1. Every other leg enumerates every open PR — the payload sha is
+# deliberately unused, so a pending run evicted by a burst strands nothing —
+# and one failing PR fails the pass while the others still converge. Zero
+# bytes, whitespace and an error object are the three shapes adjacent to
+# `[]` (truly no open PRs) that must fail loud rather than strand every gate
+# green; a ghost-authored PR enumerates with an empty author.
+table \
+  "w24: a read-only token (fork pull_request_review) is a no-op that posts nothing and never consults the predicate|single|STUB_PREDICATE_RC=2;WRITER_READ_ONLY=1|rc=0 posts=none says~no-op=true" \
+  "w25: the merge_group leg posts an unconditional success saying why, never consulting the predicate|single|STUB_PREDICATE_RC=2;EVENT_NAME=merge_group|rc=0 posts=success@headsha desc~merge-queue+entry=true" \
+  "w26: a schedule pass over two open PRs converges both heads, each under its own author|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 author=alice,bob says~converging+2+open+PR(s)=true" \
+  "w27b: an approved schedule pass opens both heads|all:schedule|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[]|rc=0 posts=success@sha7,success@sha8" \
+  "w27: one failing PR fails the pass, is named, and the other PR still converges|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[];STUB_PREDICATE_FAIL_PR=7|rc=1 posts=pending@sha8 says~convergence+failed+for+PR+#7=true" \
+  "w28: an event leg converges ALL open PRs, not the payload head|all:workflow_run|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 says~converging+2+open+PR(s)=true" \
+  "w29: zero open PRs is a named empty pass that posts nothing|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=[]|rc=0 posts=none says~converging+0+open+PR(s)=true" \
+  "w22c: a zero-byte open-PR listing exits 1 naming the broken read|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=emptybytes|rc=1 posts=none says~zero+bytes=true" \
+  "w22d: a whitespace-only open-PR listing exits 1 naming the shape violation|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=whitespace|rc=1 posts=none says~not+arrays=true" \
+  "w22e: an error-object open-PR page exits 1 naming the shape violation|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=$ERROR_PAGE|rc=1 posts=none says~not+arrays=true" \
+  "w26c: a ghost-authored PR still converges, with an empty PR_AUTHOR handed down|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN_GHOST;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha9 author=-"
 
 echo "=== pagination merges (one array per page; page limits strand state) ==="
-
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" \
-  STUB_OPEN_PRS='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}}]' \
-  STUB_OPEN_PRS_PAGE2='[{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]' \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "wp1: paginated enumeration exits 0"
-assert_contains "$out" "converging 2 open PR(s)" "wp1: PRs beyond page one are enumerated (never stranded)"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "wp1: the page-two PR is converged"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"x","created_at":"'"$OLD"'"}]' \
-  STUB_GATE_HISTORY_PAGE2='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "wp2: paginated projection exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=success" "wp2: the projection merges every page before deciding"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]' \
-  STUB_GUARD_HISTORY='[]' \
-  STUB_GUARD_HISTORY_PAGE2='[{"context":"Review gate","state":"failure","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "wp3: paginated guard re-read exits 0"
-assert_contains "$out" "deferring the success post" "wp3: a newer non-success entry on page two still defers (no first-page-only fail-open)"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "wp3: no post past the paginated guard"
+table \
+  "wp1: a PR beyond page one is enumerated and converged|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN7;STUB_OPEN_PRS_PAGE2=$OPEN8;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 says~converging+2+open+PR(s)=true" \
+  "wp2: the projection merges every page before deciding: a success on page two alone is already converged|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=[];STUB_GATE_HISTORY_PAGE2=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "wp3: a newer non-success entry on the guard's page two still defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=[];STUB_GUARD_HISTORY_PAGE2=$G_FAILURE_FUTURE|rc=0 posts=none says~deferring+the+success+post=true"
 
 echo "=== settings: the writer never rewrites the override context ==="
+# REVIEW_GATE_OVERRIDE_CONTEXT is resolved in review-predicate.sh, so every
+# live gate read honors it; the writer must not export its own resolution on
+# top of that, with or without a settings file naming one.
+printf 'REVIEW_GATE_OVERRIDE_CONTEXT = "ops-override"\n' >"$TMP_ROOT/override-settings.toml"
+table \
+  "w30: a settings file naming an override context leaves it to the predicate|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=[];REVIEW_GATE_SETTINGS_FILE=$TMP_ROOT/override-settings.toml|rc=0 override=unset" \
+  "w30b: an absent override key leaves the predicate's own resolution untouched|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=[]|rc=0 override=unset"
 
-# REVIEW_GATE_OVERRIDE_CONTEXT is resolved in review-predicate.sh (so EVERY
-# live gate read honors it, not just this writer — pre-PR review finding 4);
-# the writer must not export its own resolution on top of that.
-ENV_LOG="$TMP_ROOT/predicate-env.log"
-cat > "$TMP_ROOT/override-settings.toml" <<'EOF'
-REVIEW_GATE_OVERRIDE_CONTEXT = "ops-override"
-EOF
-: > "$ENV_LOG"
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
-  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/override-settings.toml" \
-  STUB_PREDICATE_ENV_LOG="$ENV_LOG") || rc=$?
-assert_eq "$rc" "0" "w30: override-context settings file exits 0"
-assert_contains "$(cat "$ENV_LOG")" "OVERRIDE=<unset>" "w30: the writer leaves the override context entirely to the predicate (one mechanism, honored by every reader)"
-
-: > "$ENV_LOG"
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
-  STUB_PREDICATE_ENV_LOG="$ENV_LOG") || rc=$?
-assert_eq "$rc" "0" "w30b: absent override key exits 0"
-assert_contains "$(cat "$ENV_LOG")" "OVERRIDE=<unset>" "w30b: absent key leaves the predicate's own resolution untouched"
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/review-gate/tests/review-writer.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer.test.sh
@@ -216,6 +216,12 @@ H_PENDING_OLD="[$(entry pending "$AWAITING_DETAIL" "$OLD")]"
 H_PENDING_OLD_X="[$(entry pending x "$OLD")]"
 H_SUCCESS_OLD="[$(entry success "reviewed at head with no unresolved threads" "$OLD")]"
 H_PENDING_REVIEWED_OLD="[$(entry pending "reviewed at head with no unresolved threads" "$OLD")]"
+# The commit-status API caps a description at 140 characters; the writer
+# truncates there and compares the truncated form when it decides a no-op.
+LONG_DETAIL="1 decline names no mechanism: give a passing state or a false premise it disproves, a label alone is not a reason, and the gate will not clear until then"
+LONG_DETAIL_140="${LONG_DETAIL:0:140}"
+LONG_UNREASONED="verdict=unreasoned-decline detail=$LONG_DETAIL"
+H_FAILURE_LONG_OLD="[$(entry failure "$LONG_DETAIL_140" "$OLD")]"
 H_FAILURE_OLD="[$(entry failure "standing review changes requested" "$OLD")]"
 H_SUCCESS_FUTURE="[$(entry success ok "$FUTURE")]"
 G_PENDING_FUTURE="[$(entry pending "newer writer run" "$FUTURE")]"
@@ -318,13 +324,14 @@ observe() {
 
 # table ROW... — one run and one assertion per row: `label|mode|env|expect`.
 table() {
-  local row label mode env expect
+  local row label mode env expect before=$((PASS + FAIL))
   for row in "$@"; do
     IFS='|' read -r label mode env expect <<<"$row"
     [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
     run_writer "$mode" "$env"
     assert_eq "$(observe "$expect")" "$expect" "$label"
   done
+  [[ "$((PASS + FAIL))" -gt "$before" ]] || { echo "table: no row was asserted" >&2; exit 2; }
 }
 
 echo "=== downward transitions are direct posts, idempotent, never deferred ==="
@@ -342,11 +349,13 @@ table \
   "w8: unreasoned-decline posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+decline+names+no+mechanism" \
   "w8b: unreasoned-decline over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false" \
   "w9: untracked-claim posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+tracking+claim+names+no+issue" \
+  "w9c: a detail past the API's 140 characters is posted truncated there|single|STUB_VERDICT_LINE=$LONG_UNREASONED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=${LONG_DETAIL_140// /+}" \
+  "w9d: the no-op check compares the truncated form, so a long detail already posted is not re-posted|single|STUB_VERDICT_LINE=$LONG_UNREASONED;STUB_GATE_HISTORY=$H_FAILURE_LONG_OLD|rc=0 posts=none says~nothing+to+do=true" \
   "w9b: untracked-claim over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false"
 
 echo "=== approved converges to success ==="
 table \
-  "w5: approved with the same success entry posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "w5: approved with the same success entry posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_SUCCESS_OLD|rc=0 posts=none says~nothing+to+do=true" \
   "w5b: the same description under a different state is re-posted|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_REVIEWED_OLD|rc=0 posts=success@headsha" \
   "w6: a reviewed head over pending opens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD|rc=0 posts=success@headsha" \
   "w7: a dismissed objection reopens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_FAILURE_OLD|rc=0 posts=success@headsha"
@@ -411,7 +420,7 @@ table \
 echo "=== pagination merges (one array per page; page limits strand state) ==="
 table \
   "wp1: a PR beyond page one is enumerated and converged|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN7;STUB_OPEN_PRS_PAGE2=$OPEN8;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 says~converging+2+open+PR(s)=true" \
-  "wp2: the projection merges every page before deciding: a success on page two alone is already converged|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=[];STUB_GATE_HISTORY_PAGE2=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "wp2: the projection merges every page before deciding: a success on page two alone is already converged|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=[];STUB_GATE_HISTORY_PAGE2=$H_SUCCESS_OLD|rc=0 posts=none says~nothing+to+do=true" \
   "wp3: a newer non-success entry on the guard's page two still defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=[];STUB_GUARD_HISTORY_PAGE2=$G_FAILURE_FUTURE|rc=0 posts=none says~deferring+the+success+post=true"
 
 echo "=== settings: the writer never rewrites the override context ==="

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -84,28 +84,6 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  fi
-}
-
-assert_not_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        must not contain: %s\n' "$name" "$needle"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
-
 # Sandbox: the real writer + its real settings lib, next to a stubbed
 # predicate.
 mkdir -p "$TMP_ROOT/scripts/lib" "$TMP_ROOT/bin"
@@ -121,6 +99,7 @@ cat > "$TMP_ROOT/scripts/review-predicate.sh" <<'EOF'
 # hands down (the override-context cases).
 if [[ -n "${STUB_PREDICATE_ENV_LOG:-}" ]]; then
   printf 'OVERRIDE=%s\n' "${REVIEW_GATE_OVERRIDE_CONTEXT-<unset>}" >> "$STUB_PREDICATE_ENV_LOG"
+  printf 'AUTHOR=%s\n' "${PR_AUTHOR-<unset>}" >> "$STUB_PREDICATE_ENV_LOG"
 fi
 if [[ "${STUB_PREDICATE_RC:-0}" != "0" ]]; then
   echo "::error::stubbed predicate failure" >&2
@@ -167,6 +146,7 @@ case "$args" in
       echo "HTTP 500" >&2
       exit 1
     fi
+    if [[ "$guard" == "whitespace" ]]; then printf '   \n'; exit 0; fi
     printf '%s\n' "$guard"
     if [[ -n "${STUB_GUARD_HISTORY_PAGE2:-}" ]]; then printf '%s\n' "$STUB_GUARD_HISTORY_PAGE2"; fi
     ;;
@@ -213,375 +193,236 @@ fi
 EOF
 chmod +x "$TMP_ROOT/bin/date"
 
-# run_writer [ENV=val ...] — runs the writer under the stubs in the
-# single-head recursive contract (PR_NUMBER + HEAD_SHA set) with fresh
-# POST/rerun logs; prints stdout+stderr, returns its exit code. EVENT_NAME
-# defaults to pull_request_target; only merge_group changes behavior.
-# Settings resolve from /dev/null (built-in defaults) unless a case
-# overrides REVIEW_GATE_SETTINGS_FILE.
-POST_LOG="$TMP_ROOT/post.log"
-RERUN_LOG="$TMP_ROOT/rerun.log"
-ATTEMPT_LOG="$TMP_ROOT/rerun-attempts.log"
-run_writer() {
-  : > "$POST_LOG"
-  : > "$RERUN_LOG"
-  : > "$ATTEMPT_LOG"
-  env PATH="$TMP_ROOT/bin:$PATH" \
-    GH_REPO=acme/widgets PR_NUMBER=7 HEAD_SHA=headsha PR_AUTHOR=pr-author \
-    EVENT_NAME=pull_request_target \
-    REVIEW_GATE_SETTINGS_FILE=/dev/null \
-    STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
-    STUB_RERUN_ATTEMPT_LOG="$ATTEMPT_LOG" \
-    "$@" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1
-}
-
-# The pending status text the predicate emits for this verdict. The
-# writer is idempotent on state+description, so the fixture histories
-# below reuse this exact string.
+# The verdict lines the stubbed predicate answers with. The writer is
+# idempotent on state+description, so the fixture histories below reuse the
+# awaiting detail exactly.
 AWAITING_DETAIL="no review evidence at headsha yet"
 AWAITING="verdict=awaiting detail=$AWAITING_DETAIL"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
 CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
 THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
-UNREASONED_DETAIL="1 decline(s) name no mechanism — give a passing state, a false premise, or an excluded class with the fact that puts it there"
-UNREASONED="verdict=unreasoned-decline detail=$UNREASONED_DETAIL"
-UNTRACKED_DETAIL="1 tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
-UNTRACKED="verdict=untracked-claim detail=$UNTRACKED_DETAIL"
+UNREASONED="verdict=unreasoned-decline detail=1 decline names no mechanism"
+UNTRACKED="verdict=untracked-claim detail=1 tracking claim names no issue"
 
-# created_at anchors: OLD predates every stub run's start (RUN_START =
-# OLD and every evaluation instant; LATE lands after RUN_START but
-# before now; FUTURE postdates every evaluation instant.
+# created_at anchors: OLD predates every evaluation instant; FUTURE postdates
+# every one; SAME is the instant a `date` shim pins the evaluation to.
 OLD="2020-01-01T00:00:00Z"
-# RECENT is five minutes ago: inside the stall bound (so markers dated with
-# it exercise the WAITING path) but strictly BEFORE this run's evaluation
-# instant, so it does not also trip the ordering guard. Markers dated
-# OLD are past the bound and exercise the self-heal path.
-RECENT="$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-  || date -u -v-5M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
-LATE="2020-12-31T00:00:00Z"
 FUTURE="2999-01-01T00:00:00Z"
+SAME="2026-06-15T12:00:00Z"
+entry() { # state, description, created_at -> one gate status row
+  printf '{"context":"Review gate","state":"%s","description":"%s","created_at":"%s"}' "$1" "$2" "$3"
+}
+H_PENDING_OLD="[$(entry pending "$AWAITING_DETAIL" "$OLD")]"
+H_PENDING_OLD_X="[$(entry pending x "$OLD")]"
+H_SUCCESS_OLD="[$(entry success "reviewed at head with no unresolved threads" "$OLD")]"
+H_PENDING_REVIEWED_OLD="[$(entry pending "reviewed at head with no unresolved threads" "$OLD")]"
+H_FAILURE_OLD="[$(entry failure "standing review changes requested" "$OLD")]"
+H_SUCCESS_FUTURE="[$(entry success ok "$FUTURE")]"
+G_PENDING_FUTURE="[$(entry pending "newer writer run" "$FUTURE")]"
+G_PENDING_SAME="[$(entry pending "same-second write" "$SAME")]"
+G_SUCCESS_FUTURE="[$(entry success "operator override (ctx) : real reason" "$FUTURE")]"
+G_FAILURE_FUTURE="[$(entry failure newer "$FUTURE")]"
+OPEN2='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}},{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]'
+OPEN7='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}}]'
+OPEN8='[{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]'
+OPEN_GHOST='[{"number":9,"head":{"sha":"sha9"},"user":null}]'
+ERROR_PAGE='{"message":"Server Error"}'
 
-echo "=== downward transitions are direct posts, idempotent, never deferred ==="
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w1: awaiting exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=pending" "w1: awaiting posts pending"
-assert_contains "$(cat "$POST_LOG")" "context=Review gate" "w1: post carries the default gate context"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w1: no rerun on a downward transition"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "w2: the idempotent no-op exits 0"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w2: second evaluation of an unchanged state posts nothing (one entry total)"
-assert_contains "$out" "nothing to do" "w2: reports the no-op"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$CR" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w3: changes-requested exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w3: posts failure over a newer success — downward posts never defer"
-assert_not_contains "$out" "deferring" "w3: no deferral on the downward path"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w3: no rerun on changes-requested"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$THREADS" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w4: threads-open exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=pending" "w4: threads-open posts pending"
-
-# w8: a decline naming no mechanism is a failure, not a pending — the gate
-# must go red rather than wait for something to converge. Driven through
-# the writer, because the mapping line alone reads the same whether the
-# verdict is spelled right or not.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNREASONED" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w8: unreasoned-decline exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w8: unreasoned-decline posts failure"
-assert_contains "$(cat "$POST_LOG")" "$UNREASONED_DETAIL" "w8: the remedy reaches the status description"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNREASONED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w8b: unreasoned-decline over a newer success exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w8b: posts failure over it — a downward post never defers"
-assert_not_contains "$out" "deferring" "w8b: no deferral on the downward path"
-
-# w9: a reply claiming tracking that names no issue is the other red verdict.
-# Driven through the writer for the same reason w8 is: the mapping line reads
-# the same whether the verdict is spelled right or not, and an unmapped
-# verdict exits 1 on "unknown verdict" instead of posting anything.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w9: untracked-claim exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w9: untracked-claim posts failure"
-assert_contains "$(cat "$POST_LOG")" "$UNTRACKED_DETAIL" "w9: the remedy reaches the status description"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w9b: untracked-claim over a newer success exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w9b: posts failure over it — a downward post never defers"
-assert_not_contains "$out" "deferring" "w9b: no deferral on the downward path"
-
-echo "=== approved converges to success ==="
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"reviewed at head with no unresolved threads","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "w5: approved with the same success entry exits 0"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w5: unchanged success posts nothing (idempotent)"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "w6: approved over pending exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=success" "w6: a reviewed head opens the gate"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w6: the writer never re-runs CI (branch protection owns that)"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"failure","description":"standing review changes requested","created_at":"'"$OLD"'"}]') || rc=$?
-assert_contains "$(cat "$POST_LOG")" "state=success" "w7: a dismissed objection reopens the gate"
-
-echo "=== VST-65 ordering guard (success posts only) ==="
-
-PENDING_OLD='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]'
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer writer run","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w10: stale success defers with exit 0"
-assert_contains "$out" "deferring the success post" "w10: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w10: deferred success posts nothing"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_DATE_FIXED="2026-06-15T12:00:00Z" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"same-second write","created_at":"2026-06-15T12:00:00Z"}]') || rc=$?
-assert_eq "$rc" "0" "w10b: same-second non-success write exits 0"
-assert_contains "$out" "deferring the success post" "w10b: equality defers (one-second resolution)"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w10b: no post on the equal-second boundary"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"success","description":"operator override (ctx) : real reason","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "w10c: a newer SUCCESS entry also defers (exit 0)"
-assert_contains "$out" "deferring the success post" "w10c: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w10c: the stale run must not overwrite the newer success's description"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY=fail) || rc=$?
-assert_eq "$rc" "0" "w11: failed guard re-read defers with exit 0 (fail-safe side)"
-assert_contains "$out" "deferring the success post" "w11: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11: no post on an unreadable re-read"
-
-# A MALFORMED re-read must land on the same fail-safe side as a failed one:
-# a whitespace-only success slurps to [] and an error-object page collapses
-# through `add` — both would report newer=0 and permit exactly the stale
-# success the guard exists to block.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY=$' \n  \n') || rc=$?
-assert_eq "$rc" "0" "w11b: whitespace-only guard re-read defers with exit 0"
-assert_contains "$out" "deferring the success post" "w11b: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11b: no post past a vacuous guard re-read"
-
-# EMPTY object, deliberately: `{"message":...}` would have deferred under
-# the OLD filter too (`.[]` yields the string, `.context` on a string is a
-# jq error → guard_newer="" → defer), proving nothing. `{}` collapses
-# through the old `add // [] | .[]` to zero rows → newer=0 → stale success
-# POSTS under the old code; only the all-arrays validation defers it.
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='{}') || rc=$?
-assert_eq "$rc" "0" "w11c: empty-object guard re-read defers with exit 0 (the old filter posted through it)"
-assert_contains "$out" "deferring the success post" "w11c: names the deferral"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11c: no post past a malformed guard re-read"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$CR" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_contains "$(cat "$POST_LOG")" "state=failure" "w12: downward posts never consult the guard"
-assert_not_contains "$out" "deferring" "w12: and never defer"
-
-echo "=== fail loud, act never ==="
-
-set +e
-out=$(run_writer STUB_PREDICATE_RC=2 STUB_GATE_HISTORY='[]')
-rc=$?
-set -e
-assert_eq "$rc" "1" "w21: predicate failure exits 1"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w21: no POST and no rerun on predicate failure"
-
-set +e
-out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=fail)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w22: status-history read failure exits 1"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w22: no action on history read failure"
-
-# A SUCCESSFUL read that produced zero bytes is a broken read, not an empty
-# page (`[]`) — slurped silently it would misread current state (here) or
-# report a green zero-PR convergence (w22c below).
-set +e
-out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=emptybytes)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w22b: zero-byte status-history read exits 1"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22b: no POST past a zero-byte read"
-
-set +e
-out=$(env -u HEAD_SHA PATH="$TMP_ROOT/bin:$PATH" \
-  GH_REPO=acme/widgets PR_NUMBER=7 EVENT_NAME=pull_request_target \
-  REVIEW_GATE_SETTINGS_FILE=/dev/null \
-  STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
-  STUB_VERDICT_LINE="$AWAITING" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w23: PR_NUMBER without HEAD_SHA exits 1 (recursive contract)"
-
-echo "=== leg routing: converge-all on every leg ==="
-
-# A broken predicate (RC=2) proves these legs never consult it: if the
-# guard regressed and the predicate ran, the exit code would flip to 1.
-rc=0; out=$(run_writer STUB_PREDICATE_RC=2 WRITER_READ_ONLY=1) || rc=$?
-assert_eq "$rc" "0" "w24: fork pull_request_review (read-only token) exits 0"
-assert_contains "$out" "no-op" "w24: names the no-op"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w24: read-only run posts and reruns nothing"
-
-rc=0; out=$(run_writer STUB_PREDICATE_RC=2 EVENT_NAME=merge_group) || rc=$?
-assert_eq "$rc" "0" "w25: merge_group leg exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=success" "w25: merge-group sha gets the unconditional success"
-assert_contains "$(cat "$POST_LOG")" "merge-queue entry" "w25: post says why"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w25: queue leg never reruns"
-
-# Converge-all enumeration (binding F2: EVERY leg, not just
-# schedule/dispatch). `env -u` scrubs the single-PR identifiers so the
-# top-level invocation enumerates.
-run_writer_all() {
-  : > "$POST_LOG"
-  : > "$RERUN_LOG"
-  : > "$ATTEMPT_LOG"
-  local event="$1"; shift
-  local -a runner=()
-  command -v timeout >/dev/null 2>&1 && runner=(timeout 90)
-  env -u PR_NUMBER -u HEAD_SHA -u PR_AUTHOR \
-    PATH="$TMP_ROOT/bin:$PATH" \
-    GH_REPO=acme/widgets EVENT_NAME="$event" \
-    REVIEW_GATE_SETTINGS_FILE=/dev/null \
-    STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
-    STUB_RERUN_ATTEMPT_LOG="$ATTEMPT_LOG" \
-    "$@" "${runner[@]+"${runner[@]}"}" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1
+# run_writer MODE ENV — runs the writer under the stubs. MODE is `single`
+# (the single-head recursive contract: PR_NUMBER and HEAD_SHA set), `nohead`
+# (PR_NUMBER without HEAD_SHA), or `all:<event>` (the identifiers scrubbed
+# so the top-level invocation enumerates every open PR). ENV is a
+# semicolon-separated list of `env` arguments, applied after the defaults so
+# a row may override any of them. Every run gets its own post log and
+# predicate-environment log under $RUN. OUT is stdout and stderr together;
+# RC the exit status. Settings resolve from /dev/null (built-in defaults)
+# unless a row overrides REVIEW_GATE_SETTINGS_FILE.
+RUN_SEQ=0
+run_writer() {
+  local mode="$1" env_list="$2" env_args=() unset=() ids=() runner=()
+  [[ -z "$env_list" ]] || IFS=';' read -ra env_args <<<"$env_list"
+  RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"
+  mkdir -p "$RUN"
+  : > "$RUN/post.log"
+  : > "$RUN/predicate-env.log"
+  case "$mode" in
+    single) ids=(PR_NUMBER=7 HEAD_SHA=headsha PR_AUTHOR=pr-author) ;;
+    nohead) unset=(-u HEAD_SHA); ids=(PR_NUMBER=7) ;;
+    all:*)  unset=(-u PR_NUMBER -u HEAD_SHA -u PR_AUTHOR); ids=("EVENT_NAME=${mode#all:}")
+            # A converge-all pass forks the writer once per PR; the bound is
+            # what turns a hang there into a red rather than a stuck shard.
+            command -v timeout >/dev/null 2>&1 && runner=(timeout 90) ;;
+    *) printf 'run_writer: unknown mode %s\n' "$mode" >&2; exit 1 ;;
+  esac
+  set +e
+  OUT=$(env ${unset[@]+"${unset[@]}"} PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets \
+    EVENT_NAME=pull_request_target REVIEW_GATE_SETTINGS_FILE=/dev/null \
+    STUB_POST_LOG="$RUN/post.log" STUB_PREDICATE_ENV_LOG="$RUN/predicate-env.log" \
+    "${ids[@]}" ${env_args[@]+"${env_args[@]}"} \
+    ${runner[@]+"${runner[@]}"} bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1)
+  RC=$?
+  set -e
 }
 
-OPEN2='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}},{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]'
+# observe EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order, so a row fails on the field it names:
+#   rc         exit status
+#   posts      every status POST in order as `<state>@<sha>`, or none
+#   context    the distinct gate contexts posted, `+` for a space
+#   desc       the last post's description, `+` for a space
+#   desc~<t>   whether the last post's description carries <t>
+#   says~<t>   whether the output carries <t>, `+` read as a space
+#   override   the REVIEW_GATE_OVERRIDE_CONTEXT the predicate saw: unset, its
+#              value, or none when the predicate never ran
+#   author     the PR_AUTHOR values the predicate saw, `-` for an empty one
+observe() {
+  local got="" token name value line needle
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) value="$RC" ;;
+      posts)
+        value=""
+        while IFS= read -r line; do
+          [[ -n "$line" ]] || continue
+          line="${line#post:-X POST repos/acme/widgets/statuses/}"
+          value="$value,${line#* -f state=}"
+          value="${value%% -f *}@${line%% -f *}"
+        done <"$RUN/post.log"
+        value="${value#,}"; value="${value:-none}" ;;
+      context)
+        value="$(sed -n 's/.* -f context=\(.*\) -f description=.*/\1/p' "$RUN/post.log" | sort -u | paste -sd, - | tr ' ' '+')"
+        value="${value:-none}" ;;
+      desc)
+        value="$(sed -n '$s/.* -f description=\(.*\) -f target_url=.*/\1/p; $s/.* -f description=\(.*\)$/\1/p' "$RUN/post.log" | tr ' ' '+')"
+        value="${value:-none}" ;;
+      desc~*)
+        needle="${name#desc~}"; needle="${needle//+/ }"
+        line="$(sed -n '$p' "$RUN/post.log")"
+        value="$(grep -qF -- "-f description=${needle}" <<<"$line" || grep -qF -- "$needle" <<<"${line#* -f description=}" && echo true || echo false)" ;;
+      says~*)
+        needle="${name#says~}"; needle="${needle//+/ }"
+        value="$(grep -qF -- "$needle" <<<"$OUT" && echo true || echo false)" ;;
+      override)
+        value="$(sed -n 's/^OVERRIDE=//p' "$RUN/predicate-env.log" | sort -u | paste -sd, -)"
+        value="${value//</}"; value="${value//>/}"; value="${value:-none}" ;;
+      author)
+        value="$(sed -n 's/^AUTHOR=//p; s/^AUTHOR=$/-/p' "$RUN/predicate-env.log" | sed 's/^$/-/' | paste -sd, -)"
+        value="${value//</}"; value="${value//>/}"; value="${value:-none}" ;;
+      *) value=UNKNOWN_FIELD ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
+}
 
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w26: all-PRs pass over two PRs exits 0"
-assert_contains "$out" "converging 2 open PR(s)" "w26: reports the enumeration"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "2" "w26: one post per open PR"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha7" "w26: converged PR #7's head"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "w26: converged PR #8's head"
+# table ROW... — one run and one assertion per row: `label|mode|env|expect`.
+table() {
+  local row label mode env expect
+  for row in "$@"; do
+    IFS='|' read -r label mode env expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    run_writer "$mode" "$env"
+    assert_eq "$(observe "$expect")" "$expect" "$label"
+  done
+}
 
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w27b: all-PRs approved pass exits 0"
-assert_eq "$(grep -c 'state=success' "$POST_LOG")" "2" "w27b: both approved heads open"
-assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w27b: and the writer re-runs nothing"
+echo "=== downward transitions are direct posts, idempotent, never deferred ==="
+# A decline naming no mechanism and a tracking claim naming no issue are
+# failures, not pendings: the gate goes red rather than waiting for something
+# to converge. Both are driven through the writer because the mapping line
+# alone reads the same whether the verdict is spelled right or not, and an
+# unmapped verdict exits 1 on "unknown verdict" instead of posting.
+table \
+  "w1: awaiting with no gate status posts pending under the default gate context|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=[]|rc=0 posts=pending@headsha context=Review+gate" \
+  "w2: a second evaluation of an unchanged state posts nothing and reports the no-op|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=$H_PENDING_OLD|rc=0 posts=none says~nothing+to+do=true" \
+  "w2b: the same state under a different description is re-posted|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=$H_PENDING_OLD_X|rc=0 posts=pending@headsha desc=no+review+evidence+at+headsha+yet" \
+  "w3: changes-requested posts failure over a newer success without deferring|single|STUB_VERDICT_LINE=$CR;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false" \
+  "w4: threads-open posts pending|single|STUB_VERDICT_LINE=$THREADS;STUB_GATE_HISTORY=[]|rc=0 posts=pending@headsha" \
+  "w8: unreasoned-decline posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+decline+names+no+mechanism" \
+  "w8b: unreasoned-decline over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false" \
+  "w9: untracked-claim posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+tracking+claim+names+no+issue" \
+  "w9b: untracked-claim over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false"
 
-set +e
-out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]' STUB_PREDICATE_FAIL_PR=7)
-rc=$?
-set -e
-assert_eq "$rc" "1" "w27: one failing PR fails the pass"
-assert_contains "$out" "convergence failed for PR #7" "w27: names the failing PR"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "w27: the other PR is still converged"
+echo "=== approved converges to success ==="
+table \
+  "w5: approved with the same success entry posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "w5b: the same description under a different state is re-posted|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_REVIEWED_OLD|rc=0 posts=success@headsha" \
+  "w6: a reviewed head over pending opens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD|rc=0 posts=success@headsha" \
+  "w7: a dismissed objection reopens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_FAILURE_OLD|rc=0 posts=success@headsha"
 
-# Binding F2's teeth: an EVENT leg (here workflow_run) also enumerates every
-# open PR — the payload sha is deliberately unused, so a pending run evicted
-# by a burst strands nothing (whichever run survives converges everyone).
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$AWAITING" STUB_OPEN_PRS="$OPEN2" \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w28: event leg exits 0"
-assert_contains "$out" "converging 2 open PR(s)" "w28: event legs converge ALL open PRs, not the payload head"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha7" "w28: converged PR #7"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "w28: converged PR #8"
+echo "=== the ordering guard (success posts only) ==="
+# The guard re-reads before a success post and defers, exit 0 and no POST,
+# to any entry at or after this run's evaluation instant: a newer
+# non-success, a same-second write (>=, one-second resolution), and a newer
+# SUCCESS too, whose description carries the audit detail a stale run must
+# not overwrite. A re-read that fails or is malformed lands on the same
+# fail-safe side: a whitespace-only page slurps to [] and an empty object
+# collapses through `add`, and both would report newer=0 and permit exactly
+# the stale success the guard exists to block. Downward posts never consult
+# it.
+table \
+  "w10: a newer non-success entry defers the success post|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=$G_PENDING_FUTURE|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w10b: a same-second non-success write still defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_DATE_FIXED=$SAME;STUB_GUARD_HISTORY=$G_PENDING_SAME|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w10c: a newer SUCCESS entry also defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=$G_SUCCESS_FUTURE|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w11: a failed guard re-read defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=fail|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w11b: a whitespace-only guard re-read defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=whitespace|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w11c: an empty-object guard re-read defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY={}|rc=0 posts=none says~deferring+the+success+post=true" \
+  "w12: a downward post never consults the guard and never defers|single|STUB_VERDICT_LINE=$CR;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=$G_PENDING_FUTURE|rc=0 posts=failure@headsha says~deferring=false"
 
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS='[]') || rc=$?
-assert_eq "$rc" "0" "w29: zero open PRs exits 0"
-assert_contains "$out" "converging 0 open PR(s)" "w29: names the empty pass"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w29: posts nothing (a superseded sha's completion converges nothing, naturally)"
+echo "=== fail loud, act never ==="
+# A read the writer cannot trust is exit 1 and no POST: a failed predicate, a
+# failed or zero-byte status read (a SUCCESSFUL call producing zero bytes is
+# a broken read, not the empty page `[]`), a status page that is not an
+# array (an error object, or whitespace that slurps to []), and the
+# recursive contract's missing HEAD_SHA. The gh stub answers any endpoint the
+# writer is not meant to touch with exit 1, so a rerun or run read would
+# surface here as a red too.
+table \
+  "w21: a predicate failure exits 1 and posts nothing|single|STUB_PREDICATE_RC=2;STUB_GATE_HISTORY=[]|rc=1 posts=none" \
+  "w22: a failed status-history read exits 1 and posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=fail|rc=1 posts=none" \
+  "w22b: a zero-byte status-history read exits 1 and posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=emptybytes|rc=1 posts=none says~zero+bytes=true" \
+  "w22f: an error-object status page exits 1 naming the shape violation|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$ERROR_PAGE|rc=1 posts=none says~not+arrays=true" \
+  "w22g: a whitespace-only status-history read exits 1 naming the shape violation|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=whitespace|rc=1 posts=none says~not+arrays=true" \
+  "w23: PR_NUMBER without HEAD_SHA exits 1 (recursive contract)|nohead|STUB_VERDICT_LINE=$AWAITING|rc=1 posts=none"
 
-# w22c: the empty-page case above is exactly why zero BYTES must fail loud —
-# the two are adjacent shapes with opposite meanings (`[]` = truly no open
-# PRs; nothing at all = a broken read that would strand every gate green).
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS=emptybytes 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22c: zero-byte open-PR listing exits 1"
-assert_contains "$out" "zero bytes" "w22c: names the broken read"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22c: posts nothing on a broken listing"
-
-# The two adjacent shapes the -z guard cannot see: whitespace-only slurps to
-# [] and an error-object page to {} — both would read as "zero open PRs"
-# and exit green.
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS=whitespace 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22d: whitespace-only open-PR listing exits 1"
-assert_contains "$out" "not arrays" "w22d: names the shape violation"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22d: posts nothing"
-
-rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS='{"message":"Server Error"}' 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22e: an error-object page exits 1"
-assert_contains "$out" "not arrays" "w22e: names the shape violation"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22e: posts nothing"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='{"message":"Server Error"}' 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22f: an error-object status page exits 1"
-assert_contains "$out" "not arrays" "w22f: names the shape violation (a red for another reason is not this guard)"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22f: no post past a malformed status page"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=$' \n  \n' 2>&1) || rc=$?
-assert_eq "$rc" "1" "w22g: a whitespace-only status-history read exits 1 (slurps to [], not an empty status set)"
-assert_contains "$out" "not arrays" "w22g: names the shape violation"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22g: posts nothing"
-
-# A ghost-authored PR (user serialized null) enumerates with an empty
-# author; the predicate resolves the real author itself downstream.
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" \
-  STUB_OPEN_PRS='[{"number":9,"head":{"sha":"sha9"},"user":null}]' \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "w26c: ghost-authored PR exits 0"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha9" "w26c: ghost-authored PR still converges (empty PR_AUTHOR handed down)"
+echo "=== leg routing: converge-all on every leg ==="
+# A broken predicate (exit 2) proves the read-only and merge-group legs never
+# consult it: if the guard regressed and the predicate ran, the exit would
+# flip to 1. Every other leg enumerates every open PR — the payload sha is
+# deliberately unused, so a pending run evicted by a burst strands nothing —
+# and one failing PR fails the pass while the others still converge. Zero
+# bytes, whitespace and an error object are the three shapes adjacent to
+# `[]` (truly no open PRs) that must fail loud rather than strand every gate
+# green; a ghost-authored PR enumerates with an empty author.
+table \
+  "w24: a read-only token (fork pull_request_review) is a no-op that posts nothing and never consults the predicate|single|STUB_PREDICATE_RC=2;WRITER_READ_ONLY=1|rc=0 posts=none says~no-op=true" \
+  "w25: the merge_group leg posts an unconditional success saying why, never consulting the predicate|single|STUB_PREDICATE_RC=2;EVENT_NAME=merge_group|rc=0 posts=success@headsha desc~merge-queue+entry=true" \
+  "w26: a schedule pass over two open PRs converges both heads, each under its own author|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 author=alice,bob says~converging+2+open+PR(s)=true" \
+  "w27b: an approved schedule pass opens both heads|all:schedule|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[]|rc=0 posts=success@sha7,success@sha8" \
+  "w27: one failing PR fails the pass, is named, and the other PR still converges|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[];STUB_PREDICATE_FAIL_PR=7|rc=1 posts=pending@sha8 says~convergence+failed+for+PR+#7=true" \
+  "w28: an event leg converges ALL open PRs, not the payload head|all:workflow_run|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN2;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 says~converging+2+open+PR(s)=true" \
+  "w29: zero open PRs is a named empty pass that posts nothing|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=[]|rc=0 posts=none says~converging+0+open+PR(s)=true" \
+  "w22c: a zero-byte open-PR listing exits 1 naming the broken read|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=emptybytes|rc=1 posts=none says~zero+bytes=true" \
+  "w22d: a whitespace-only open-PR listing exits 1 naming the shape violation|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=whitespace|rc=1 posts=none says~not+arrays=true" \
+  "w22e: an error-object open-PR page exits 1 naming the shape violation|all:workflow_run|STUB_VERDICT_LINE=$APPROVED;STUB_OPEN_PRS=$ERROR_PAGE|rc=1 posts=none says~not+arrays=true" \
+  "w26c: a ghost-authored PR still converges, with an empty PR_AUTHOR handed down|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN_GHOST;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha9 author=-"
 
 echo "=== pagination merges (one array per page; page limits strand state) ==="
-
-rc=0; out=$(run_writer_all schedule STUB_VERDICT_LINE="$AWAITING" \
-  STUB_OPEN_PRS='[{"number":7,"head":{"sha":"sha7"},"user":{"login":"alice"}}]' \
-  STUB_OPEN_PRS_PAGE2='[{"number":8,"head":{"sha":"sha8"},"user":{"login":"bob"}}]' \
-  STUB_GATE_HISTORY='[]') || rc=$?
-assert_eq "$rc" "0" "wp1: paginated enumeration exits 0"
-assert_contains "$out" "converging 2 open PR(s)" "wp1: PRs beyond page one are enumerated (never stranded)"
-assert_contains "$(cat "$POST_LOG")" "statuses/sha8" "wp1: the page-two PR is converged"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"x","created_at":"'"$OLD"'"}]' \
-  STUB_GATE_HISTORY_PAGE2='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$OLD"'"}]') || rc=$?
-assert_eq "$rc" "0" "wp2: paginated projection exits 0"
-assert_contains "$(cat "$POST_LOG")" "state=success" "wp2: the projection merges every page before deciding"
-
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]' \
-  STUB_GUARD_HISTORY='[]' \
-  STUB_GUARD_HISTORY_PAGE2='[{"context":"Review gate","state":"failure","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
-assert_eq "$rc" "0" "wp3: paginated guard re-read exits 0"
-assert_contains "$out" "deferring the success post" "wp3: a newer non-success entry on page two still defers (no first-page-only fail-open)"
-assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "wp3: no post past the paginated guard"
+table \
+  "wp1: a PR beyond page one is enumerated and converged|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN7;STUB_OPEN_PRS_PAGE2=$OPEN8;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 says~converging+2+open+PR(s)=true" \
+  "wp2: the projection merges every page before deciding: a success on page two alone is already converged|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=[];STUB_GATE_HISTORY_PAGE2=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "wp3: a newer non-success entry on the guard's page two still defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=[];STUB_GUARD_HISTORY_PAGE2=$G_FAILURE_FUTURE|rc=0 posts=none says~deferring+the+success+post=true"
 
 echo "=== settings: the writer never rewrites the override context ==="
+# REVIEW_GATE_OVERRIDE_CONTEXT is resolved in review-predicate.sh, so every
+# live gate read honors it; the writer must not export its own resolution on
+# top of that, with or without a settings file naming one.
+printf 'REVIEW_GATE_OVERRIDE_CONTEXT = "ops-override"\n' >"$TMP_ROOT/override-settings.toml"
+table \
+  "w30: a settings file naming an override context leaves it to the predicate|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=[];REVIEW_GATE_SETTINGS_FILE=$TMP_ROOT/override-settings.toml|rc=0 override=unset" \
+  "w30b: an absent override key leaves the predicate's own resolution untouched|single|STUB_VERDICT_LINE=$AWAITING;STUB_GATE_HISTORY=[]|rc=0 override=unset"
 
-# REVIEW_GATE_OVERRIDE_CONTEXT is resolved in review-predicate.sh (so EVERY
-# live gate read honors it, not just this writer — pre-PR review finding 4);
-# the writer must not export its own resolution on top of that.
-ENV_LOG="$TMP_ROOT/predicate-env.log"
-cat > "$TMP_ROOT/override-settings.toml" <<'EOF'
-REVIEW_GATE_OVERRIDE_CONTEXT = "ops-override"
-EOF
-: > "$ENV_LOG"
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
-  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/override-settings.toml" \
-  STUB_PREDICATE_ENV_LOG="$ENV_LOG") || rc=$?
-assert_eq "$rc" "0" "w30: override-context settings file exits 0"
-assert_contains "$(cat "$ENV_LOG")" "OVERRIDE=<unset>" "w30: the writer leaves the override context entirely to the predicate (one mechanism, honored by every reader)"
-
-: > "$ENV_LOG"
-rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
-  STUB_PREDICATE_ENV_LOG="$ENV_LOG") || rc=$?
-assert_eq "$rc" "0" "w30b: absent override key exits 0"
-assert_contains "$(cat "$ENV_LOG")" "OVERRIDE=<unset>" "w30b: absent key leaves the predicate's own resolution untouched"
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -216,6 +216,12 @@ H_PENDING_OLD="[$(entry pending "$AWAITING_DETAIL" "$OLD")]"
 H_PENDING_OLD_X="[$(entry pending x "$OLD")]"
 H_SUCCESS_OLD="[$(entry success "reviewed at head with no unresolved threads" "$OLD")]"
 H_PENDING_REVIEWED_OLD="[$(entry pending "reviewed at head with no unresolved threads" "$OLD")]"
+# The commit-status API caps a description at 140 characters; the writer
+# truncates there and compares the truncated form when it decides a no-op.
+LONG_DETAIL="1 decline names no mechanism: give a passing state or a false premise it disproves, a label alone is not a reason, and the gate will not clear until then"
+LONG_DETAIL_140="${LONG_DETAIL:0:140}"
+LONG_UNREASONED="verdict=unreasoned-decline detail=$LONG_DETAIL"
+H_FAILURE_LONG_OLD="[$(entry failure "$LONG_DETAIL_140" "$OLD")]"
 H_FAILURE_OLD="[$(entry failure "standing review changes requested" "$OLD")]"
 H_SUCCESS_FUTURE="[$(entry success ok "$FUTURE")]"
 G_PENDING_FUTURE="[$(entry pending "newer writer run" "$FUTURE")]"
@@ -318,13 +324,14 @@ observe() {
 
 # table ROW... — one run and one assertion per row: `label|mode|env|expect`.
 table() {
-  local row label mode env expect
+  local row label mode env expect before=$((PASS + FAIL))
   for row in "$@"; do
     IFS='|' read -r label mode env expect <<<"$row"
     [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
     run_writer "$mode" "$env"
     assert_eq "$(observe "$expect")" "$expect" "$label"
   done
+  [[ "$((PASS + FAIL))" -gt "$before" ]] || { echo "table: no row was asserted" >&2; exit 2; }
 }
 
 echo "=== downward transitions are direct posts, idempotent, never deferred ==="
@@ -342,11 +349,13 @@ table \
   "w8: unreasoned-decline posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+decline+names+no+mechanism" \
   "w8b: unreasoned-decline over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNREASONED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false" \
   "w9: untracked-claim posts failure with the remedy in the description|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=1+tracking+claim+names+no+issue" \
+  "w9c: a detail past the API's 140 characters is posted truncated there|single|STUB_VERDICT_LINE=$LONG_UNREASONED;STUB_GATE_HISTORY=[]|rc=0 posts=failure@headsha desc=${LONG_DETAIL_140// /+}" \
+  "w9d: the no-op check compares the truncated form, so a long detail already posted is not re-posted|single|STUB_VERDICT_LINE=$LONG_UNREASONED;STUB_GATE_HISTORY=$H_FAILURE_LONG_OLD|rc=0 posts=none says~nothing+to+do=true" \
   "w9b: untracked-claim over a newer success posts failure without deferring|single|STUB_VERDICT_LINE=$UNTRACKED;STUB_GATE_HISTORY=$H_SUCCESS_FUTURE|rc=0 posts=failure@headsha says~deferring=false"
 
 echo "=== approved converges to success ==="
 table \
-  "w5: approved with the same success entry posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "w5: approved with the same success entry posts nothing|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_SUCCESS_OLD|rc=0 posts=none says~nothing+to+do=true" \
   "w5b: the same description under a different state is re-posted|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_REVIEWED_OLD|rc=0 posts=success@headsha" \
   "w6: a reviewed head over pending opens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD|rc=0 posts=success@headsha" \
   "w7: a dismissed objection reopens the gate|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_FAILURE_OLD|rc=0 posts=success@headsha"
@@ -411,7 +420,7 @@ table \
 echo "=== pagination merges (one array per page; page limits strand state) ==="
 table \
   "wp1: a PR beyond page one is enumerated and converged|all:schedule|STUB_VERDICT_LINE=$AWAITING;STUB_OPEN_PRS=$OPEN7;STUB_OPEN_PRS_PAGE2=$OPEN8;STUB_GATE_HISTORY=[]|rc=0 posts=pending@sha7,pending@sha8 says~converging+2+open+PR(s)=true" \
-  "wp2: the projection merges every page before deciding: a success on page two alone is already converged|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=[];STUB_GATE_HISTORY_PAGE2=$H_SUCCESS_OLD|rc=0 posts=none" \
+  "wp2: the projection merges every page before deciding: a success on page two alone is already converged|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=[];STUB_GATE_HISTORY_PAGE2=$H_SUCCESS_OLD|rc=0 posts=none says~nothing+to+do=true" \
   "wp3: a newer non-success entry on the guard's page two still defers|single|STUB_VERDICT_LINE=$APPROVED;STUB_GATE_HISTORY=$H_PENDING_OLD;STUB_GUARD_HISTORY=[];STUB_GUARD_HISTORY_PAGE2=$G_FAILURE_FUTURE|rc=0 posts=none says~deferring+the+success+post=true"
 
 echo "=== settings: the writer never rewrites the override context ==="


### PR DESCRIPTION
KEN-1241 tests audit, lane E: `skills/review-gate/tests/review-writer.test.sh`.

## What changed

The 40 hand-written writer cases (112 assertions: a substring of the post log, a `wc -l` of it, a substring of the output, and a count of a rerun log no stub arm ever wrote) are seven tables of 44 rows over one renderer, `table`. A row names its mode (the single-head contract, the head-less contract, or a converge-all leg), its stub environment, and the fields it pins: `rc`, every status POST as `<state>@<sha>` in order, the gate `context`, the `desc`ription, the one output phrase (`says~`) that names the path, and what the predicate saw of the `override` context and the `author`. The script under test is unchanged.

The second commit is the reviewer's fixes: a table whose row list is emptied exits 2 (the guard every merged table suite carries); the two rows that pinned only `rc=0 posts=none`, also the read-only leg's answer, pin the no-op path's own phrase; and the description's 140-character API bound, which no fixture in either suite approached, has two rows (a 153-character detail posted truncated, and the truncated form in the gate history read as a no-op).

## Former assertions and surviving rows

Every old case label survives as a row of the same label; the new file adds w2b, w5b (the idempotence check's two halves), w9c and w9d (the 140-character bound). The reviewer's map: every assertion class is preserved at equal or greater tightness (a post's state gains its sha, count and order; a description or context gains whole-value equality; a `wc -l` gains which posts). The only drops are the eight `RERUN_LOG` counts (w1, w3, w6, w21, w22, w24, w25, w27b): the old gh stub had no arm that wrote that log, so they could not fail, and a planted unchecked rerun call left both suites green in the same measurement. The rc column reads a checked call to an endpoint the stub refuses (33 rows red); an unchecked one is visible in neither suite.

The ghost-author mutant (`.user.login // ""` to `.user.login`) is a measured equivalent: row w26c drives a ghost author, and the recursion's own `// ""` on the same field lands the same bytes either way.

## Must-fail controls

Battery `mutate-writer-2.py`, one mutant of `review-writer.sh` per run, 41/42 killed (`mutants-writer.txt`; w-m25 the equivalent above): session 1's 25 plus the reviewer's isolating killers for the six rows the delivered set never reached (the idempotent no-op dropped or silenced, approved mapped to pending, the final success post dropped, the guard never deferring or deferring silently, the empty enumeration exiting 1, skipped, or losing its count), its order and target pins (the enumeration reversed, a double post, the wrong repo path, a fixed merge-group sha), the recursion's author (dropped, fixed), and the 140-character bound (truncation dropped, the no-op comparing the untruncated detail), the last two each red on its new row alone. The empty-table guard: an emptied table call exits 2 with `no row was asserted` (measured on a copy).

## Test command

```
TMPDIR=/tmp bash skills/review-gate/tests/review-writer.test.sh   # 44 passed, 0 failed
TMPDIR=/tmp tools/guard --full                                     # rc=0
```

## Reviewer round

reviewer-test on f0f38f379 (one round, finished across two sessions after an interruption): ACCEPT. Suggestions 1 (empty-table guard) and 2 (w5/wp2 phrase) applied; suggestion 3 (the 140-character bound) folded as rows w9c and w9d on the overseer's direction; suggestion 4 (the commit message's rc claim) reworded to a checked call; suggestion 5 (the battery's killers) recorded. The reviewed tree is the first commit's tree unchanged (its message reworded; the rebase onto main touched no file of this branch).

KEN-1241

https://claude.ai/code/session_01BqYKUFTzUMFVTa4MsRR5T1
