### PR TITLE
test(KEN-1241): table background widget state and expiry

### DIFF
--- a/pi-extensions/pi-background-tasks/tests/widget-expiry.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/widget-expiry.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import {
+	createBackgroundWidgetExpiryScheduler,
+	nextBackgroundWidgetExpiryDelay,
+} from "../extensions/widget-visibility.js";
+
+const tasks = [
+	{ status: "running", updatedAt: 500 },
+	{ status: "completed", updatedAt: 1_000 },
+	{ status: "failed", updatedAt: 2_000 },
+];
+
+test("widget expiry selects the earliest unexpired finished task", () => {
+	expect.hasAssertions();
+	for (const [name, now, expected] of [
+		["first finished task", 10_000, 6_001],
+		["inclusive deadline", 16_000, 1],
+		["next finished task", 16_001, 1_000],
+		["all finished tasks expired", 17_001, null],
+	] as const) {
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, now), name).toBe(expected);
+	}
+});
+
+test("widget expiry owns one timer until it fires or is cleared", () => {
+	expect.hasAssertions();
+	for (const { name, retention, now, steps, expected } of [
+		{ name: "refresh then cancel", retention: 15_000, now: 10_000, steps: ["schedule", "fire", "schedule", "clear"], expected: { delays: [6_001, 6_001], refreshes: 1, clears: 1, pending: false } },
+		{ name: "replace pending timer", retention: 15_000, now: 10_000, steps: ["schedule", "schedule", "clear"], expected: { delays: [6_001, 6_001], refreshes: 0, clears: 2, pending: false } },
+		{ name: "fired timer is no longer owned", retention: 15_000, now: 10_000, steps: ["schedule", "fire", "clear"], expected: { delays: [6_001], refreshes: 1, clears: 0, pending: false } },
+		{ name: "expired tasks need no timer", retention: 15_000, now: 17_001, steps: ["schedule", "clear"], expected: { delays: [], refreshes: 0, clears: 0, pending: false } },
+		{ name: "native timer limit", retention: 2_592_000_000, now: 10_000, steps: ["schedule"], expected: { delays: [2_147_483_647], refreshes: 0, clears: 0, pending: true } },
+	] as const) {
+		const delays: number[] = [];
+		let refreshes = 0;
+		let clears = 0;
+		const clock: { pending: { callback: () => void; unref(): void } | null } = { pending: null };
+		const expiry = createBackgroundWidgetExpiryScheduler(
+			() => refreshes++,
+			((callback: () => void, delay: number) => {
+				if (clock.pending) throw new Error("previous timer was not cleared");
+				delays.push(delay);
+				clock.pending = { callback, unref() {} };
+				return clock.pending;
+			}) as unknown as typeof setTimeout,
+			((timer: unknown) => {
+				if (timer !== clock.pending) throw new Error("cleared timer is not pending");
+				clock.pending = null;
+				clears++;
+			}) as typeof clearTimeout,
+		);
+		for (const step of steps) {
+			switch (step) {
+				case "schedule": expiry.schedule(tasks, retention, now); break;
+				case "clear": expiry.clear(); break;
+				case "fire": {
+					const timer = clock.pending;
+					if (!timer) throw new Error("no timer to fire");
+					clock.pending = null;
+					timer.callback();
+					break;
+				}
+			}
+		}
+		expect({ delays, refreshes, clears, pending: clock.pending !== null }, name).toEqual(expected);
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/widget-visibility.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/widget-visibility.test.ts
@@ -1,67 +1,36 @@
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
-	createBackgroundWidgetExpiryScheduler,
 	createBackgroundWidgetVisibility,
-	nextBackgroundWidgetExpiryDelay,
 	shouldRenderBackgroundWidget,
 	toggleBackgroundWidgetVisibility,
 } from "../extensions/widget-visibility.js";
 
-function lifecycleRefreshRenders(mode: "compact" | "expanded" | "hidden"): boolean {
-	return shouldRenderBackgroundWidget({ hasUi: true, mode, showWidget: true, trackedTaskCount: 1, visibleTaskCount: 1 });
-}
+test("widget toggles preserve the last visible mode", () => {
+	expect.hasAssertions();
+	for (const { name, initial, toggles, expected } of [
+		{ name: "hide expanded", initial: "expanded", toggles: 1, expected: { mode: "hidden", lastVisibleMode: "expanded", renders: false } },
+		{ name: "restore expanded", initial: "expanded", toggles: 2, expected: { mode: "expanded", lastVisibleMode: "expanded", renders: true } },
+		{ name: "hide compact", initial: "compact", toggles: 1, expected: { mode: "hidden", lastVisibleMode: "compact", renders: false } },
+		{ name: "restore compact", initial: "compact", toggles: 2, expected: { mode: "compact", lastVisibleMode: "compact", renders: true } },
+		{ name: "show initially hidden", initial: "hidden", toggles: 1, expected: { mode: "compact", lastVisibleMode: "compact", renders: true } },
+	] as const) {
+		const state = createBackgroundWidgetVisibility(initial);
+		for (let index = 0; index < toggles; index++) toggleBackgroundWidgetVisibility(state);
+		const renders = shouldRenderBackgroundWidget({ hasUi: true, mode: state.mode, showWidget: true, trackedTaskCount: 1, visibleTaskCount: 1 });
+		expect({ ...state, renders }, name).toEqual(expected);
+	}
+});
 
-describe("background task mini-dashboard visibility", () => {
-	test("task lifecycle refreshes do not reopen widget after manual hide", () => {
-		const visibility = createBackgroundWidgetVisibility("expanded");
-		toggleBackgroundWidgetVisibility(visibility);
-		expect(visibility.mode).toBe("hidden");
-		expect(visibility.lastVisibleMode).toBe("expanded");
-
-		for (const _event of ["spawnTask", "output update", "exit update", "restore/replay", "clear/retention"]) {
-			expect(lifecycleRefreshRenders(visibility.mode)).toBe(false);
-			expect(visibility.mode).toBe("hidden");
-		}
-	});
-
-	test("explicit toggle-in restores last visible widget mode", () => {
-		const visibility = createBackgroundWidgetVisibility("expanded");
-		toggleBackgroundWidgetVisibility(visibility);
-		toggleBackgroundWidgetVisibility(visibility);
-		expect(visibility.mode).toBe("expanded");
-		expect(lifecycleRefreshRenders(visibility.mode)).toBe(true);
-	});
-
-	test("refreshes after the earliest finished task expires", () => {
-		const tasks = [
-			{ status: "running", updatedAt: 500 },
-			{ status: "completed", updatedAt: 1_000 },
-			{ status: "failed", updatedAt: 2_000 },
-		];
-		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 10_000)).toBe(6_001);
-		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 16_001)).toBe(1_000);
-		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 17_001)).toBeNull();
-
-		let refreshes = 0;
-		let scheduledDelay = 0;
-		let callback = () => {};
-		let clears = 0;
-		const timer = { unref() {} } as ReturnType<typeof setTimeout>;
-		const expiry = createBackgroundWidgetExpiryScheduler(
-			() => refreshes++,
-			(nextCallback, delay) => {
-				callback = nextCallback;
-				scheduledDelay = delay;
-				return timer;
-			},
-			() => clears++,
-		);
-		expiry.schedule(tasks, 15_000, 10_000);
-		expect(scheduledDelay).toBe(6_001);
-		callback();
-		expect(refreshes).toBe(1);
-		expiry.schedule(tasks, 15_000, 10_000);
-		expiry.clear();
-		expect(clears).toBe(1);
-	});
+test("widget rendering requires UI, enabled visibility and visible tasks", () => {
+	expect.hasAssertions();
+	for (const [name, hasUi, showWidget, trackedTaskCount, visibleTaskCount, mode, expected] of [
+		["visible", true, true, 1, 1, "expanded", true],
+		["headless", false, true, 1, 1, "expanded", false],
+		["disabled", true, false, 1, 1, "expanded", false],
+		["untracked", true, true, 0, 0, "expanded", false],
+		["expired", true, true, 1, 0, "expanded", false],
+		["manually hidden", true, true, 1, 1, "hidden", false],
+	] as const) {
+		expect(shouldRenderBackgroundWidget({ hasUi, showWidget, trackedTaskCount, visibleTaskCount, mode }), name).toBe(expected);
+	}
 });


### PR DESCRIPTION
The background-task widget tests repeat the same render call under unused event labels and mix visibility with expiry. This change gives the inputs named rows and puts expiry checks in a separate test file. Timer tests use injected callbacks and check replacement, firing, cancellation and the native delay limit.

Every former assertion survives:

- `hide expanded` retains hidden mode, expanded restore mode and the false render result. It replaces the identical assertions under unused lifecycle labels.
- `restore expanded` retains restored mode and the true render result.
- `first finished task`, `next finished task` and `all finished tasks expired` retain the exact delay results.
- `refresh then cancel` retains the scheduled delay, refresh count and clear count.

The existing process-isolated widget lifecycle tests remain unchanged. They dispatch the real extension events and check registry, timer and host-widget state. No production files or tracked renders change.

Validation: full guard, focused widget tests, Pi package policy, preflight and document limits pass. All 12 planted behavior defects fail after successful compilation. All 4 empty-table controls fail. The restored copies pass. The specialist test review found no defects. Its independent restore, refresh, replacement and scheduling controls each killed their mutant and passed 10 stability samples with 4 parallel processes.

KEN-1241
