### PR TITLE
test(KEN-1241): reshape decider test cases

### DIFF
--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -1,34 +1,25 @@
 #!/usr/bin/env bash
-# Index-parse contract: the INDEX Link cell resolves each decision's document,
-# and `get` enriches from that document.
-#
-# A Link cell the parser cannot resolve yields an empty path, and an empty path
-# makes body search skip the decision and `get` report an unknown date — a miss
-# indistinguishable from "no decision governs this area". The three cell shapes
-# below all appear in indexes written from this skill's row template, so all
-# three must resolve.
-#
-# Teeth: each check is re-run against a mutated copy of the script that breaks
-# the behavior under test, and must catch it.
+# INDEX link parsing and document enrichment.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
+ERR_FILE="$TMP_ROOT/stderr"
 
 pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-# --- Fixture: one decision per supported Link cell shape ---------------------
-
 REPO="$TMP_ROOT/repo"
 mkdir -p "$REPO/docs/decisions"
-
 cat >"$REPO/docs/decisions/INDEX.md" <<'EOF'
 # Architectural Decision Log
 
@@ -39,93 +30,13 @@ cat >"$REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-03 | D003 | PROJ-3 | Bare filename cell | Reason three | Never | Active | Full -> D003-bare.md |
 | 2026-01-04 | D004 | PROJ-4 | No document yet | Reason four | Never | Active | pending |
 EOF
+printf '# D001\n\n**Date**: 2026-01-01\n\nGoverns tokenone handling.\n' >"$REPO/docs/decisions/D001-md-link.md"
+printf '# D002\n\n**Date**: 2026-01-02\n\nGoverns tokentwo handling.\n' >"$REPO/docs/decisions/D002-backtick.md"
+printf '# D003\n\n**Date**:2026-01-03\n\nGoverns tokenthree handling.\n' >"$REPO/docs/decisions/D003-bare.md"
 
-printf '# D001\n\n**Date**: 2026-01-01\n\nGoverns tokenone handling.\n' \
-  >"$REPO/docs/decisions/D001-md-link.md"
-printf '# D002\n\n**Date**: 2026-01-02\n\nGoverns tokentwo handling.\n' \
-  >"$REPO/docs/decisions/D002-backtick.md"
-printf '# D003\n\n**Date**:2026-01-03\n\nGoverns tokenthree handling.\n' \
-  >"$REPO/docs/decisions/D003-bare.md"
-
-# run <script> <args...> — stdout only, from inside the fixture repo.
-run() {
-  local script="$1"
-  shift
-  (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$script" "$@" 2>/dev/null)
-}
-
-# check_parse <script>
-# Prints the name of every failed expectation (empty output = all held).
-check_parse() {
-  local script="$1" broken=""
-
-  # Each shape resolves to its document, so a body-only keyword finds it.
-  [[ "$(run "$script" search tokenone | jq -r '[.[].id] | join(",")')" == "D001" ]] \
-    || broken="$broken md-link-body"
-  [[ "$(run "$script" search tokentwo | jq -r '[.[].id] | join(",")')" == "D002" ]] \
-    || broken="$broken backtick-body"
-  [[ "$(run "$script" search tokenthree | jq -r '[.[].id] | join(",")')" == "D003" ]] \
-    || broken="$broken bare-body"
-
-  # get resolves the same path and reads the date out of the document.
-  [[ "$(run "$script" get D001 | jq -r '.path')" == "$REPO/docs/decisions/D001-md-link.md" ]] \
-    || broken="$broken md-link-path"
-  [[ "$(run "$script" get D002 | jq -r '.path')" == "$REPO/docs/decisions/D002-backtick.md" ]] \
-    || broken="$broken backtick-path"
-  [[ "$(run "$script" get D001 | jq -r '.date')" == "2026-01-01" ]] \
-    || broken="$broken date-enrichment"
-  # The date label tolerates no space after the colon.
-  [[ "$(run "$script" get D003 | jq -r '.date')" == "2026-01-03" ]] \
-    || broken="$broken date-unspaced"
-
-  # A cell naming no document resolves to nothing rather than a wrong path.
-  [[ "$(run "$script" get D004 | jq -r '.path')" == "" ]] \
-    || broken="$broken empty-cell-path"
-  [[ "$(run "$script" get D004 | jq -r '.date')" == "unknown" ]] \
-    || broken="$broken empty-cell-date"
-
-  printf '%s' "$broken"
-}
-
-# mutate <name> <sed-script> — copies scripts/ and patches the entry point.
-mutate() {
-  local dir="$TMP_ROOT/mutant-$1"
-  mkdir -p "$dir"
-  cp -R "$SKILL_DIR/scripts/lib" "$dir/lib"
-  sed "$2" "$DECISIONS" >"$dir/decisions"
-  chmod +x "$dir/decisions"
-  printf '%s' "$dir/decisions"
-}
-
-# expect_caught <clause> <mutant> <description>
-expect_caught() {
-  local clause="$1" mutant="$2" desc="$3" out
-  out="$(check_parse "$mutant")"
-  if [[ "$out" == *"$clause"* ]]; then
-    pass "$desc"
-  else
-    fail "$desc (check output: '$out')"
-  fi
-}
-
-echo "=== decisions INDEX link-cell and get enrichment ==="
-
-broken="$(check_parse "$DECISIONS")"
-if [[ -z "$broken" ]]; then
-  pass "every Link cell shape resolves and get enriches from the document"
-else
-  fail "index parse contract broken:$broken"
-fi
-
-echo "=== malformed rows are named, not silently dropped ==="
-
-# A row that opens like a decision but misses the eight-cell contract is skipped
-# by the parser. Skipped silently, a mistyped row reads downstream as a decision
-# that was never recorded — the index says one thing, every consumer says
-# another, and nothing points at the row to fix.
-BADREPO="$TMP_ROOT/badrepo"
-mkdir -p "$BADREPO/docs/decisions"
-cat >"$BADREPO/docs/decisions/INDEX.md" <<'EOF'
+BAD_REPO="$TMP_ROOT/bad-repo"
+mkdir -p "$BAD_REPO/docs/decisions"
+cat >"$BAD_REPO/docs/decisions/INDEX.md" <<'EOF'
 # Architectural Decision Log
 
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
@@ -135,60 +46,153 @@ cat >"$BADREPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-02-03 | D103 | PROJ-3 | Second well-formed | Reason three | Never | Active | [Full](D103.md) |
 EOF
 
-run_bad() { (cd "$BADREPO" && DECISIONS_DIR="$BADREPO/docs/decisions" "$DECISIONS" "$@"); }
+run_decisions() {
+  local script="$1" repo="$2" decisions_dir="$3"
+  shift 3
+  set +e
+  out=$( (cd "$repo" && DECISIONS_DIR="$decisions_dir" "$script" "$@") 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-bad_stdout="$(run_bad list 2>/dev/null)"
-bad_stderr="$(run_bad list 2>&1 >/dev/null)"
+project_json() {
+  local expression="$1"
+  set +e
+  projected=$(jq -cer "$expression" <<<"$out" 2>/dev/null)
+  projection_rc=$?
+  set -e
+}
 
-# stdout contract is unchanged: the parseable rows, and only those.
-if [[ "$(jq -r '[.[].id] | join(",")' <<<"$bad_stdout")" == "D101,D103" ]]; then
-  pass "stdout still carries exactly the rows that parse"
-else
-  fail "stdout contract changed (got: $bad_stdout)"
-fi
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-if grep -q 'D102\|:6:' <<<"$bad_stderr"; then
-  pass "the malformed row is named on stderr"
-else
-  fail "the malformed row was dropped without a diagnostic (stderr: $bad_stderr)"
-fi
+evaluate_link_rows() {
+  local script="$1" mode="$2" name kind argument expected actual
+  table_failures=""
+  while IFS='~' read -r name kind argument expected; do
+    run_decisions "$script" "$REPO" "$REPO/docs/decisions" "${kind%%-*}" "$argument"
+    case "$kind" in
+      search-ids)
+        project_json 'if type == "array" then [.[].id] | join(",") else error("not an array") end'
+        ;;
+      get-path)
+        project_json 'if type == "object" and has("path") then .path else error("missing path") end'
+        expected="$REPO/docs/decisions/$expected"
+        ;;
+      get-empty-path)
+        project_json 'if type == "object" and has("path") then .path else error("missing path") end'
+        ;;
+      get-date)
+        project_json 'if type == "object" and has("date") then .date else error("missing date") end'
+        ;;
+      *)
+        fail "unknown link-row projection: $kind"
+        continue
+        ;;
+    esac
+    if [[ -z "$projected" ]]; then
+      projected='<empty>'
+    fi
+    actual="$rc~$projection_rc~$projected"
+    record_row "$mode" "$name" "$actual" "0~0~$expected"
+  done <<'CASES'
+md-link-body~search-ids~tokenone~D001
+backtick-body~search-ids~tokentwo~D002
+bare-body~search-ids~tokenthree~D003
+md-link-path~get-path~D001~D001-md-link.md
+backtick-path~get-path~D002~D002-backtick.md
+date-enrichment~get-date~D001~2026-01-01
+date-unspaced~get-date~D003~2026-01-03
+empty-cell-path~get-empty-path~D004~<empty>
+empty-cell-date~get-date~D004~unknown
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-if grep -q ':6:' <<<"$bad_stderr"; then
-  pass "the diagnostic cites the row's line in the index"
-else
-  fail "the diagnostic does not cite the index line (stderr: $bad_stderr)"
-fi
+evaluate_diagnostic_rows() {
+  local script="$1" mode="$2" name fixture projection expected actual first second
+  table_failures=""
+  while IFS='~' read -r name fixture projection expected; do
+    if [[ "$fixture" == malformed ]]; then
+      run_decisions "$script" "$BAD_REPO" "$BAD_REPO/docs/decisions" list
+    else
+      run_decisions "$script" "$REPO" "$REPO/docs/decisions" list
+    fi
+    case "$projection" in
+      ids)
+        project_json 'if type == "array" then [.[].id] | join(",") else error("not an array") end'
+        actual="$rc~$projection_rc~$projected"
+        expected="0~0~$expected"
+        ;;
+      malformed-warning)
+        first=0
+        second=0
+        [[ "$err" == *D102* || "$err" == *:6:* ]] && first=1
+        [[ "$err" == *:6:* ]] && second=1
+        actual="$rc~$first~$second"
+        ;;
+      empty-stderr)
+        actual="$rc~${err:-<empty>}"
+        ;;
+      *)
+        fail "unknown diagnostic-row projection: $projection"
+        continue
+        ;;
+    esac
+    record_row "$mode" "$name" "$actual" "$expected"
+  done <<'CASES'
+malformed-row-results~malformed~ids~D101,D103
+malformed-row-diagnostic~malformed~malformed-warning~0~1~1
+healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-# The diagnostic must not fire for a healthy index, or it is just noise.
-if [[ -z "$( (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$DECISIONS" list 2>&1 >/dev/null) )" ]]; then
-  pass "a well-formed index emits no warning"
-else
-  fail "a well-formed index emitted a spurious warning"
-fi
+expect_control_failure() {
+  local failures="$1" row="$2" description="$3"
+  if [[ "$failures" == *"|$row|"* ]]; then
+    pass "$description"
+  else
+    fail "$description (failed rows: $failures)"
+  fi
+}
 
-echo "=== teeth ==="
+echo "=== decisions INDEX link and get rows ==="
+evaluate_link_rows "$DECISIONS" normal
 
-# Drop the non-markdown-link fallbacks: only [text](path) cells resolve.
-expect_caught backtick-body \
-  "$(mutate no-fallback 's/+ \[ \$cell | scan/+ [ empty | scan/g')" \
-  "losing the backticked-filename fallback is caught"
+echo "=== decisions malformed and healthy INDEX rows ==="
+evaluate_diagnostic_rows "$DECISIONS" normal
 
-expect_caught bare-body \
-  "$(mutate no-fallback2 's/+ \[ \$cell | scan/+ [ empty | scan/g')" \
-  "losing the bare-filename fallback is caught"
+echo "=== must-fail controls ==="
+fallback_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-fallback/decisions" '+ [ $cell | scan' '+ [ empty | scan' 2)"
+failures="$(evaluate_link_rows "$fallback_mutant" control)"
+expect_control_failure "$failures" backtick-body "backtick fallback loss fails its row"
+expect_control_failure "$failures" bare-body "bare fallback loss fails its row"
 
-# Stop get from adopting the date parsed out of the document.
-expect_caught date-enrichment \
-  "$(mutate no-date 's/date="\$parsed"/date="mutated"/')" \
-  "losing get's date enrichment is caught"
+date_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-date/decisions" '      date="$parsed"' '      date="mutated"' 1)"
+failures="$(evaluate_link_rows "$date_mutant" control)"
+expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
 
-# Drop the malformed-row diagnostic: the rows still vanish, but nothing says so.
-silent="$(mutate no-warn 's/| select((.value | split("|") | length) < 9)/| select(false)/')"
-if [[ -z "$( (cd "$BADREPO" && DECISIONS_DIR="$BADREPO/docs/decisions" "$silent" list 2>&1 >/dev/null) )" ]]; then
-  pass "losing the malformed-row diagnostic is caught"
-else
-  fail "the no-warn mutant still emitted a diagnostic"
-fi
+warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
+failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
+expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -129,6 +129,7 @@ LINK_CASES
     [[ -n "$only_row" ]] && guard="link table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -185,6 +186,7 @@ DIAGNOSTIC_CASES
     [[ -n "$only_row" ]] && guard="diagnostic table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -210,26 +212,31 @@ evaluate_link_rows "$DECISIONS" normal
 echo "=== decisions malformed and healthy INDEX rows ==="
 evaluate_diagnostic_rows "$DECISIONS" normal
 
-echo "=== must-fail controls ==="
-fallback_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-fallback/decisions" '+ [ $cell | scan' '+ [ empty | scan' 2)"
-failures="$(evaluate_link_rows "$fallback_mutant" control)"
-expect_control_failure "$failures" backtick-body "backtick fallback loss fails its row"
-expect_control_failure "$failures" bare-body "bare fallback loss fails its row"
-
-date_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-date/decisions" '      date="$parsed"' '      date="mutated"' 1)"
-failures="$(evaluate_link_rows "$date_mutant" control)"
-expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
-
-warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
-failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
-expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  fallback_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-fallback/decisions" '+ [ $cell | scan' '+ [ empty | scan' 2)"
+  failures="$(evaluate_link_rows "$fallback_mutant" control)"
+  expect_control_failure "$failures" backtick-body "backtick fallback loss fails its row"
+  expect_control_failure "$failures" bare-body "bare fallback loss fails its row"
+
+  date_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-date/decisions" '      date="$parsed"' '      date="mutated"' 1)"
+  failures="$(evaluate_link_rows "$date_mutant" control)"
+  expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
+
+  warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
+  failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
+  expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
+
   link_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-link-table/decider/tests/decider-index-parse.test.sh" LINK_CASES)"
   if decider_test_fails_with "$link_table_mutant" "link table executed no rows"; then
     pass "an empty link table fails its row-count guard"
   else
     fail "an empty link table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$link_table_mutant" "$TMP_ROOT/empty-link-table/decider/tests/diagnostic-only.test.sh" "link table executed no rows" 2; then
+    pass "a link-table diagnostic without a failure is rejected"
+  else
+    fail "a link-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_link_rows "$fallback_mutant" control unknown-link-row 2>&1)"
@@ -246,6 +253,11 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "an empty diagnostic table fails its row-count guard"
   else
     fail "an empty diagnostic table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$diagnostic_table_mutant" "$TMP_ROOT/empty-diagnostic-table/decider/tests/diagnostic-only.test.sh" "diagnostic table executed no rows" 2; then
+    pass "a diagnostic-table diagnostic without a failure is rejected"
+  else
+    fail "a diagnostic-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_diagnostic_rows "$warning_mutant" control unknown-diagnostic-row 2>&1)"

--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -80,9 +80,14 @@ record_row() {
 }
 
 evaluate_link_rows() {
-  local script="$1" mode="$2" name kind argument expected actual
+  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name kind argument expected; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    executed_rows=$((executed_rows + 1))
     run_decisions "$script" "$REPO" "$REPO/docs/decisions" "${kind%%-*}" "$argument"
     case "$kind" in
       search-ids)
@@ -108,7 +113,7 @@ evaluate_link_rows() {
     fi
     actual="$rc~$projection_rc~$projected"
     record_row "$mode" "$name" "$actual" "0~0~$expected"
-  done <<'CASES'
+  done <<'LINK_CASES'
 md-link-body~search-ids~tokenone~D001
 backtick-body~search-ids~tokentwo~D002
 bare-body~search-ids~tokenthree~D003
@@ -118,16 +123,31 @@ date-enrichment~get-date~D001~2026-01-01
 date-unspaced~get-date~D003~2026-01-03
 empty-cell-path~get-empty-path~D004~<empty>
 empty-cell-date~get-date~D004~unknown
-CASES
+LINK_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="link table executed no rows"
+    [[ -n "$only_row" ]] && guard="link table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
 }
 
 evaluate_diagnostic_rows() {
-  local script="$1" mode="$2" name fixture projection expected actual first second
+  local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name fixture projection expected; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    executed_rows=$((executed_rows + 1))
     if [[ "$fixture" == malformed ]]; then
       run_decisions "$script" "$BAD_REPO" "$BAD_REPO/docs/decisions" list
     else
@@ -155,11 +175,21 @@ evaluate_diagnostic_rows() {
         ;;
     esac
     record_row "$mode" "$name" "$actual" "$expected"
-  done <<'CASES'
+  done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103
 malformed-row-diagnostic~malformed~malformed-warning~0~1~1
 healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
-CASES
+DIAGNOSTIC_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="diagnostic table executed no rows"
+    [[ -n "$only_row" ]] && guard="diagnostic table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -193,6 +223,40 @@ expect_control_failure "$failures" date-enrichment "date mutation fails the enri
 warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
 failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
 expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  link_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-link-table/decider/tests/decider-index-parse.test.sh" LINK_CASES)"
+  if decider_test_fails_with "$link_table_mutant" "link table executed no rows"; then
+    pass "an empty link table fails its row-count guard"
+  else
+    fail "an empty link table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_link_rows "$fallback_mutant" control unknown-link-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:link table selected no row: unknown-link-row"* ]]; then
+    pass "an unknown link row fails its selection guard"
+  else
+    fail "an unknown link row missed its selection guard"
+  fi
+
+  diagnostic_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-diagnostic-table/decider/tests/decider-index-parse.test.sh" DIAGNOSTIC_CASES)"
+  if decider_test_fails_with "$diagnostic_table_mutant" "diagnostic table executed no rows"; then
+    pass "an empty diagnostic table fails its row-count guard"
+  else
+    fail "an empty diagnostic table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_diagnostic_rows "$warning_mutant" control unknown-diagnostic-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:diagnostic table selected no row: unknown-diagnostic-row"* ]]; then
+    pass "an unknown diagnostic row fails its selection guard"
+  else
+    fail "an unknown diagnostic row missed its selection guard"
+  fi
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -111,6 +111,7 @@ ACTION_CASES
     [[ -n "$only_row" ]] && guard="action table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -124,21 +125,26 @@ ACTION_CASES
 echo "=== decisions issue action rows ==="
 evaluate_action_rows "$DECISIONS" normal
 
-echo "=== must-fail control ==="
-lookup_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-issue-match/decisions" '      .[] | select(.research | test($issue + "(?![0-9])"; "i")) |' '      .[] | select(false) |' 1)"
-failures="$(evaluate_action_rows "$lookup_mutant" control supported-issue-lookup)"
-if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
-  pass "wrong lookup result fails the supported lookup row"
-else
-  fail "wrong lookup result did not fail the supported lookup row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  lookup_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-issue-match/decisions" '      .[] | select(.research | test($issue + "(?![0-9])"; "i")) |' '      .[] | select(false) |' 1)"
+  failures="$(evaluate_action_rows "$lookup_mutant" control supported-issue-lookup)"
+  if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
+    pass "wrong lookup result fails the supported lookup row"
+  else
+    fail "wrong lookup result did not fail the supported lookup row"
+  fi
+
   action_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-action-table/decider/tests/decider-issue-action-hint.test.sh" ACTION_CASES)"
   if decider_test_fails_with "$action_table_mutant" "action table executed no rows"; then
     pass "an empty action table fails its row-count guard"
   else
     fail "an empty action table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$action_table_mutant" "$TMP_ROOT/empty-action-table/decider/tests/diagnostic-only.test.sh" "action table executed no rows" 1; then
+    pass "an action-table diagnostic without a failure is rejected"
+  else
+    fail "an action-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_action_rows "$lookup_mutant" control unknown-action-row 2>&1)"

--- a/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -54,13 +54,15 @@ record_row() {
 }
 
 evaluate_action_rows() {
-  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual
+  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual guard
   local first second projected projection_rc
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name kind argument expected; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     case "$kind" in
       issue)
         run_decisions "$script" issue "$argument"
@@ -98,12 +100,22 @@ evaluate_action_rows() {
         ;;
     esac
     record_row "$mode" "$name" "$actual" "$expected"
-  done <<'CASES'
+  done <<'ACTION_CASES'
 issue-action~issue~CC-125~1~~1~1
 issues-action~issues~CC-125~1~1
 generic-unknown-action~unknown~bogus~1~1~1
 supported-issue-lookup~lookup~CC-125~0~0~D001
-CASES
+ACTION_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="action table executed no rows"
+    [[ -n "$only_row" ]] && guard="action table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -119,6 +131,24 @@ if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
   pass "wrong lookup result fails the supported lookup row"
 else
   fail "wrong lookup result did not fail the supported lookup row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  action_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-action-table/decider/tests/decider-issue-action-hint.test.sh" ACTION_CASES)"
+  if decider_test_fails_with "$action_table_mutant" "action table executed no rows"; then
+    pass "an empty action table fails its row-count guard"
+  else
+    fail "an empty action table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_action_rows "$lookup_mutant" control unknown-action-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:action table selected no row: unknown-action-row"* ]]; then
+    pass "an unknown action row fails its selection guard"
+  else
+    fail "an unknown action row missed its selection guard"
+  fi
 fi
 
 echo

--- a/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -1,68 +1,26 @@
 #!/usr/bin/env bash
-# The unsupported `issue` action hint.
-#
-# The CLI has no `issue` action — the supported lookup is
-# `decisions search --issue CC-125` — and generated guidance can tell an agent
-# to run `decisions issue CC-125`. The dispatcher catches `issue`/`issues`
-# with a targeted error naming the supported form, so an agent that receives
-# stale guidance self-corrects in one step. Pinned here: that hint, that other
-# unknown actions keep the generic error + usage, and that the supported
-# `search --issue` lookup works.
+# Unsupported issue actions and the supported issue lookup.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
-
 ERR_FILE="$TMP_ROOT/stderr"
 
-# Run the decisions script from a given directory with DECISIONS_DIR removed
-# from the parent environment (pass VAR=value args to set it explicitly).
-# Captures stdout in $out, stderr in $err, exit code in $rc.
-run_decisions() {
-  local dir="$1"
-  shift
-  set +e
-  out=$( (cd "$dir" && env -u DECISIONS_DIR "$@" "$DECISIONS" ${ARGS[@]+"${ARGS[@]}"}) 2>"$ERR_FILE")
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
-}
-
-assert_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
-echo "=== decisions unsupported issue action hint (kendex#641) ==="
-
-# Fixture: a project with one decision linked to CC-125, so the supported
-# lookup has a real match to return.
-PROJ="$TMP_ROOT/project"
-mkdir -p "$PROJ/docs/decisions"
-cat >"$PROJ/docs/decisions/INDEX.md" <<'EOF'
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/docs/decisions"
+cat >"$PROJECT/docs/decisions/INDEX.md" <<'EOF'
 # Architectural Decision Log
 
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
@@ -70,31 +28,98 @@ cat >"$PROJ/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-10 | D001 | CC-125 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
 EOF
 
-# --- Unsupported `issue` action gets a targeted hint --------------------------
-ARGS=(issue CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "issue action exits nonzero"
-assert_eq "$out" "" "issue action emits no stdout result"
-assert_contains "$err" "Unknown action 'issue'" "issue action names the unknown action"
-assert_contains "$err" "search --issue" "issue action hint names the supported lookup"
+run_decisions() {
+  local script="$1"
+  shift
+  set +e
+  out=$( (cd "$PROJECT" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-ARGS=(issues CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "issues action exits nonzero"
-assert_contains "$err" "search --issue" "issues action hint names the supported lookup"
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-# --- Other unknown actions keep the generic error + usage ---------------------
-ARGS=(bogus CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "unknown action exits nonzero"
-assert_contains "$err" "Unknown action 'bogus'" "unknown action reports generic error"
-assert_contains "$out" "Usage: decisions" "unknown action prints usage"
+evaluate_action_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual
+  local first second projected projection_rc
+  table_failures=""
+  while IFS='~' read -r name kind argument expected; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    case "$kind" in
+      issue)
+        run_decisions "$script" issue "$argument"
+        first=0
+        second=0
+        [[ "$err" == *"Unknown action 'issue'"* ]] && first=1
+        [[ "$err" == *"search --issue"* ]] && second=1
+        actual="$rc~$out~$first~$second"
+        ;;
+      issues)
+        run_decisions "$script" issues "$argument"
+        first=0
+        [[ "$err" == *"search --issue"* ]] && first=1
+        actual="$rc~$first"
+        ;;
+      unknown)
+        run_decisions "$script" "$argument" CC-125
+        first=0
+        second=0
+        [[ "$err" == *"Unknown action '$argument'"* ]] && first=1
+        [[ "$out" == *"Usage: decisions"* ]] && second=1
+        actual="$rc~$first~$second"
+        ;;
+      lookup)
+        run_decisions "$script" search --issue "$argument"
+        set +e
+        projected=$(jq -cer 'if type == "array" then [.[].id] | join(",") else error("not an array") end' <<<"$out" 2>/dev/null)
+        projection_rc=$?
+        set -e
+        actual="$rc~$projection_rc~$projected"
+        ;;
+      *)
+        fail "unknown action-row kind: $kind"
+        continue
+        ;;
+    esac
+    record_row "$mode" "$name" "$actual" "$expected"
+  done <<'CASES'
+issue-action~issue~CC-125~1~~1~1
+issues-action~issues~CC-125~1~1
+generic-unknown-action~unknown~bogus~1~1~1
+supported-issue-lookup~lookup~CC-125~0~0~D001
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-# --- Supported issue lookup still works ---------------------------------------
-ARGS=(search --issue CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "search --issue exits 0"
-assert_contains "$out" '"D001"' "search --issue returns the linked decision"
+echo "=== decisions issue action rows ==="
+evaluate_action_rows "$DECISIONS" normal
+
+echo "=== must-fail control ==="
+lookup_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-issue-match/decisions" '      .[] | select(.research | test($issue + "(?![0-9])"; "i")) |' '      .[] | select(false) |' 1)"
+failures="$(evaluate_action_rows "$lookup_mutant" control supported-issue-lookup)"
+if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
+  pass "wrong lookup result fails the supported lookup row"
+else
+  fail "wrong lookup result did not fail the supported lookup row"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -169,6 +169,7 @@ NEXT_ID_CASES
     [[ -n "$only_row" ]] && guard="next-ID table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -182,21 +183,26 @@ NEXT_ID_CASES
 echo "=== decisions next-id scheme rows ==="
 evaluate_next_id_rows "$DECISIONS" normal
 
-echo "=== must-fail control ==="
-arithmetic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wrong-next-id/decisions" '$((max_num + 1))' '$((max_num + 2))' 1)"
-failures="$(evaluate_next_id_rows "$arithmetic_mutant" control inferred-adr)"
-if [[ "$failures" == *'|inferred-adr|'* ]]; then
-  pass "wrong next ID fails the inferred scheme row"
-else
-  fail "wrong next ID did not fail the inferred scheme row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  arithmetic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wrong-next-id/decisions" '$((max_num + 1))' '$((max_num + 2))' 1)"
+  failures="$(evaluate_next_id_rows "$arithmetic_mutant" control inferred-adr)"
+  if [[ "$failures" == *'|inferred-adr|'* ]]; then
+    pass "wrong next ID fails the inferred scheme row"
+  else
+    fail "wrong next ID did not fail the inferred scheme row"
+  fi
+
   next_id_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-next-id-table/decider/tests/decider-next-id-scheme.test.sh" NEXT_ID_CASES)"
   if decider_test_fails_with "$next_id_table_mutant" "next-ID table executed no rows"; then
     pass "an empty next-ID table fails its row-count guard"
   else
     fail "an empty next-ID table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$next_id_table_mutant" "$TMP_ROOT/empty-next-id-table/decider/tests/diagnostic-only.test.sh" "next-ID table executed no rows" 1; then
+    pass "a next-ID-table diagnostic without a failure is rejected"
+  else
+    fail "a next-ID-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_next_id_rows "$arithmetic_mutant" control unknown-next-id-row 2>&1)"

--- a/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -1,91 +1,48 @@
 #!/usr/bin/env bash
-# Scheme-aware decisions next-id.
-#
-# next-id must derive the next decision number from the INDEX.md ID column, not
-# from DNNN-looking tokens in prose cells, and it must preserve repositories'
-# existing ID schemes such as ADR-0001.
+# Scheme-aware decisions next-id rows.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
-
 ERR_FILE="$TMP_ROOT/stderr"
 
-run_next_id() {
-  local dir="$1"
-  shift
-  set +e
-  out=$( (cd "$dir" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH "$@" "$DECISIONS" next-id) 2>"$ERR_FILE")
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
+make_index() {
+  local repo="$1"
+  mkdir -p "$repo/docs/decisions"
 }
-
-assert_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
-echo "=== decisions next-id scheme inference (kendex#956) ==="
 
 ADR_REPO="$TMP_ROOT/adr-repo"
-mkdir -p "$ADR_REPO/docs/decisions"
+make_index "$ADR_REPO"
 cat >"$ADR_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | ADR-0001 | PROJ-100 | First decision | Establishes the log | Never | Active | [Full](ADR-0001-first.md) |
 | 2026-01-11 | ADR-0035 | PROJ-101 | Current scheme | Summary mentions **D1:** and D1/D3/D5 prose labels | Never | Active | [Full](ADR-0035-current.md) |
 EOF
 
-run_next_id "$ADR_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "ADR next-id exits 0"
-assert_eq "$out" "ADR-0036" "ADR scheme and width are preserved"
-assert_eq "$err" "" "ADR next-id emits no stderr"
-
 D_REPO="$TMP_ROOT/d-repo"
-mkdir -p "$D_REPO/docs/decisions"
+make_index "$D_REPO"
 cat >"$D_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | D001 | PROJ-100 | First decision | Mentions unrelated D999 prose token | Never | Active | [Full](D001-first.md) |
 EOF
 
-run_next_id "$D_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "D next-id exits 0"
-assert_eq "$out" "D002" "prose DNNN token does not affect next-id"
-
 MIXED_REPO="$TMP_ROOT/mixed-repo"
-mkdir -p "$MIXED_REPO/docs/decisions"
+make_index "$MIXED_REPO"
 cat >"$MIXED_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | D008 | PROJ-100 | Legacy decision | Existing D-prefixed row | Never | Active | [Full](D008-legacy.md) |
@@ -93,19 +50,9 @@ cat >"$MIXED_REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-12 | ADR-0035 | PROJ-102 | Latest ADR decision | Current scheme | Never | Active | [Full](ADR-0035-latest.md) |
 EOF
 
-run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "mixed next-id exits 0"
-assert_eq "$out" "ADR-0036" "unconfigured next-id follows the last ID-column scheme"
-
-run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=D
-assert_eq "$rc" "0" "configured prefix next-id exits 0"
-assert_eq "$out" "D009" "configured prefix scans only matching ID-column rows"
-
 BAD_LAST_REPO="$TMP_ROOT/bad-last-repo"
-mkdir -p "$BAD_LAST_REPO/docs/decisions"
+make_index "$BAD_LAST_REPO"
 cat >"$BAD_LAST_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | D008 | PROJ-100 | Legacy decision | Existing D-prefixed row | Never | Active | [Full](D008-legacy.md) |
@@ -113,36 +60,124 @@ cat >"$BAD_LAST_REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-12 | ADR-current | PROJ-102 | Unparseable final ID | Current row has no numeric suffix | Never | Active | [Full](ADR-current.md) |
 EOF
 
-run_next_id "$BAD_LAST_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "unparseable final ID exits nonzero"
-assert_eq "$out" "" "unparseable final ID emits no stdout"
-assert_contains "$err" "ADR-current" "unparseable final ID names the bad ID"
-assert_contains "$err" "DECISION_ID_PREFIX" "unparseable final ID points at explicit scheme configuration"
-
-run_next_id "$BAD_LAST_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR-
-assert_eq "$rc" "0" "configured prefix bypasses unparseable final-ID inference"
-assert_eq "$out" "ADR-0036" "configured prefix still scans matching numeric rows"
-
 EMPTY_REPO="$TMP_ROOT/empty-repo"
-mkdir -p "$EMPTY_REPO/docs/decisions"
+make_index "$EMPTY_REPO"
 cat >"$EMPTY_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 EOF
 
-run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "empty index next-id exits 0"
-assert_eq "$out" "D001" "empty index keeps the default DXXX scheme"
+run_next_id() {
+  local script="$1" repo="$2" environment="$3"
+  set +e
+  case "$environment" in
+    default)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    d-prefix)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=D "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    adr-prefix)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    adr-configured)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    invalid-width)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_WIDTH=zero "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    *)
+      set -e
+      fail "unknown next-id environment: $environment"
+      return
+      ;;
+  esac
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4
-assert_eq "$rc" "0" "configured empty index next-id exits 0"
-assert_eq "$out" "ADR-0001" "configured empty index supports custom scheme"
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_WIDTH=zero
-assert_eq "$rc" "1" "invalid width exits nonzero"
-assert_contains "$err" "DECISION_ID_WIDTH" "invalid width names DECISION_ID_WIDTH"
+evaluate_next_id_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name repo_name environment expected_status
+  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected
+  table_failures=""
+  while IFS='~' read -r name repo_name environment expected_status stdout_rule expected_stdout stderr_rule; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    repo="$TMP_ROOT/$repo_name"
+    run_next_id "$script" "$repo" "$environment"
+    case "$stdout_rule" in
+      exact) actual_stdout="$out" ;;
+      ignore) actual_stdout=ignored; expected_stdout=ignored ;;
+      *) fail "unknown stdout rule: $stdout_rule"; continue ;;
+    esac
+    case "$stderr_rule" in
+      empty)
+        actual_stderr="$err"
+        expected=""
+        ;;
+      ignore)
+        actual_stderr=ignored
+        expected=ignored
+        ;;
+      bad-id-prefix)
+        actual_stderr=0,0
+        [[ "$err" == *ADR-current* ]] && actual_stderr=1,0
+        [[ "$err" == *ADR-current* && "$err" == *DECISION_ID_PREFIX* ]] && actual_stderr=1,1
+        expected=1,1
+        ;;
+      width)
+        actual_stderr=0
+        [[ "$err" == *DECISION_ID_WIDTH* ]] && actual_stderr=1
+        expected=1
+        ;;
+      *) fail "unknown stderr rule: $stderr_rule"; continue ;;
+    esac
+    actual="$rc~$actual_stdout~$actual_stderr"
+    record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
+  done <<'CASES'
+inferred-adr~adr-repo~default~0~exact~ADR-0036~empty
+ignore-prose-id~d-repo~default~0~exact~D002~ignore
+latest-scheme~mixed-repo~default~0~exact~ADR-0036~ignore
+configured-prefix~mixed-repo~d-prefix~0~exact~D009~ignore
+unparseable-last-id~bad-last-repo~default~1~exact~~bad-id-prefix
+configured-prefix-after-bad-id~bad-last-repo~adr-prefix~0~exact~ADR-0036~ignore
+empty-default~empty-repo~default~0~exact~D001~ignore
+empty-configured~empty-repo~adr-configured~0~exact~ADR-0001~ignore
+invalid-width~empty-repo~invalid-width~1~ignore~~width
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
+
+echo "=== decisions next-id scheme rows ==="
+evaluate_next_id_rows "$DECISIONS" normal
+
+echo "=== must-fail control ==="
+arithmetic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wrong-next-id/decisions" '$((max_num + 1))' '$((max_num + 2))' 1)"
+failures="$(evaluate_next_id_rows "$arithmetic_mutant" control inferred-adr)"
+if [[ "$failures" == *'|inferred-adr|'* ]]; then
+  pass "wrong next ID fails the inferred scheme row"
+else
+  fail "wrong next ID did not fail the inferred scheme row"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -114,12 +114,14 @@ record_row() {
 
 evaluate_next_id_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name repo_name environment expected_status
-  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected
+  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name repo_name environment expected_status stdout_rule expected_stdout stderr_rule; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     repo="$TMP_ROOT/$repo_name"
     run_next_id "$script" "$repo" "$environment"
     case "$stdout_rule" in
@@ -151,7 +153,7 @@ evaluate_next_id_rows() {
     esac
     actual="$rc~$actual_stdout~$actual_stderr"
     record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
-  done <<'CASES'
+  done <<'NEXT_ID_CASES'
 inferred-adr~adr-repo~default~0~exact~ADR-0036~empty
 ignore-prose-id~d-repo~default~0~exact~D002~ignore
 latest-scheme~mixed-repo~default~0~exact~ADR-0036~ignore
@@ -161,7 +163,17 @@ configured-prefix-after-bad-id~bad-last-repo~adr-prefix~0~exact~ADR-0036~ignore
 empty-default~empty-repo~default~0~exact~D001~ignore
 empty-configured~empty-repo~adr-configured~0~exact~ADR-0001~ignore
 invalid-width~empty-repo~invalid-width~1~ignore~~width
-CASES
+NEXT_ID_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="next-ID table executed no rows"
+    [[ -n "$only_row" ]] && guard="next-ID table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -177,6 +189,24 @@ if [[ "$failures" == *'|inferred-adr|'* ]]; then
   pass "wrong next ID fails the inferred scheme row"
 else
   fail "wrong next ID did not fail the inferred scheme row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  next_id_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-next-id-table/decider/tests/decider-next-id-scheme.test.sh" NEXT_ID_CASES)"
+  if decider_test_fails_with "$next_id_table_mutant" "next-ID table executed no rows"; then
+    pass "an empty next-ID table fails its row-count guard"
+  else
+    fail "an empty next-ID table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_next_id_rows "$arithmetic_mutant" control unknown-next-id-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:next-ID table selected no row: unknown-next-id-row"* ]]; then
+    pass "an unknown next-ID row fails its selection guard"
+  else
+    fail "an unknown next-ID row missed its selection guard"
+  fi
 fi
 
 echo

--- a/.agents/skills/decider/tests/decider-search-body.test.sh
+++ b/.agents/skills/decider/tests/decider-search-body.test.sh
@@ -1,101 +1,119 @@
 #!/usr/bin/env bash
-# Body-scoped decision search.
-#
-# `decisions search` reads the decision document itself, not only the INDEX.md
-# summary columns (decision, rationale, id). A search over the summary alone
-# returns `[]` for a keyword that appears only in a decision's prose —
-# indistinguishable from "no decision governs this area", the opposite of the
-# truth — and that silently passes the pre-mutation guards that call this
-# search (orch review-pr § 1.1, dev-fix § 2, tpm-audit § 2, and the issue
-# template).
-#
-# Pinned here: the body match and the ranking contract: body matches surface
-# BELOW every summary match, so a summary match keeps its position and score
-# rather than being displaced by a body match.
+# Body search, scoring, and result ordering.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1)); printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
 REPO="$TMP_ROOT/repo"
 mkdir -p "$REPO/docs/decisions"
-
-cat > "$REPO/docs/decisions/INDEX.md" <<'EOF'
+cat >"$REPO/docs/decisions/INDEX.md" <<'EOF'
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-01 | D027 | CC-1 | Performance measurement stack | Needs stable baselines | Never | Active | [D027](D027-perf.md) |
 | 2026-01-02 | D046 | CC-2 | Dev surface feature gating | Keeps prod lean | Never | Active | [D046](D046-gating.md) |
 | 2026-01-03 | D047 | CC-3 | Signature forgery guard | Prevents forgery | Never | Active | [D047](D047-forgery.md) |
 EOF
-
-# "hermetic" and "clippy" appear ONLY in prose — the exact shape from the report.
-printf '# D027\n\nBenchmarks run in a hermetic sandbox to avoid host drift.\n' \
-  > "$REPO/docs/decisions/D027-perf.md"
-printf '# D046\n\nClippy lints are enforced on the dev surface.\n' \
-  > "$REPO/docs/decisions/D046-gating.md"
-# D047 mentions forgery in title, rationale AND body — used for the ranking test.
-printf '# D047\n\nGuards against forgery of signatures.\n' \
-  > "$REPO/docs/decisions/D047-forgery.md"
+printf '# D027\n\nBenchmarks run in a hermetic sandbox against forgery and host drift.\n' >"$REPO/docs/decisions/D027-perf.md"
+printf '# D046\n\nClippy lints are enforced on the dev surface.\n' >"$REPO/docs/decisions/D046-gating.md"
+printf '# D047\n\nGuards against forgery of signatures.\n' >"$REPO/docs/decisions/D047-forgery.md"
 
 run_search() {
-  (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$DECISIONS" search "$@" 2>/dev/null)
+  local script="$1" query="$2"
+  set +e
+  out=$( (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$script" search "$query") 2>/dev/null)
+  rc=$?
+  set -e
 }
 
-echo "=== a keyword that appears only in a decision body is found ==="
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-assert_eq "$(run_search hermetic | jq -r '[.[].id] | join(",")')" "D027" \
-  "body-only keyword returns the governing decision"
-assert_eq "$(run_search clippy | jq -r '[.[].id] | join(",")')" "D046" \
-  "second body-only keyword returns its decision"
+evaluate_search_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name query projection expected setup
+  local projected projection_rc actual
+  table_failures=""
+  while IFS='~' read -r name query projection expected setup; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    if [[ "$setup" == stray ]]; then
+      printf 'hermetic stray note not linked from INDEX\n' >"$REPO/docs/decisions/STRAY.md"
+    fi
+    run_search "$script" "$query"
+    set +e
+    case "$projection" in
+      ids)
+        projected=$(jq -cer 'if type == "array" then [.[].id] else error("not an array") end' <<<"$out" 2>/dev/null)
+        ;;
+      sorted-ids)
+        projected=$(jq -cer 'if type == "array" then [.[].id] | sort else error("not an array") end' <<<"$out" 2>/dev/null)
+        ;;
+      ids-scores)
+        projected=$(jq -cer 'if type == "array" then [.[] | "\(.id):\(.score)"] | join(",") else error("not an array") end' <<<"$out" 2>/dev/null)
+        ;;
+      *)
+        set -e
+        fail "unknown search-row projection: $projection"
+        continue
+        ;;
+    esac
+    projection_rc=$?
+    set -e
+    actual="$rc~$projection_rc~$projected"
+    record_row "$mode" "$name" "$actual" "0~0~$expected"
+  done <<'CASES'
+body-hermetic~hermetic~ids~["D027"]~none
+body-clippy~clippy~ids~["D046"]~none
+summary-body-score~forgery~ids-scores~D047:4.5,D027:0.5~none
+body-score~hermetic~ids-scores~D027:0.5~none
+and-across-fields~performance hermetic~ids~["D027"]~none
+and-across-decisions-miss~hermetic gating~ids~[]~none
+regex-bodies~hermetic|clippy~sorted-ids~["D027","D046"]~none
+keyword-miss~zzz-absent-token~ids~[]~none
+unindexed-file~hermetic~ids~["D027"]~stray
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-echo "=== summary matches keep priority over body matches ==="
+echo "=== decisions body-search rows ==="
+evaluate_search_rows "$DECISIONS" normal
 
-# forgery is in D047's title (3) + rationale (1) + body (0.5).
-assert_eq "$(run_search forgery | jq -r '.[0].score')" "4.5" \
-  "summary weights unchanged; body adds a fractional bonus"
-# A body-only hit scores below any summary hit, so it can never displace one.
-assert_eq "$(run_search hermetic | jq -r '.[0].score')" "0.5" \
-  "body-only match scores below rationale (1pt)"
+echo "=== must-fail control ==="
+ordering_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-score-sort/decisions" '] | sort_by(-.score) | .[:$limit]' '] | .[:$limit]' 1)"
+failures="$(evaluate_search_rows "$ordering_mutant" control summary-body-score)"
+if [[ "$failures" == *'|summary-body-score|'* ]]; then
+  pass "missing score sort fails the ranking row"
+else
+  fail "missing score sort did not fail the ranking row"
+fi
 
-echo "=== AND logic spans summary and body together ==="
-
-# "performance" is in D027's title only; "hermetic" is in its body only.
-assert_eq "$(run_search "performance hermetic" | jq -r '[.[].id] | join(",")')" "D027" \
-  "one term in the summary and another in the body still satisfies AND"
-assert_eq "$(run_search "hermetic gating" | jq -r 'length')" "0" \
-  "AND still excludes when the terms live in different decisions"
-
-echo "=== regex mode also reaches bodies ==="
-
-assert_eq "$(run_search 'hermetic|clippy' | jq -r '[.[].id] | sort | join(",")')" "D027,D046" \
-  "regex alternation matches body text in both decisions"
-
-echo "=== a genuine miss is still an empty result ==="
-
-assert_eq "$(run_search zzz-absent-token | jq -r 'length')" "0" \
-  "unmatched keyword still returns an empty array"
-
-echo "=== unindexed files in the directory cannot influence results ==="
-
-printf 'hermetic stray note not linked from INDEX\n' > "$REPO/docs/decisions/STRAY.md"
-assert_eq "$(run_search hermetic | jq -r '[.[].id] | join(",")')" "D027" \
-  "a stray unindexed file adds no result"
-
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/decider/tests/decider-search-body.test.sh
+++ b/.agents/skills/decider/tests/decider-search-body.test.sh
@@ -104,6 +104,7 @@ SEARCH_CASES
     [[ -n "$only_row" ]] && guard="body-search table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -117,21 +118,26 @@ SEARCH_CASES
 echo "=== decisions body-search rows ==="
 evaluate_search_rows "$DECISIONS" normal
 
-echo "=== must-fail control ==="
-ordering_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-score-sort/decisions" '] | sort_by(-.score) | .[:$limit]' '] | .[:$limit]' 1)"
-failures="$(evaluate_search_rows "$ordering_mutant" control summary-body-score)"
-if [[ "$failures" == *'|summary-body-score|'* ]]; then
-  pass "missing score sort fails the ranking row"
-else
-  fail "missing score sort did not fail the ranking row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  ordering_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-score-sort/decisions" '] | sort_by(-.score) | .[:$limit]' '] | .[:$limit]' 1)"
+  failures="$(evaluate_search_rows "$ordering_mutant" control summary-body-score)"
+  if [[ "$failures" == *'|summary-body-score|'* ]]; then
+    pass "missing score sort fails the ranking row"
+  else
+    fail "missing score sort did not fail the ranking row"
+  fi
+
   search_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-search-table/decider/tests/decider-search-body.test.sh" SEARCH_CASES)"
   if decider_test_fails_with "$search_table_mutant" "body-search table executed no rows"; then
     pass "an empty body-search table fails its row-count guard"
   else
     fail "an empty body-search table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$search_table_mutant" "$TMP_ROOT/empty-search-table/decider/tests/diagnostic-only.test.sh" "body-search table executed no rows" 1; then
+    pass "a body-search-table diagnostic without a failure is rejected"
+  else
+    fail "a body-search-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_search_rows "$ordering_mutant" control unknown-search-row 2>&1)"

--- a/.agents/skills/decider/tests/decider-search-body.test.sh
+++ b/.agents/skills/decider/tests/decider-search-body.test.sh
@@ -55,12 +55,14 @@ record_row() {
 
 evaluate_search_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name query projection expected setup
-  local projected projection_rc actual
+  local projected projection_rc actual guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name query projection expected setup; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     if [[ "$setup" == stray ]]; then
       printf 'hermetic stray note not linked from INDEX\n' >"$REPO/docs/decisions/STRAY.md"
     fi
@@ -86,7 +88,7 @@ evaluate_search_rows() {
     set -e
     actual="$rc~$projection_rc~$projected"
     record_row "$mode" "$name" "$actual" "0~0~$expected"
-  done <<'CASES'
+  done <<'SEARCH_CASES'
 body-hermetic~hermetic~ids~["D027"]~none
 body-clippy~clippy~ids~["D046"]~none
 summary-body-score~forgery~ids-scores~D047:4.5,D027:0.5~none
@@ -96,7 +98,17 @@ and-across-decisions-miss~hermetic gating~ids~[]~none
 regex-bodies~hermetic|clippy~sorted-ids~["D027","D046"]~none
 keyword-miss~zzz-absent-token~ids~[]~none
 unindexed-file~hermetic~ids~["D027"]~stray
-CASES
+SEARCH_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="body-search table executed no rows"
+    [[ -n "$only_row" ]] && guard="body-search table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -112,6 +124,24 @@ if [[ "$failures" == *'|summary-body-score|'* ]]; then
   pass "missing score sort fails the ranking row"
 else
   fail "missing score sort did not fail the ranking row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  search_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-search-table/decider/tests/decider-search-body.test.sh" SEARCH_CASES)"
+  if decider_test_fails_with "$search_table_mutant" "body-search table executed no rows"; then
+    pass "an empty body-search table fails its row-count guard"
+  else
+    fail "an empty body-search table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_search_rows "$ordering_mutant" control unknown-search-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:body-search table selected no row: unknown-search-row"* ]]; then
+    pass "an unknown body-search row fails its selection guard"
+  else
+    fail "an unknown body-search row missed its selection guard"
+  fi
 fi
 
 echo

--- a/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -1,116 +1,30 @@
 #!/usr/bin/env bash
-# decisions missing-directory handling.
-#
-# In a repository with no decisions directory, read-only lookups (search,
-# list) emit an empty JSON array with a stderr note and exit 0: an
-# inapplicable lookup is not a workflow failure. Pinned here: that soft path
-# for both the configured-but-absent and unset-undiscovered cases, and that
-# real errors stay hard: a zero-match search in an existing directory is
-# unchanged, a configured path that exists but is a file is a hard error, and
-# creation-workflow commands (next-id, get) require the directory.
+# Missing, existing, and invalid decisions directory rows.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
-
 ERR_FILE="$TMP_ROOT/stderr"
 
-# Run the decisions script from a given directory with DECISIONS_DIR removed
-# from the parent environment (pass VAR=value args to set it explicitly).
-# Captures stdout in $out, stderr in $err, exit code in $rc.
-run_decisions() {
-  local dir="$1"
-  shift
-  set +e
-  out=$( (cd "$dir" && env -u DECISIONS_DIR "$@" "$DECISIONS" "${ARGS[@]}") 2>"$ERR_FILE")
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
-}
-
-assert_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
-echo "=== decisions missing decisions dir (kendex#561) ==="
-
-# --- Project with a configured DECISIONS_DIR that does not exist -------------
-# Mirrors the reported failure: kendex.settings.toml sets DECISIONS_DIR but
-# the repository has no decisions directory.
 NO_DIR="$TMP_ROOT/no-dir-project"
 mkdir -p "$NO_DIR"
 printf '[env]\nDECISIONS_DIR = "docs/decisions"\n' >"$NO_DIR/kendex.settings.toml"
 
-ARGS=(search --issue PROJ-557)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "0" "issue search with absent dir exits 0"
-assert_eq "$out" "[]" "issue search with absent dir emits empty array"
-assert_contains "$err" "docs/decisions" "issue search note names the missing dir"
-assert_contains "$err" "not present" "issue search notes dir not present on stderr"
-
-ARGS=(search "ffi error handling")
-run_decisions "$NO_DIR"
-assert_eq "$rc" "0" "keyword search with absent dir exits 0"
-assert_eq "$out" "[]" "keyword search with absent dir emits empty array"
-assert_contains "$err" "not present" "keyword search notes dir not present on stderr"
-
-ARGS=(list)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "0" "list with absent dir exits 0"
-assert_eq "$out" "[]" "list with absent dir emits empty array"
-assert_contains "$err" "not present" "list notes dir not present on stderr"
-
-# Creation-workflow commands still require the directory.
-ARGS=(next-id)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "1" "next-id with absent dir still errors"
-assert_contains "$err" "does not exist" "next-id reports missing DECISIONS_DIR"
-
-ARGS=(get D001)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "1" "get with absent dir still errors"
-assert_contains "$err" "does not exist" "get reports missing DECISIONS_DIR"
-
-# --- DECISIONS_DIR unset and auto-discovery finds nothing --------------------
 UNSET_DIR="$TMP_ROOT/unset-project"
 mkdir -p "$UNSET_DIR"
 
-ARGS=(search --issue PROJ-557)
-run_decisions "$UNSET_DIR"
-assert_eq "$rc" "0" "issue search with undiscovered dir exits 0"
-assert_eq "$out" "[]" "issue search with undiscovered dir emits empty array"
-assert_contains "$err" "no decisions directory found" "undiscovered dir noted on stderr"
-
-ARGS=(help)
-run_decisions "$UNSET_DIR"
-assert_eq "$rc" "0" "help works without a decisions dir"
-assert_contains "$out" "Decision Lookup Tool" "help prints usage without a decisions dir"
-
-# --- Existing directory: zero-match and match behavior unchanged -------------
 HAS_DIR="$TMP_ROOT/has-dir-project"
 mkdir -p "$HAS_DIR/docs/decisions"
 cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
@@ -121,41 +35,163 @@ cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-10 | D001 | PROJ-100 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
 EOF
 
-ARGS=(search "zzz nonexistent term")
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "zero-match keyword search in existing dir exits 0"
-assert_eq "$out" "[]" "zero-match keyword search emits empty array"
-assert_eq "$err" "" "zero-match keyword search emits no stderr note"
+NOT_A_DIR="$TMP_ROOT/not-a-dir"
+touch "$NOT_A_DIR"
 
-ARGS=(search --issue PROJ-999)
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "zero-match issue search in existing dir exits 0"
-assert_eq "$out" "[]" "zero-match issue search emits empty array"
-assert_eq "$err" "" "zero-match issue search emits no stderr note"
+run_decisions() {
+  local script="$1" state="$2"
+  shift 2
+  set +e
+  case "$state" in
+    configured-absent)
+      out=$( (cd "$NO_DIR" && env -u DECISIONS_DIR "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    undiscovered)
+      out=$( (cd "$UNSET_DIR" && env -u DECISIONS_DIR "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    existing)
+      out=$( (cd "$HAS_DIR" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    configured-file)
+      out=$( (cd "$NO_DIR" && env -u DECISIONS_DIR DECISIONS_DIR="$NOT_A_DIR" "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    *)
+      set -e
+      fail "unknown directory state: $state"
+      return
+      ;;
+  esac
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-ARGS=(search "redis")
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "matching keyword search in existing dir exits 0"
-assert_contains "$out" '"D001"' "matching keyword search returns D001"
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-ARGS=(next-id)
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "next-id in existing dir exits 0"
-assert_eq "$out" "D002" "next-id in existing dir returns D002"
+evaluate_directory_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name state action argument expected_status
+  local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr
+  local projected projection_rc actual expected
+  table_failures=""
+  while IFS='~' read -r name state action argument expected_status stdout_rule expected_stdout stderr_rule needle_one needle_two; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    case "$action" in
+      issue) run_decisions "$script" "$state" search --issue "$argument" ;;
+      keyword) run_decisions "$script" "$state" search "$argument" ;;
+      list|next-id|help) run_decisions "$script" "$state" "$action" ;;
+      get) run_decisions "$script" "$state" get "$argument" ;;
+      *) fail "unknown directory-row action: $action"; continue ;;
+    esac
 
-# --- Configured path exists but is a file: hard error for every command ------
-touch "$TMP_ROOT/not-a-dir"
+    case "$stdout_rule" in
+      exact)
+        actual_stdout="$out"
+        ;;
+      contains)
+        actual_stdout=0
+        [[ "$out" == *"$expected_stdout"* ]] && actual_stdout=1
+        expected_stdout=1
+        ;;
+      ids)
+        set +e
+        projected=$(jq -cer 'if type == "array" then [.[].id] else error("not an array") end' <<<"$out" 2>/dev/null)
+        projection_rc=$?
+        set -e
+        actual_stdout="$projection_rc:$projected"
+        expected_stdout="0:$expected_stdout"
+        ;;
+      ignore)
+        actual_stdout=ignored
+        expected_stdout=ignored
+        ;;
+      *) fail "unknown stdout rule: $stdout_rule"; continue ;;
+    esac
 
-ARGS=(search --issue PROJ-557)
-run_decisions "$NO_DIR" DECISIONS_DIR="$TMP_ROOT/not-a-dir"
-assert_eq "$rc" "1" "search with file at DECISIONS_DIR exits nonzero"
-assert_eq "$out" "" "search with file at DECISIONS_DIR emits no result"
-assert_contains "$err" "is not a directory" "search with file at DECISIONS_DIR reports hard error"
+    case "$stderr_rule" in
+      contains)
+        actual_stderr=0
+        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1
+        expected=1
+        ;;
+      both)
+        actual_stderr=0,0
+        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1,0
+        [[ "$err" == *"$needle_one"* && "$err" == *"$needle_two"* ]] && actual_stderr=1,1
+        expected=1,1
+        ;;
+      empty)
+        actual_stderr="$err"
+        expected=""
+        ;;
+      ignore)
+        actual_stderr=ignored
+        expected=ignored
+        ;;
+      *) fail "unknown stderr rule: $stderr_rule"; continue ;;
+    esac
 
-ARGS=(next-id)
-run_decisions "$NO_DIR" DECISIONS_DIR="$TMP_ROOT/not-a-dir"
-assert_eq "$rc" "1" "next-id with file at DECISIONS_DIR exits nonzero"
-assert_contains "$err" "is not a directory" "next-id with file at DECISIONS_DIR reports hard error"
+    actual="$rc~$actual_stdout~$actual_stderr"
+    record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
+  done <<'CASES'
+configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~both~docs/decisions~not present
+configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~contains~not present~
+configured-absent-list~configured-absent~list~~0~exact~[]~contains~not present~
+configured-absent-next-id~configured-absent~next-id~~1~ignore~~contains~does not exist~
+configured-absent-get~configured-absent~get~D001~1~ignore~~contains~does not exist~
+undiscovered-issue~undiscovered~issue~PROJ-557~0~exact~[]~contains~no decisions directory found~
+help-without-directory~undiscovered~help~~0~contains~Decision Lookup Tool~ignore~~
+existing-keyword-miss~existing~keyword~zzz nonexistent term~0~exact~[]~empty~~
+existing-issue-miss~existing~issue~PROJ-999~0~exact~[]~empty~~
+existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
+existing-next-id~existing~next-id~~0~exact~D002~ignore~~
+configured-file-search~configured-file~issue~PROJ-557~1~exact~~contains~is not a directory~
+configured-file-next-id~configured-file~next-id~~1~ignore~~contains~is not a directory~
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
+
+echo "=== decisions directory-state rows ==="
+evaluate_directory_rows "$DECISIONS" normal
+
+echo "=== must-fail controls ==="
+old_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+old_branch+=$'\n    note_missing_decisions_dir\n'
+old_branch+="    echo '[]'"
+old_branch+=$'\n    return 0\n  fi\n\n  local all'
+new_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+new_branch+=$'\n    note_missing_decisions_dir\n'
+new_branch+="    echo '[]'"
+new_branch+=$'\n    return 1\n  fi\n\n  local all'
+status_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/absent-search-fails/decisions" "$old_branch" "$new_branch" 1)"
+failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-issue)"
+if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
+  pass "absent issue-search failure fails its row"
+else
+  fail "absent issue-search failure did not fail its row"
+fi
+failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-keyword)"
+if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
+  pass "absent keyword-search failure fails its row"
+else
+  fail "absent keyword-search failure did not fail its row"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -169,6 +169,7 @@ DIRECTORY_CASES
     [[ -n "$only_row" ]] && guard="directory table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -182,35 +183,40 @@ DIRECTORY_CASES
 echo "=== decisions directory-state rows ==="
 evaluate_directory_rows "$DECISIONS" normal
 
-echo "=== must-fail controls ==="
-old_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
-old_branch+=$'\n    note_missing_decisions_dir\n'
-old_branch+="    echo '[]'"
-old_branch+=$'\n    return 0\n  fi\n\n  local all'
-new_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
-new_branch+=$'\n    note_missing_decisions_dir\n'
-new_branch+="    echo '[]'"
-new_branch+=$'\n    return 1\n  fi\n\n  local all'
-status_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/absent-search-fails/decisions" "$old_branch" "$new_branch" 1)"
-failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-issue)"
-if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
-  pass "absent issue-search failure fails its row"
-else
-  fail "absent issue-search failure did not fail its row"
-fi
-failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-keyword)"
-if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
-  pass "absent keyword-search failure fails its row"
-else
-  fail "absent keyword-search failure did not fail its row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  old_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+  old_branch+=$'\n    note_missing_decisions_dir\n'
+  old_branch+="    echo '[]'"
+  old_branch+=$'\n    return 0\n  fi\n\n  local all'
+  new_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+  new_branch+=$'\n    note_missing_decisions_dir\n'
+  new_branch+="    echo '[]'"
+  new_branch+=$'\n    return 1\n  fi\n\n  local all'
+  status_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/absent-search-fails/decisions" "$old_branch" "$new_branch" 1)"
+  failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-issue)"
+  if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
+    pass "absent issue-search failure fails its row"
+  else
+    fail "absent issue-search failure did not fail its row"
+  fi
+  failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-keyword)"
+  if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
+    pass "absent keyword-search failure fails its row"
+  else
+    fail "absent keyword-search failure did not fail its row"
+  fi
+
   directory_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-directory-table/decider/tests/decider-search-missing-dir.test.sh" DIRECTORY_CASES)"
   if decider_test_fails_with "$directory_table_mutant" "directory table executed no rows"; then
     pass "an empty directory table fails its row-count guard"
   else
     fail "an empty directory table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$directory_table_mutant" "$TMP_ROOT/empty-directory-table/decider/tests/diagnostic-only.test.sh" "directory table executed no rows" 1; then
+    pass "a directory-table diagnostic without a failure is rejected"
+  else
+    fail "a directory-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_directory_rows "$status_mutant" control unknown-directory-row 2>&1)"

--- a/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -84,12 +84,14 @@ record_row() {
 evaluate_directory_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name state action argument expected_status
   local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr
-  local projected projection_rc actual expected
+  local projected projection_rc actual expected guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name state action argument expected_status stdout_rule expected_stdout stderr_rule needle_one needle_two; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     case "$action" in
       issue) run_decisions "$script" "$state" search --issue "$argument" ;;
       keyword) run_decisions "$script" "$state" search "$argument" ;;
@@ -147,7 +149,7 @@ evaluate_directory_rows() {
 
     actual="$rc~$actual_stdout~$actual_stderr"
     record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
-  done <<'CASES'
+  done <<'DIRECTORY_CASES'
 configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~both~docs/decisions~not present
 configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~contains~not present~
 configured-absent-list~configured-absent~list~~0~exact~[]~contains~not present~
@@ -161,7 +163,17 @@ existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
 existing-next-id~existing~next-id~~0~exact~D002~ignore~~
 configured-file-search~configured-file~issue~PROJ-557~1~exact~~contains~is not a directory~
 configured-file-next-id~configured-file~next-id~~1~ignore~~contains~is not a directory~
-CASES
+DIRECTORY_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="directory table executed no rows"
+    [[ -n "$only_row" ]] && guard="directory table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -191,6 +203,24 @@ if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
   pass "absent keyword-search failure fails its row"
 else
   fail "absent keyword-search failure did not fail its row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  directory_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-directory-table/decider/tests/decider-search-missing-dir.test.sh" DIRECTORY_CASES)"
+  if decider_test_fails_with "$directory_table_mutant" "directory table executed no rows"; then
+    pass "an empty directory table fails its row-count guard"
+  else
+    fail "an empty directory table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_directory_rows "$status_mutant" control unknown-directory-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:directory table selected no row: unknown-directory-row"* ]]; then
+    pass "an unknown directory row fails its selection guard"
+  else
+    fail "an unknown directory row missed its selection guard"
+  fi
 fi
 
 echo

--- a/.agents/skills/decider/tests/lib/mutate-script.sh
+++ b/.agents/skills/decider/tests/lib/mutate-script.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+decider_mutate_script() {
+  local source="$1" destination="$2" old="$3" new="$4" expected_count="$5"
+  local content="" rest="" prefix="" mutated="" count=0 destination_dir source_dir
+
+  if [[ -L "$source" ]]; then
+    printf 'refusing to mutate symlink: %s\n' "$source" >&2
+    return 1
+  fi
+  if ! content="$(<"$source")"; then
+    printf 'could not read mutation source: %s\n' "$source" >&2
+    return 1
+  fi
+
+  rest="$content"
+  while [[ "$rest" == *"$old"* ]]; do
+    prefix="${rest%%"$old"*}"
+    mutated+="$prefix$new"
+    rest="${rest#*"$old"}"
+    count=$((count + 1))
+  done
+  mutated+="$rest"
+
+  if [[ "$count" -ne "$expected_count" ]]; then
+    printf 'mutation match count: expected %s, got %s\n' "$expected_count" "$count" >&2
+    return 1
+  fi
+
+  destination_dir="${destination%/*}"
+  source_dir="${source%/*}"
+  if ! mkdir -p "$destination_dir"; then
+    printf 'could not create mutant directory: %s\n' "$destination_dir" >&2
+    return 1
+  fi
+  if ! cp -R "$source_dir/lib" "$destination_dir/lib"; then
+    printf 'could not copy mutation support files\n' >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$mutated" >"$destination"; then
+    printf 'could not write mutant: %s\n' "$destination" >&2
+    return 1
+  fi
+  if ! chmod +x "$destination"; then
+    printf 'could not mark mutant executable: %s\n' "$destination" >&2
+    return 1
+  fi
+
+  if cmp -s "$source" "$destination"; then
+    printf 'mutation changed no bytes: %s\n' "$destination" >&2
+    return 1
+  fi
+
+  printf '%s' "$destination"
+}

--- a/.agents/skills/decider/tests/lib/mutate-script.sh
+++ b/.agents/skills/decider/tests/lib/mutate-script.sh
@@ -33,9 +33,11 @@ decider_mutate_script() {
     printf 'could not create mutant directory: %s\n' "$destination_dir" >&2
     return 1
   fi
-  if ! cp -R "$source_dir/lib" "$destination_dir/lib"; then
-    printf 'could not copy mutation support files\n' >&2
-    return 1
+  if [[ "$source_dir" != "$destination_dir" ]]; then
+    if ! cp -R "$source_dir/lib" "$destination_dir/lib"; then
+      printf 'could not copy mutation support files\n' >&2
+      return 1
+    fi
   fi
   if ! printf '%s\n' "$mutated" >"$destination"; then
     printf 'could not write mutant: %s\n' "$destination" >&2
@@ -95,10 +97,32 @@ decider_empty_test_table() {
 decider_test_fails_with() {
   local test_script="$1" expected="$2" output status
   DECIDER_CONTROL_DETAIL=""
+  DECIDER_CONTROL_OUTPUT=""
+  DECIDER_CONTROL_STATUS=0
   set +e
   output=$(DECIDER_TABLE_CONTROL_RUN=1 "$test_script" 2>&1)
   status=$?
   set -e
+  DECIDER_CONTROL_OUTPUT="$output"
+  DECIDER_CONTROL_STATUS=$status
   DECIDER_CONTROL_DETAIL="status $status; output: $output"
   [[ "$status" -ne 0 && "$output" == *"$expected"* ]]
+}
+
+decider_diagnostic_only_table_control() {
+  local test_script="$1" destination="$2" expected="$3" expected_count="$4" mutant
+  local old='      fail "$guard"'$'\n''      return 1'
+  local new='      printf '\''  FAIL  %s\n'\'' "$guard"'$'\n''      return 0'
+
+  if ! mutant="$(decider_mutate_script "$test_script" "$destination" "$old" "$new" "$expected_count")"; then
+    return 1
+  fi
+  if ! bash -n "$mutant"; then
+    DECIDER_CONTROL_DETAIL="diagnostic-only table control did not compile"
+    return 1
+  fi
+  if decider_test_fails_with "$mutant" "$expected"; then
+    return 1
+  fi
+  [[ "$DECIDER_CONTROL_STATUS" -eq 0 && "$DECIDER_CONTROL_OUTPUT" == *"$expected"* ]]
 }

--- a/.agents/skills/decider/tests/lib/mutate-script.sh
+++ b/.agents/skills/decider/tests/lib/mutate-script.sh
@@ -53,3 +53,52 @@ decider_mutate_script() {
 
   printf '%s' "$destination"
 }
+
+decider_empty_test_table() {
+  local source="$1" destination="$2" delimiter="$3"
+  local content="" start after_start rows old new mutant source_dir source_skill_dir
+  local destination_dir destination_skill_dir
+
+  if ! content="$(<"$source")"; then
+    printf 'could not read table-control source: %s\n' "$source" >&2
+    return 1
+  fi
+  start="  done <<'$delimiter'"
+  after_start="${content#*"$start"$'\n'}"
+  if [[ "$after_start" == "$content" ]]; then
+    printf 'table start not found: %s\n' "$delimiter" >&2
+    return 1
+  fi
+  rows="${after_start%%$'\n'"$delimiter"*}"
+  if [[ "$rows" == "$after_start" ]]; then
+    printf 'table end not found: %s\n' "$delimiter" >&2
+    return 1
+  fi
+  old="$start"$'\n'"$rows"$'\n'"$delimiter"
+  new="$start"$'\n'"$delimiter"
+  if ! mutant="$(decider_mutate_script "$source" "$destination" "$old" "$new" 1)"; then
+    return 1
+  fi
+
+  source_dir="${source%/*}"
+  source_skill_dir="${source_dir%/*}"
+  destination_dir="${destination%/*}"
+  destination_skill_dir="${destination_dir%/*}"
+  if ! cp -R "$source_skill_dir/scripts" "$destination_skill_dir/scripts"; then
+    printf 'could not copy production scripts for table control\n' >&2
+    return 1
+  fi
+
+  printf '%s' "$mutant"
+}
+
+decider_test_fails_with() {
+  local test_script="$1" expected="$2" output status
+  DECIDER_CONTROL_DETAIL=""
+  set +e
+  output=$(DECIDER_TABLE_CONTROL_RUN=1 "$test_script" 2>&1)
+  status=$?
+  set -e
+  DECIDER_CONTROL_DETAIL="status $status; output: $output"
+  [[ "$status" -ne 0 && "$output" == *"$expected"* ]]
+}

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -1,34 +1,25 @@
 #!/usr/bin/env bash
-# Index-parse contract: the INDEX Link cell resolves each decision's document,
-# and `get` enriches from that document.
-#
-# A Link cell the parser cannot resolve yields an empty path, and an empty path
-# makes body search skip the decision and `get` report an unknown date — a miss
-# indistinguishable from "no decision governs this area". The three cell shapes
-# below all appear in indexes written from this skill's row template, so all
-# three must resolve.
-#
-# Teeth: each check is re-run against a mutated copy of the script that breaks
-# the behavior under test, and must catch it.
+# INDEX link parsing and document enrichment.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
+ERR_FILE="$TMP_ROOT/stderr"
 
 pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-# --- Fixture: one decision per supported Link cell shape ---------------------
-
 REPO="$TMP_ROOT/repo"
 mkdir -p "$REPO/docs/decisions"
-
 cat >"$REPO/docs/decisions/INDEX.md" <<'EOF'
 # Architectural Decision Log
 
@@ -39,93 +30,13 @@ cat >"$REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-03 | D003 | PROJ-3 | Bare filename cell | Reason three | Never | Active | Full -> D003-bare.md |
 | 2026-01-04 | D004 | PROJ-4 | No document yet | Reason four | Never | Active | pending |
 EOF
+printf '# D001\n\n**Date**: 2026-01-01\n\nGoverns tokenone handling.\n' >"$REPO/docs/decisions/D001-md-link.md"
+printf '# D002\n\n**Date**: 2026-01-02\n\nGoverns tokentwo handling.\n' >"$REPO/docs/decisions/D002-backtick.md"
+printf '# D003\n\n**Date**:2026-01-03\n\nGoverns tokenthree handling.\n' >"$REPO/docs/decisions/D003-bare.md"
 
-printf '# D001\n\n**Date**: 2026-01-01\n\nGoverns tokenone handling.\n' \
-  >"$REPO/docs/decisions/D001-md-link.md"
-printf '# D002\n\n**Date**: 2026-01-02\n\nGoverns tokentwo handling.\n' \
-  >"$REPO/docs/decisions/D002-backtick.md"
-printf '# D003\n\n**Date**:2026-01-03\n\nGoverns tokenthree handling.\n' \
-  >"$REPO/docs/decisions/D003-bare.md"
-
-# run <script> <args...> — stdout only, from inside the fixture repo.
-run() {
-  local script="$1"
-  shift
-  (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$script" "$@" 2>/dev/null)
-}
-
-# check_parse <script>
-# Prints the name of every failed expectation (empty output = all held).
-check_parse() {
-  local script="$1" broken=""
-
-  # Each shape resolves to its document, so a body-only keyword finds it.
-  [[ "$(run "$script" search tokenone | jq -r '[.[].id] | join(",")')" == "D001" ]] \
-    || broken="$broken md-link-body"
-  [[ "$(run "$script" search tokentwo | jq -r '[.[].id] | join(",")')" == "D002" ]] \
-    || broken="$broken backtick-body"
-  [[ "$(run "$script" search tokenthree | jq -r '[.[].id] | join(",")')" == "D003" ]] \
-    || broken="$broken bare-body"
-
-  # get resolves the same path and reads the date out of the document.
-  [[ "$(run "$script" get D001 | jq -r '.path')" == "$REPO/docs/decisions/D001-md-link.md" ]] \
-    || broken="$broken md-link-path"
-  [[ "$(run "$script" get D002 | jq -r '.path')" == "$REPO/docs/decisions/D002-backtick.md" ]] \
-    || broken="$broken backtick-path"
-  [[ "$(run "$script" get D001 | jq -r '.date')" == "2026-01-01" ]] \
-    || broken="$broken date-enrichment"
-  # The date label tolerates no space after the colon.
-  [[ "$(run "$script" get D003 | jq -r '.date')" == "2026-01-03" ]] \
-    || broken="$broken date-unspaced"
-
-  # A cell naming no document resolves to nothing rather than a wrong path.
-  [[ "$(run "$script" get D004 | jq -r '.path')" == "" ]] \
-    || broken="$broken empty-cell-path"
-  [[ "$(run "$script" get D004 | jq -r '.date')" == "unknown" ]] \
-    || broken="$broken empty-cell-date"
-
-  printf '%s' "$broken"
-}
-
-# mutate <name> <sed-script> — copies scripts/ and patches the entry point.
-mutate() {
-  local dir="$TMP_ROOT/mutant-$1"
-  mkdir -p "$dir"
-  cp -R "$SKILL_DIR/scripts/lib" "$dir/lib"
-  sed "$2" "$DECISIONS" >"$dir/decisions"
-  chmod +x "$dir/decisions"
-  printf '%s' "$dir/decisions"
-}
-
-# expect_caught <clause> <mutant> <description>
-expect_caught() {
-  local clause="$1" mutant="$2" desc="$3" out
-  out="$(check_parse "$mutant")"
-  if [[ "$out" == *"$clause"* ]]; then
-    pass "$desc"
-  else
-    fail "$desc (check output: '$out')"
-  fi
-}
-
-echo "=== decisions INDEX link-cell and get enrichment ==="
-
-broken="$(check_parse "$DECISIONS")"
-if [[ -z "$broken" ]]; then
-  pass "every Link cell shape resolves and get enriches from the document"
-else
-  fail "index parse contract broken:$broken"
-fi
-
-echo "=== malformed rows are named, not silently dropped ==="
-
-# A row that opens like a decision but misses the eight-cell contract is skipped
-# by the parser. Skipped silently, a mistyped row reads downstream as a decision
-# that was never recorded — the index says one thing, every consumer says
-# another, and nothing points at the row to fix.
-BADREPO="$TMP_ROOT/badrepo"
-mkdir -p "$BADREPO/docs/decisions"
-cat >"$BADREPO/docs/decisions/INDEX.md" <<'EOF'
+BAD_REPO="$TMP_ROOT/bad-repo"
+mkdir -p "$BAD_REPO/docs/decisions"
+cat >"$BAD_REPO/docs/decisions/INDEX.md" <<'EOF'
 # Architectural Decision Log
 
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
@@ -135,60 +46,153 @@ cat >"$BADREPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-02-03 | D103 | PROJ-3 | Second well-formed | Reason three | Never | Active | [Full](D103.md) |
 EOF
 
-run_bad() { (cd "$BADREPO" && DECISIONS_DIR="$BADREPO/docs/decisions" "$DECISIONS" "$@"); }
+run_decisions() {
+  local script="$1" repo="$2" decisions_dir="$3"
+  shift 3
+  set +e
+  out=$( (cd "$repo" && DECISIONS_DIR="$decisions_dir" "$script" "$@") 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-bad_stdout="$(run_bad list 2>/dev/null)"
-bad_stderr="$(run_bad list 2>&1 >/dev/null)"
+project_json() {
+  local expression="$1"
+  set +e
+  projected=$(jq -cer "$expression" <<<"$out" 2>/dev/null)
+  projection_rc=$?
+  set -e
+}
 
-# stdout contract is unchanged: the parseable rows, and only those.
-if [[ "$(jq -r '[.[].id] | join(",")' <<<"$bad_stdout")" == "D101,D103" ]]; then
-  pass "stdout still carries exactly the rows that parse"
-else
-  fail "stdout contract changed (got: $bad_stdout)"
-fi
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-if grep -q 'D102\|:6:' <<<"$bad_stderr"; then
-  pass "the malformed row is named on stderr"
-else
-  fail "the malformed row was dropped without a diagnostic (stderr: $bad_stderr)"
-fi
+evaluate_link_rows() {
+  local script="$1" mode="$2" name kind argument expected actual
+  table_failures=""
+  while IFS='~' read -r name kind argument expected; do
+    run_decisions "$script" "$REPO" "$REPO/docs/decisions" "${kind%%-*}" "$argument"
+    case "$kind" in
+      search-ids)
+        project_json 'if type == "array" then [.[].id] | join(",") else error("not an array") end'
+        ;;
+      get-path)
+        project_json 'if type == "object" and has("path") then .path else error("missing path") end'
+        expected="$REPO/docs/decisions/$expected"
+        ;;
+      get-empty-path)
+        project_json 'if type == "object" and has("path") then .path else error("missing path") end'
+        ;;
+      get-date)
+        project_json 'if type == "object" and has("date") then .date else error("missing date") end'
+        ;;
+      *)
+        fail "unknown link-row projection: $kind"
+        continue
+        ;;
+    esac
+    if [[ -z "$projected" ]]; then
+      projected='<empty>'
+    fi
+    actual="$rc~$projection_rc~$projected"
+    record_row "$mode" "$name" "$actual" "0~0~$expected"
+  done <<'CASES'
+md-link-body~search-ids~tokenone~D001
+backtick-body~search-ids~tokentwo~D002
+bare-body~search-ids~tokenthree~D003
+md-link-path~get-path~D001~D001-md-link.md
+backtick-path~get-path~D002~D002-backtick.md
+date-enrichment~get-date~D001~2026-01-01
+date-unspaced~get-date~D003~2026-01-03
+empty-cell-path~get-empty-path~D004~<empty>
+empty-cell-date~get-date~D004~unknown
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-if grep -q ':6:' <<<"$bad_stderr"; then
-  pass "the diagnostic cites the row's line in the index"
-else
-  fail "the diagnostic does not cite the index line (stderr: $bad_stderr)"
-fi
+evaluate_diagnostic_rows() {
+  local script="$1" mode="$2" name fixture projection expected actual first second
+  table_failures=""
+  while IFS='~' read -r name fixture projection expected; do
+    if [[ "$fixture" == malformed ]]; then
+      run_decisions "$script" "$BAD_REPO" "$BAD_REPO/docs/decisions" list
+    else
+      run_decisions "$script" "$REPO" "$REPO/docs/decisions" list
+    fi
+    case "$projection" in
+      ids)
+        project_json 'if type == "array" then [.[].id] | join(",") else error("not an array") end'
+        actual="$rc~$projection_rc~$projected"
+        expected="0~0~$expected"
+        ;;
+      malformed-warning)
+        first=0
+        second=0
+        [[ "$err" == *D102* || "$err" == *:6:* ]] && first=1
+        [[ "$err" == *:6:* ]] && second=1
+        actual="$rc~$first~$second"
+        ;;
+      empty-stderr)
+        actual="$rc~${err:-<empty>}"
+        ;;
+      *)
+        fail "unknown diagnostic-row projection: $projection"
+        continue
+        ;;
+    esac
+    record_row "$mode" "$name" "$actual" "$expected"
+  done <<'CASES'
+malformed-row-results~malformed~ids~D101,D103
+malformed-row-diagnostic~malformed~malformed-warning~0~1~1
+healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-# The diagnostic must not fire for a healthy index, or it is just noise.
-if [[ -z "$( (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$DECISIONS" list 2>&1 >/dev/null) )" ]]; then
-  pass "a well-formed index emits no warning"
-else
-  fail "a well-formed index emitted a spurious warning"
-fi
+expect_control_failure() {
+  local failures="$1" row="$2" description="$3"
+  if [[ "$failures" == *"|$row|"* ]]; then
+    pass "$description"
+  else
+    fail "$description (failed rows: $failures)"
+  fi
+}
 
-echo "=== teeth ==="
+echo "=== decisions INDEX link and get rows ==="
+evaluate_link_rows "$DECISIONS" normal
 
-# Drop the non-markdown-link fallbacks: only [text](path) cells resolve.
-expect_caught backtick-body \
-  "$(mutate no-fallback 's/+ \[ \$cell | scan/+ [ empty | scan/g')" \
-  "losing the backticked-filename fallback is caught"
+echo "=== decisions malformed and healthy INDEX rows ==="
+evaluate_diagnostic_rows "$DECISIONS" normal
 
-expect_caught bare-body \
-  "$(mutate no-fallback2 's/+ \[ \$cell | scan/+ [ empty | scan/g')" \
-  "losing the bare-filename fallback is caught"
+echo "=== must-fail controls ==="
+fallback_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-fallback/decisions" '+ [ $cell | scan' '+ [ empty | scan' 2)"
+failures="$(evaluate_link_rows "$fallback_mutant" control)"
+expect_control_failure "$failures" backtick-body "backtick fallback loss fails its row"
+expect_control_failure "$failures" bare-body "bare fallback loss fails its row"
 
-# Stop get from adopting the date parsed out of the document.
-expect_caught date-enrichment \
-  "$(mutate no-date 's/date="\$parsed"/date="mutated"/')" \
-  "losing get's date enrichment is caught"
+date_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-date/decisions" '      date="$parsed"' '      date="mutated"' 1)"
+failures="$(evaluate_link_rows "$date_mutant" control)"
+expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
 
-# Drop the malformed-row diagnostic: the rows still vanish, but nothing says so.
-silent="$(mutate no-warn 's/| select((.value | split("|") | length) < 9)/| select(false)/')"
-if [[ -z "$( (cd "$BADREPO" && DECISIONS_DIR="$BADREPO/docs/decisions" "$silent" list 2>&1 >/dev/null) )" ]]; then
-  pass "losing the malformed-row diagnostic is caught"
-else
-  fail "the no-warn mutant still emitted a diagnostic"
-fi
+warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
+failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
+expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -129,6 +129,7 @@ LINK_CASES
     [[ -n "$only_row" ]] && guard="link table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -185,6 +186,7 @@ DIAGNOSTIC_CASES
     [[ -n "$only_row" ]] && guard="diagnostic table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -210,26 +212,31 @@ evaluate_link_rows "$DECISIONS" normal
 echo "=== decisions malformed and healthy INDEX rows ==="
 evaluate_diagnostic_rows "$DECISIONS" normal
 
-echo "=== must-fail controls ==="
-fallback_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-fallback/decisions" '+ [ $cell | scan' '+ [ empty | scan' 2)"
-failures="$(evaluate_link_rows "$fallback_mutant" control)"
-expect_control_failure "$failures" backtick-body "backtick fallback loss fails its row"
-expect_control_failure "$failures" bare-body "bare fallback loss fails its row"
-
-date_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-date/decisions" '      date="$parsed"' '      date="mutated"' 1)"
-failures="$(evaluate_link_rows "$date_mutant" control)"
-expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
-
-warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
-failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
-expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  fallback_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-fallback/decisions" '+ [ $cell | scan' '+ [ empty | scan' 2)"
+  failures="$(evaluate_link_rows "$fallback_mutant" control)"
+  expect_control_failure "$failures" backtick-body "backtick fallback loss fails its row"
+  expect_control_failure "$failures" bare-body "bare fallback loss fails its row"
+
+  date_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-date/decisions" '      date="$parsed"' '      date="mutated"' 1)"
+  failures="$(evaluate_link_rows "$date_mutant" control)"
+  expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
+
+  warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
+  failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
+  expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
+
   link_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-link-table/decider/tests/decider-index-parse.test.sh" LINK_CASES)"
   if decider_test_fails_with "$link_table_mutant" "link table executed no rows"; then
     pass "an empty link table fails its row-count guard"
   else
     fail "an empty link table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$link_table_mutant" "$TMP_ROOT/empty-link-table/decider/tests/diagnostic-only.test.sh" "link table executed no rows" 2; then
+    pass "a link-table diagnostic without a failure is rejected"
+  else
+    fail "a link-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_link_rows "$fallback_mutant" control unknown-link-row 2>&1)"
@@ -246,6 +253,11 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "an empty diagnostic table fails its row-count guard"
   else
     fail "an empty diagnostic table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$diagnostic_table_mutant" "$TMP_ROOT/empty-diagnostic-table/decider/tests/diagnostic-only.test.sh" "diagnostic table executed no rows" 2; then
+    pass "a diagnostic-table diagnostic without a failure is rejected"
+  else
+    fail "a diagnostic-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_diagnostic_rows "$warning_mutant" control unknown-diagnostic-row 2>&1)"

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -80,9 +80,14 @@ record_row() {
 }
 
 evaluate_link_rows() {
-  local script="$1" mode="$2" name kind argument expected actual
+  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name kind argument expected; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    executed_rows=$((executed_rows + 1))
     run_decisions "$script" "$REPO" "$REPO/docs/decisions" "${kind%%-*}" "$argument"
     case "$kind" in
       search-ids)
@@ -108,7 +113,7 @@ evaluate_link_rows() {
     fi
     actual="$rc~$projection_rc~$projected"
     record_row "$mode" "$name" "$actual" "0~0~$expected"
-  done <<'CASES'
+  done <<'LINK_CASES'
 md-link-body~search-ids~tokenone~D001
 backtick-body~search-ids~tokentwo~D002
 bare-body~search-ids~tokenthree~D003
@@ -118,16 +123,31 @@ date-enrichment~get-date~D001~2026-01-01
 date-unspaced~get-date~D003~2026-01-03
 empty-cell-path~get-empty-path~D004~<empty>
 empty-cell-date~get-date~D004~unknown
-CASES
+LINK_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="link table executed no rows"
+    [[ -n "$only_row" ]] && guard="link table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
 }
 
 evaluate_diagnostic_rows() {
-  local script="$1" mode="$2" name fixture projection expected actual first second
+  local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name fixture projection expected; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    executed_rows=$((executed_rows + 1))
     if [[ "$fixture" == malformed ]]; then
       run_decisions "$script" "$BAD_REPO" "$BAD_REPO/docs/decisions" list
     else
@@ -155,11 +175,21 @@ evaluate_diagnostic_rows() {
         ;;
     esac
     record_row "$mode" "$name" "$actual" "$expected"
-  done <<'CASES'
+  done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103
 malformed-row-diagnostic~malformed~malformed-warning~0~1~1
 healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
-CASES
+DIAGNOSTIC_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="diagnostic table executed no rows"
+    [[ -n "$only_row" ]] && guard="diagnostic table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -193,6 +223,40 @@ expect_control_failure "$failures" date-enrichment "date mutation fails the enri
 warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
 failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
 expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  link_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-link-table/decider/tests/decider-index-parse.test.sh" LINK_CASES)"
+  if decider_test_fails_with "$link_table_mutant" "link table executed no rows"; then
+    pass "an empty link table fails its row-count guard"
+  else
+    fail "an empty link table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_link_rows "$fallback_mutant" control unknown-link-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:link table selected no row: unknown-link-row"* ]]; then
+    pass "an unknown link row fails its selection guard"
+  else
+    fail "an unknown link row missed its selection guard"
+  fi
+
+  diagnostic_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-diagnostic-table/decider/tests/decider-index-parse.test.sh" DIAGNOSTIC_CASES)"
+  if decider_test_fails_with "$diagnostic_table_mutant" "diagnostic table executed no rows"; then
+    pass "an empty diagnostic table fails its row-count guard"
+  else
+    fail "an empty diagnostic table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_diagnostic_rows "$warning_mutant" control unknown-diagnostic-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:diagnostic table selected no row: unknown-diagnostic-row"* ]]; then
+    pass "an unknown diagnostic row fails its selection guard"
+  else
+    fail "an unknown diagnostic row missed its selection guard"
+  fi
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -111,6 +111,7 @@ ACTION_CASES
     [[ -n "$only_row" ]] && guard="action table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -124,21 +125,26 @@ ACTION_CASES
 echo "=== decisions issue action rows ==="
 evaluate_action_rows "$DECISIONS" normal
 
-echo "=== must-fail control ==="
-lookup_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-issue-match/decisions" '      .[] | select(.research | test($issue + "(?![0-9])"; "i")) |' '      .[] | select(false) |' 1)"
-failures="$(evaluate_action_rows "$lookup_mutant" control supported-issue-lookup)"
-if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
-  pass "wrong lookup result fails the supported lookup row"
-else
-  fail "wrong lookup result did not fail the supported lookup row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  lookup_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-issue-match/decisions" '      .[] | select(.research | test($issue + "(?![0-9])"; "i")) |' '      .[] | select(false) |' 1)"
+  failures="$(evaluate_action_rows "$lookup_mutant" control supported-issue-lookup)"
+  if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
+    pass "wrong lookup result fails the supported lookup row"
+  else
+    fail "wrong lookup result did not fail the supported lookup row"
+  fi
+
   action_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-action-table/decider/tests/decider-issue-action-hint.test.sh" ACTION_CASES)"
   if decider_test_fails_with "$action_table_mutant" "action table executed no rows"; then
     pass "an empty action table fails its row-count guard"
   else
     fail "an empty action table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$action_table_mutant" "$TMP_ROOT/empty-action-table/decider/tests/diagnostic-only.test.sh" "action table executed no rows" 1; then
+    pass "an action-table diagnostic without a failure is rejected"
+  else
+    fail "an action-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_action_rows "$lookup_mutant" control unknown-action-row 2>&1)"

--- a/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -54,13 +54,15 @@ record_row() {
 }
 
 evaluate_action_rows() {
-  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual
+  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual guard
   local first second projected projection_rc
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name kind argument expected; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     case "$kind" in
       issue)
         run_decisions "$script" issue "$argument"
@@ -98,12 +100,22 @@ evaluate_action_rows() {
         ;;
     esac
     record_row "$mode" "$name" "$actual" "$expected"
-  done <<'CASES'
+  done <<'ACTION_CASES'
 issue-action~issue~CC-125~1~~1~1
 issues-action~issues~CC-125~1~1
 generic-unknown-action~unknown~bogus~1~1~1
 supported-issue-lookup~lookup~CC-125~0~0~D001
-CASES
+ACTION_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="action table executed no rows"
+    [[ -n "$only_row" ]] && guard="action table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -119,6 +131,24 @@ if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
   pass "wrong lookup result fails the supported lookup row"
 else
   fail "wrong lookup result did not fail the supported lookup row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  action_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-action-table/decider/tests/decider-issue-action-hint.test.sh" ACTION_CASES)"
+  if decider_test_fails_with "$action_table_mutant" "action table executed no rows"; then
+    pass "an empty action table fails its row-count guard"
+  else
+    fail "an empty action table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_action_rows "$lookup_mutant" control unknown-action-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:action table selected no row: unknown-action-row"* ]]; then
+    pass "an unknown action row fails its selection guard"
+  else
+    fail "an unknown action row missed its selection guard"
+  fi
 fi
 
 echo

--- a/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -1,68 +1,26 @@
 #!/usr/bin/env bash
-# The unsupported `issue` action hint.
-#
-# The CLI has no `issue` action — the supported lookup is
-# `decisions search --issue CC-125` — and generated guidance can tell an agent
-# to run `decisions issue CC-125`. The dispatcher catches `issue`/`issues`
-# with a targeted error naming the supported form, so an agent that receives
-# stale guidance self-corrects in one step. Pinned here: that hint, that other
-# unknown actions keep the generic error + usage, and that the supported
-# `search --issue` lookup works.
+# Unsupported issue actions and the supported issue lookup.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
-
 ERR_FILE="$TMP_ROOT/stderr"
 
-# Run the decisions script from a given directory with DECISIONS_DIR removed
-# from the parent environment (pass VAR=value args to set it explicitly).
-# Captures stdout in $out, stderr in $err, exit code in $rc.
-run_decisions() {
-  local dir="$1"
-  shift
-  set +e
-  out=$( (cd "$dir" && env -u DECISIONS_DIR "$@" "$DECISIONS" ${ARGS[@]+"${ARGS[@]}"}) 2>"$ERR_FILE")
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
-}
-
-assert_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
-echo "=== decisions unsupported issue action hint (kendex#641) ==="
-
-# Fixture: a project with one decision linked to CC-125, so the supported
-# lookup has a real match to return.
-PROJ="$TMP_ROOT/project"
-mkdir -p "$PROJ/docs/decisions"
-cat >"$PROJ/docs/decisions/INDEX.md" <<'EOF'
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/docs/decisions"
+cat >"$PROJECT/docs/decisions/INDEX.md" <<'EOF'
 # Architectural Decision Log
 
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
@@ -70,31 +28,98 @@ cat >"$PROJ/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-10 | D001 | CC-125 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
 EOF
 
-# --- Unsupported `issue` action gets a targeted hint --------------------------
-ARGS=(issue CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "issue action exits nonzero"
-assert_eq "$out" "" "issue action emits no stdout result"
-assert_contains "$err" "Unknown action 'issue'" "issue action names the unknown action"
-assert_contains "$err" "search --issue" "issue action hint names the supported lookup"
+run_decisions() {
+  local script="$1"
+  shift
+  set +e
+  out=$( (cd "$PROJECT" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-ARGS=(issues CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "issues action exits nonzero"
-assert_contains "$err" "search --issue" "issues action hint names the supported lookup"
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-# --- Other unknown actions keep the generic error + usage ---------------------
-ARGS=(bogus CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "unknown action exits nonzero"
-assert_contains "$err" "Unknown action 'bogus'" "unknown action reports generic error"
-assert_contains "$out" "Usage: decisions" "unknown action prints usage"
+evaluate_action_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual
+  local first second projected projection_rc
+  table_failures=""
+  while IFS='~' read -r name kind argument expected; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    case "$kind" in
+      issue)
+        run_decisions "$script" issue "$argument"
+        first=0
+        second=0
+        [[ "$err" == *"Unknown action 'issue'"* ]] && first=1
+        [[ "$err" == *"search --issue"* ]] && second=1
+        actual="$rc~$out~$first~$second"
+        ;;
+      issues)
+        run_decisions "$script" issues "$argument"
+        first=0
+        [[ "$err" == *"search --issue"* ]] && first=1
+        actual="$rc~$first"
+        ;;
+      unknown)
+        run_decisions "$script" "$argument" CC-125
+        first=0
+        second=0
+        [[ "$err" == *"Unknown action '$argument'"* ]] && first=1
+        [[ "$out" == *"Usage: decisions"* ]] && second=1
+        actual="$rc~$first~$second"
+        ;;
+      lookup)
+        run_decisions "$script" search --issue "$argument"
+        set +e
+        projected=$(jq -cer 'if type == "array" then [.[].id] | join(",") else error("not an array") end' <<<"$out" 2>/dev/null)
+        projection_rc=$?
+        set -e
+        actual="$rc~$projection_rc~$projected"
+        ;;
+      *)
+        fail "unknown action-row kind: $kind"
+        continue
+        ;;
+    esac
+    record_row "$mode" "$name" "$actual" "$expected"
+  done <<'CASES'
+issue-action~issue~CC-125~1~~1~1
+issues-action~issues~CC-125~1~1
+generic-unknown-action~unknown~bogus~1~1~1
+supported-issue-lookup~lookup~CC-125~0~0~D001
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-# --- Supported issue lookup still works ---------------------------------------
-ARGS=(search --issue CC-125)
-run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "search --issue exits 0"
-assert_contains "$out" '"D001"' "search --issue returns the linked decision"
+echo "=== decisions issue action rows ==="
+evaluate_action_rows "$DECISIONS" normal
+
+echo "=== must-fail control ==="
+lookup_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-issue-match/decisions" '      .[] | select(.research | test($issue + "(?![0-9])"; "i")) |' '      .[] | select(false) |' 1)"
+failures="$(evaluate_action_rows "$lookup_mutant" control supported-issue-lookup)"
+if [[ "$failures" == *'|supported-issue-lookup|'* ]]; then
+  pass "wrong lookup result fails the supported lookup row"
+else
+  fail "wrong lookup result did not fail the supported lookup row"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -169,6 +169,7 @@ NEXT_ID_CASES
     [[ -n "$only_row" ]] && guard="next-ID table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -182,21 +183,26 @@ NEXT_ID_CASES
 echo "=== decisions next-id scheme rows ==="
 evaluate_next_id_rows "$DECISIONS" normal
 
-echo "=== must-fail control ==="
-arithmetic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wrong-next-id/decisions" '$((max_num + 1))' '$((max_num + 2))' 1)"
-failures="$(evaluate_next_id_rows "$arithmetic_mutant" control inferred-adr)"
-if [[ "$failures" == *'|inferred-adr|'* ]]; then
-  pass "wrong next ID fails the inferred scheme row"
-else
-  fail "wrong next ID did not fail the inferred scheme row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  arithmetic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wrong-next-id/decisions" '$((max_num + 1))' '$((max_num + 2))' 1)"
+  failures="$(evaluate_next_id_rows "$arithmetic_mutant" control inferred-adr)"
+  if [[ "$failures" == *'|inferred-adr|'* ]]; then
+    pass "wrong next ID fails the inferred scheme row"
+  else
+    fail "wrong next ID did not fail the inferred scheme row"
+  fi
+
   next_id_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-next-id-table/decider/tests/decider-next-id-scheme.test.sh" NEXT_ID_CASES)"
   if decider_test_fails_with "$next_id_table_mutant" "next-ID table executed no rows"; then
     pass "an empty next-ID table fails its row-count guard"
   else
     fail "an empty next-ID table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$next_id_table_mutant" "$TMP_ROOT/empty-next-id-table/decider/tests/diagnostic-only.test.sh" "next-ID table executed no rows" 1; then
+    pass "a next-ID-table diagnostic without a failure is rejected"
+  else
+    fail "a next-ID-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_next_id_rows "$arithmetic_mutant" control unknown-next-id-row 2>&1)"

--- a/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -1,91 +1,48 @@
 #!/usr/bin/env bash
-# Scheme-aware decisions next-id.
-#
-# next-id must derive the next decision number from the INDEX.md ID column, not
-# from DNNN-looking tokens in prose cells, and it must preserve repositories'
-# existing ID schemes such as ADR-0001.
+# Scheme-aware decisions next-id rows.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
-
 ERR_FILE="$TMP_ROOT/stderr"
 
-run_next_id() {
-  local dir="$1"
-  shift
-  set +e
-  out=$( (cd "$dir" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH "$@" "$DECISIONS" next-id) 2>"$ERR_FILE")
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
+make_index() {
+  local repo="$1"
+  mkdir -p "$repo/docs/decisions"
 }
-
-assert_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
-echo "=== decisions next-id scheme inference (kendex#956) ==="
 
 ADR_REPO="$TMP_ROOT/adr-repo"
-mkdir -p "$ADR_REPO/docs/decisions"
+make_index "$ADR_REPO"
 cat >"$ADR_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | ADR-0001 | PROJ-100 | First decision | Establishes the log | Never | Active | [Full](ADR-0001-first.md) |
 | 2026-01-11 | ADR-0035 | PROJ-101 | Current scheme | Summary mentions **D1:** and D1/D3/D5 prose labels | Never | Active | [Full](ADR-0035-current.md) |
 EOF
 
-run_next_id "$ADR_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "ADR next-id exits 0"
-assert_eq "$out" "ADR-0036" "ADR scheme and width are preserved"
-assert_eq "$err" "" "ADR next-id emits no stderr"
-
 D_REPO="$TMP_ROOT/d-repo"
-mkdir -p "$D_REPO/docs/decisions"
+make_index "$D_REPO"
 cat >"$D_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | D001 | PROJ-100 | First decision | Mentions unrelated D999 prose token | Never | Active | [Full](D001-first.md) |
 EOF
 
-run_next_id "$D_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "D next-id exits 0"
-assert_eq "$out" "D002" "prose DNNN token does not affect next-id"
-
 MIXED_REPO="$TMP_ROOT/mixed-repo"
-mkdir -p "$MIXED_REPO/docs/decisions"
+make_index "$MIXED_REPO"
 cat >"$MIXED_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | D008 | PROJ-100 | Legacy decision | Existing D-prefixed row | Never | Active | [Full](D008-legacy.md) |
@@ -93,19 +50,9 @@ cat >"$MIXED_REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-12 | ADR-0035 | PROJ-102 | Latest ADR decision | Current scheme | Never | Active | [Full](ADR-0035-latest.md) |
 EOF
 
-run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "mixed next-id exits 0"
-assert_eq "$out" "ADR-0036" "unconfigured next-id follows the last ID-column scheme"
-
-run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=D
-assert_eq "$rc" "0" "configured prefix next-id exits 0"
-assert_eq "$out" "D009" "configured prefix scans only matching ID-column rows"
-
 BAD_LAST_REPO="$TMP_ROOT/bad-last-repo"
-mkdir -p "$BAD_LAST_REPO/docs/decisions"
+make_index "$BAD_LAST_REPO"
 cat >"$BAD_LAST_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-10 | D008 | PROJ-100 | Legacy decision | Existing D-prefixed row | Never | Active | [Full](D008-legacy.md) |
@@ -113,36 +60,124 @@ cat >"$BAD_LAST_REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-12 | ADR-current | PROJ-102 | Unparseable final ID | Current row has no numeric suffix | Never | Active | [Full](ADR-current.md) |
 EOF
 
-run_next_id "$BAD_LAST_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "1" "unparseable final ID exits nonzero"
-assert_eq "$out" "" "unparseable final ID emits no stdout"
-assert_contains "$err" "ADR-current" "unparseable final ID names the bad ID"
-assert_contains "$err" "DECISION_ID_PREFIX" "unparseable final ID points at explicit scheme configuration"
-
-run_next_id "$BAD_LAST_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR-
-assert_eq "$rc" "0" "configured prefix bypasses unparseable final-ID inference"
-assert_eq "$out" "ADR-0036" "configured prefix still scans matching numeric rows"
-
 EMPTY_REPO="$TMP_ROOT/empty-repo"
-mkdir -p "$EMPTY_REPO/docs/decisions"
+make_index "$EMPTY_REPO"
 cat >"$EMPTY_REPO/docs/decisions/INDEX.md" <<'EOF'
-# Architectural Decision Log
-
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 EOF
 
-run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "empty index next-id exits 0"
-assert_eq "$out" "D001" "empty index keeps the default DXXX scheme"
+run_next_id() {
+  local script="$1" repo="$2" environment="$3"
+  set +e
+  case "$environment" in
+    default)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    d-prefix)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=D "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    adr-prefix)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    adr-configured)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    invalid-width)
+      out=$( (cd "$repo" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH DECISIONS_DIR=docs/decisions DECISION_ID_WIDTH=zero "$script" next-id) 2>"$ERR_FILE")
+      ;;
+    *)
+      set -e
+      fail "unknown next-id environment: $environment"
+      return
+      ;;
+  esac
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4
-assert_eq "$rc" "0" "configured empty index next-id exits 0"
-assert_eq "$out" "ADR-0001" "configured empty index supports custom scheme"
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_WIDTH=zero
-assert_eq "$rc" "1" "invalid width exits nonzero"
-assert_contains "$err" "DECISION_ID_WIDTH" "invalid width names DECISION_ID_WIDTH"
+evaluate_next_id_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name repo_name environment expected_status
+  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected
+  table_failures=""
+  while IFS='~' read -r name repo_name environment expected_status stdout_rule expected_stdout stderr_rule; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    repo="$TMP_ROOT/$repo_name"
+    run_next_id "$script" "$repo" "$environment"
+    case "$stdout_rule" in
+      exact) actual_stdout="$out" ;;
+      ignore) actual_stdout=ignored; expected_stdout=ignored ;;
+      *) fail "unknown stdout rule: $stdout_rule"; continue ;;
+    esac
+    case "$stderr_rule" in
+      empty)
+        actual_stderr="$err"
+        expected=""
+        ;;
+      ignore)
+        actual_stderr=ignored
+        expected=ignored
+        ;;
+      bad-id-prefix)
+        actual_stderr=0,0
+        [[ "$err" == *ADR-current* ]] && actual_stderr=1,0
+        [[ "$err" == *ADR-current* && "$err" == *DECISION_ID_PREFIX* ]] && actual_stderr=1,1
+        expected=1,1
+        ;;
+      width)
+        actual_stderr=0
+        [[ "$err" == *DECISION_ID_WIDTH* ]] && actual_stderr=1
+        expected=1
+        ;;
+      *) fail "unknown stderr rule: $stderr_rule"; continue ;;
+    esac
+    actual="$rc~$actual_stdout~$actual_stderr"
+    record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
+  done <<'CASES'
+inferred-adr~adr-repo~default~0~exact~ADR-0036~empty
+ignore-prose-id~d-repo~default~0~exact~D002~ignore
+latest-scheme~mixed-repo~default~0~exact~ADR-0036~ignore
+configured-prefix~mixed-repo~d-prefix~0~exact~D009~ignore
+unparseable-last-id~bad-last-repo~default~1~exact~~bad-id-prefix
+configured-prefix-after-bad-id~bad-last-repo~adr-prefix~0~exact~ADR-0036~ignore
+empty-default~empty-repo~default~0~exact~D001~ignore
+empty-configured~empty-repo~adr-configured~0~exact~ADR-0001~ignore
+invalid-width~empty-repo~invalid-width~1~ignore~~width
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
+
+echo "=== decisions next-id scheme rows ==="
+evaluate_next_id_rows "$DECISIONS" normal
+
+echo "=== must-fail control ==="
+arithmetic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wrong-next-id/decisions" '$((max_num + 1))' '$((max_num + 2))' 1)"
+failures="$(evaluate_next_id_rows "$arithmetic_mutant" control inferred-adr)"
+if [[ "$failures" == *'|inferred-adr|'* ]]; then
+  pass "wrong next ID fails the inferred scheme row"
+else
+  fail "wrong next ID did not fail the inferred scheme row"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -114,12 +114,14 @@ record_row() {
 
 evaluate_next_id_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name repo_name environment expected_status
-  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected
+  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name repo_name environment expected_status stdout_rule expected_stdout stderr_rule; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     repo="$TMP_ROOT/$repo_name"
     run_next_id "$script" "$repo" "$environment"
     case "$stdout_rule" in
@@ -151,7 +153,7 @@ evaluate_next_id_rows() {
     esac
     actual="$rc~$actual_stdout~$actual_stderr"
     record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
-  done <<'CASES'
+  done <<'NEXT_ID_CASES'
 inferred-adr~adr-repo~default~0~exact~ADR-0036~empty
 ignore-prose-id~d-repo~default~0~exact~D002~ignore
 latest-scheme~mixed-repo~default~0~exact~ADR-0036~ignore
@@ -161,7 +163,17 @@ configured-prefix-after-bad-id~bad-last-repo~adr-prefix~0~exact~ADR-0036~ignore
 empty-default~empty-repo~default~0~exact~D001~ignore
 empty-configured~empty-repo~adr-configured~0~exact~ADR-0001~ignore
 invalid-width~empty-repo~invalid-width~1~ignore~~width
-CASES
+NEXT_ID_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="next-ID table executed no rows"
+    [[ -n "$only_row" ]] && guard="next-ID table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -177,6 +189,24 @@ if [[ "$failures" == *'|inferred-adr|'* ]]; then
   pass "wrong next ID fails the inferred scheme row"
 else
   fail "wrong next ID did not fail the inferred scheme row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  next_id_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-next-id-table/decider/tests/decider-next-id-scheme.test.sh" NEXT_ID_CASES)"
+  if decider_test_fails_with "$next_id_table_mutant" "next-ID table executed no rows"; then
+    pass "an empty next-ID table fails its row-count guard"
+  else
+    fail "an empty next-ID table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_next_id_rows "$arithmetic_mutant" control unknown-next-id-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:next-ID table selected no row: unknown-next-id-row"* ]]; then
+    pass "an unknown next-ID row fails its selection guard"
+  else
+    fail "an unknown next-ID row missed its selection guard"
+  fi
 fi
 
 echo

--- a/skills/decider/tests/decider-search-body.test.sh
+++ b/skills/decider/tests/decider-search-body.test.sh
@@ -1,101 +1,119 @@
 #!/usr/bin/env bash
-# Body-scoped decision search.
-#
-# `decisions search` reads the decision document itself, not only the INDEX.md
-# summary columns (decision, rationale, id). A search over the summary alone
-# returns `[]` for a keyword that appears only in a decision's prose —
-# indistinguishable from "no decision governs this area", the opposite of the
-# truth — and that silently passes the pre-mutation guards that call this
-# search (orch review-pr § 1.1, dev-fix § 2, tpm-audit § 2, and the issue
-# template).
-#
-# Pinned here: the body match and the ranking contract: body matches surface
-# BELOW every summary match, so a summary match keeps its position and score
-# rather than being displaced by a body match.
+# Body search, scoring, and result ordering.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1)); printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
 REPO="$TMP_ROOT/repo"
 mkdir -p "$REPO/docs/decisions"
-
-cat > "$REPO/docs/decisions/INDEX.md" <<'EOF'
+cat >"$REPO/docs/decisions/INDEX.md" <<'EOF'
 | Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
 |------|----|----------|----------|-----------|--------------|--------|------|
 | 2026-01-01 | D027 | CC-1 | Performance measurement stack | Needs stable baselines | Never | Active | [D027](D027-perf.md) |
 | 2026-01-02 | D046 | CC-2 | Dev surface feature gating | Keeps prod lean | Never | Active | [D046](D046-gating.md) |
 | 2026-01-03 | D047 | CC-3 | Signature forgery guard | Prevents forgery | Never | Active | [D047](D047-forgery.md) |
 EOF
-
-# "hermetic" and "clippy" appear ONLY in prose — the exact shape from the report.
-printf '# D027\n\nBenchmarks run in a hermetic sandbox to avoid host drift.\n' \
-  > "$REPO/docs/decisions/D027-perf.md"
-printf '# D046\n\nClippy lints are enforced on the dev surface.\n' \
-  > "$REPO/docs/decisions/D046-gating.md"
-# D047 mentions forgery in title, rationale AND body — used for the ranking test.
-printf '# D047\n\nGuards against forgery of signatures.\n' \
-  > "$REPO/docs/decisions/D047-forgery.md"
+printf '# D027\n\nBenchmarks run in a hermetic sandbox against forgery and host drift.\n' >"$REPO/docs/decisions/D027-perf.md"
+printf '# D046\n\nClippy lints are enforced on the dev surface.\n' >"$REPO/docs/decisions/D046-gating.md"
+printf '# D047\n\nGuards against forgery of signatures.\n' >"$REPO/docs/decisions/D047-forgery.md"
 
 run_search() {
-  (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$DECISIONS" search "$@" 2>/dev/null)
+  local script="$1" query="$2"
+  set +e
+  out=$( (cd "$REPO" && DECISIONS_DIR="$REPO/docs/decisions" "$script" search "$query") 2>/dev/null)
+  rc=$?
+  set -e
 }
 
-echo "=== a keyword that appears only in a decision body is found ==="
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-assert_eq "$(run_search hermetic | jq -r '[.[].id] | join(",")')" "D027" \
-  "body-only keyword returns the governing decision"
-assert_eq "$(run_search clippy | jq -r '[.[].id] | join(",")')" "D046" \
-  "second body-only keyword returns its decision"
+evaluate_search_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name query projection expected setup
+  local projected projection_rc actual
+  table_failures=""
+  while IFS='~' read -r name query projection expected setup; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    if [[ "$setup" == stray ]]; then
+      printf 'hermetic stray note not linked from INDEX\n' >"$REPO/docs/decisions/STRAY.md"
+    fi
+    run_search "$script" "$query"
+    set +e
+    case "$projection" in
+      ids)
+        projected=$(jq -cer 'if type == "array" then [.[].id] else error("not an array") end' <<<"$out" 2>/dev/null)
+        ;;
+      sorted-ids)
+        projected=$(jq -cer 'if type == "array" then [.[].id] | sort else error("not an array") end' <<<"$out" 2>/dev/null)
+        ;;
+      ids-scores)
+        projected=$(jq -cer 'if type == "array" then [.[] | "\(.id):\(.score)"] | join(",") else error("not an array") end' <<<"$out" 2>/dev/null)
+        ;;
+      *)
+        set -e
+        fail "unknown search-row projection: $projection"
+        continue
+        ;;
+    esac
+    projection_rc=$?
+    set -e
+    actual="$rc~$projection_rc~$projected"
+    record_row "$mode" "$name" "$actual" "0~0~$expected"
+  done <<'CASES'
+body-hermetic~hermetic~ids~["D027"]~none
+body-clippy~clippy~ids~["D046"]~none
+summary-body-score~forgery~ids-scores~D047:4.5,D027:0.5~none
+body-score~hermetic~ids-scores~D027:0.5~none
+and-across-fields~performance hermetic~ids~["D027"]~none
+and-across-decisions-miss~hermetic gating~ids~[]~none
+regex-bodies~hermetic|clippy~sorted-ids~["D027","D046"]~none
+keyword-miss~zzz-absent-token~ids~[]~none
+unindexed-file~hermetic~ids~["D027"]~stray
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
 
-echo "=== summary matches keep priority over body matches ==="
+echo "=== decisions body-search rows ==="
+evaluate_search_rows "$DECISIONS" normal
 
-# forgery is in D047's title (3) + rationale (1) + body (0.5).
-assert_eq "$(run_search forgery | jq -r '.[0].score')" "4.5" \
-  "summary weights unchanged; body adds a fractional bonus"
-# A body-only hit scores below any summary hit, so it can never displace one.
-assert_eq "$(run_search hermetic | jq -r '.[0].score')" "0.5" \
-  "body-only match scores below rationale (1pt)"
+echo "=== must-fail control ==="
+ordering_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-score-sort/decisions" '] | sort_by(-.score) | .[:$limit]' '] | .[:$limit]' 1)"
+failures="$(evaluate_search_rows "$ordering_mutant" control summary-body-score)"
+if [[ "$failures" == *'|summary-body-score|'* ]]; then
+  pass "missing score sort fails the ranking row"
+else
+  fail "missing score sort did not fail the ranking row"
+fi
 
-echo "=== AND logic spans summary and body together ==="
-
-# "performance" is in D027's title only; "hermetic" is in its body only.
-assert_eq "$(run_search "performance hermetic" | jq -r '[.[].id] | join(",")')" "D027" \
-  "one term in the summary and another in the body still satisfies AND"
-assert_eq "$(run_search "hermetic gating" | jq -r 'length')" "0" \
-  "AND still excludes when the terms live in different decisions"
-
-echo "=== regex mode also reaches bodies ==="
-
-assert_eq "$(run_search 'hermetic|clippy' | jq -r '[.[].id] | sort | join(",")')" "D027,D046" \
-  "regex alternation matches body text in both decisions"
-
-echo "=== a genuine miss is still an empty result ==="
-
-assert_eq "$(run_search zzz-absent-token | jq -r 'length')" "0" \
-  "unmatched keyword still returns an empty array"
-
-echo "=== unindexed files in the directory cannot influence results ==="
-
-printf 'hermetic stray note not linked from INDEX\n' > "$REPO/docs/decisions/STRAY.md"
-assert_eq "$(run_search hermetic | jq -r '[.[].id] | join(",")')" "D027" \
-  "a stray unindexed file adds no result"
-
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/decider/tests/decider-search-body.test.sh
+++ b/skills/decider/tests/decider-search-body.test.sh
@@ -104,6 +104,7 @@ SEARCH_CASES
     [[ -n "$only_row" ]] && guard="body-search table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -117,21 +118,26 @@ SEARCH_CASES
 echo "=== decisions body-search rows ==="
 evaluate_search_rows "$DECISIONS" normal
 
-echo "=== must-fail control ==="
-ordering_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-score-sort/decisions" '] | sort_by(-.score) | .[:$limit]' '] | .[:$limit]' 1)"
-failures="$(evaluate_search_rows "$ordering_mutant" control summary-body-score)"
-if [[ "$failures" == *'|summary-body-score|'* ]]; then
-  pass "missing score sort fails the ranking row"
-else
-  fail "missing score sort did not fail the ranking row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  ordering_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-score-sort/decisions" '] | sort_by(-.score) | .[:$limit]' '] | .[:$limit]' 1)"
+  failures="$(evaluate_search_rows "$ordering_mutant" control summary-body-score)"
+  if [[ "$failures" == *'|summary-body-score|'* ]]; then
+    pass "missing score sort fails the ranking row"
+  else
+    fail "missing score sort did not fail the ranking row"
+  fi
+
   search_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-search-table/decider/tests/decider-search-body.test.sh" SEARCH_CASES)"
   if decider_test_fails_with "$search_table_mutant" "body-search table executed no rows"; then
     pass "an empty body-search table fails its row-count guard"
   else
     fail "an empty body-search table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$search_table_mutant" "$TMP_ROOT/empty-search-table/decider/tests/diagnostic-only.test.sh" "body-search table executed no rows" 1; then
+    pass "a body-search-table diagnostic without a failure is rejected"
+  else
+    fail "a body-search-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_search_rows "$ordering_mutant" control unknown-search-row 2>&1)"

--- a/skills/decider/tests/decider-search-body.test.sh
+++ b/skills/decider/tests/decider-search-body.test.sh
@@ -55,12 +55,14 @@ record_row() {
 
 evaluate_search_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name query projection expected setup
-  local projected projection_rc actual
+  local projected projection_rc actual guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name query projection expected setup; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     if [[ "$setup" == stray ]]; then
       printf 'hermetic stray note not linked from INDEX\n' >"$REPO/docs/decisions/STRAY.md"
     fi
@@ -86,7 +88,7 @@ evaluate_search_rows() {
     set -e
     actual="$rc~$projection_rc~$projected"
     record_row "$mode" "$name" "$actual" "0~0~$expected"
-  done <<'CASES'
+  done <<'SEARCH_CASES'
 body-hermetic~hermetic~ids~["D027"]~none
 body-clippy~clippy~ids~["D046"]~none
 summary-body-score~forgery~ids-scores~D047:4.5,D027:0.5~none
@@ -96,7 +98,17 @@ and-across-decisions-miss~hermetic gating~ids~[]~none
 regex-bodies~hermetic|clippy~sorted-ids~["D027","D046"]~none
 keyword-miss~zzz-absent-token~ids~[]~none
 unindexed-file~hermetic~ids~["D027"]~stray
-CASES
+SEARCH_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="body-search table executed no rows"
+    [[ -n "$only_row" ]] && guard="body-search table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -112,6 +124,24 @@ if [[ "$failures" == *'|summary-body-score|'* ]]; then
   pass "missing score sort fails the ranking row"
 else
   fail "missing score sort did not fail the ranking row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  search_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-search-table/decider/tests/decider-search-body.test.sh" SEARCH_CASES)"
+  if decider_test_fails_with "$search_table_mutant" "body-search table executed no rows"; then
+    pass "an empty body-search table fails its row-count guard"
+  else
+    fail "an empty body-search table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_search_rows "$ordering_mutant" control unknown-search-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:body-search table selected no row: unknown-search-row"* ]]; then
+    pass "an unknown body-search row fails its selection guard"
+  else
+    fail "an unknown body-search row missed its selection guard"
+  fi
 fi
 
 echo

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -1,116 +1,30 @@
 #!/usr/bin/env bash
-# decisions missing-directory handling.
-#
-# In a repository with no decisions directory, read-only lookups (search,
-# list) emit an empty JSON array with a stderr note and exit 0: an
-# inapplicable lookup is not a workflow failure. Pinned here: that soft path
-# for both the configured-but-absent and unset-undiscovered cases, and that
-# real errors stay hard: a zero-match search in an existing directory is
-# unchanged, a configured path that exists but is a file is a hard error, and
-# creation-workflow commands (next-id, get) require the directory.
+# Missing, existing, and invalid decisions directory rows.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 DECISIONS="$SKILL_DIR/scripts/decisions"
+# shellcheck source=lib/mutate-script.sh
+source "$TEST_DIR/lib/mutate-script.sh"
 
 PASS=0
 FAIL=0
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
-
 ERR_FILE="$TMP_ROOT/stderr"
 
-# Run the decisions script from a given directory with DECISIONS_DIR removed
-# from the parent environment (pass VAR=value args to set it explicitly).
-# Captures stdout in $out, stderr in $err, exit code in $rc.
-run_decisions() {
-  local dir="$1"
-  shift
-  set +e
-  out=$( (cd "$dir" && env -u DECISIONS_DIR "$@" "$DECISIONS" "${ARGS[@]}") 2>"$ERR_FILE")
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
-}
-
-assert_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
-echo "=== decisions missing decisions dir (kendex#561) ==="
-
-# --- Project with a configured DECISIONS_DIR that does not exist -------------
-# Mirrors the reported failure: kendex.settings.toml sets DECISIONS_DIR but
-# the repository has no decisions directory.
 NO_DIR="$TMP_ROOT/no-dir-project"
 mkdir -p "$NO_DIR"
 printf '[env]\nDECISIONS_DIR = "docs/decisions"\n' >"$NO_DIR/kendex.settings.toml"
 
-ARGS=(search --issue PROJ-557)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "0" "issue search with absent dir exits 0"
-assert_eq "$out" "[]" "issue search with absent dir emits empty array"
-assert_contains "$err" "docs/decisions" "issue search note names the missing dir"
-assert_contains "$err" "not present" "issue search notes dir not present on stderr"
-
-ARGS=(search "ffi error handling")
-run_decisions "$NO_DIR"
-assert_eq "$rc" "0" "keyword search with absent dir exits 0"
-assert_eq "$out" "[]" "keyword search with absent dir emits empty array"
-assert_contains "$err" "not present" "keyword search notes dir not present on stderr"
-
-ARGS=(list)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "0" "list with absent dir exits 0"
-assert_eq "$out" "[]" "list with absent dir emits empty array"
-assert_contains "$err" "not present" "list notes dir not present on stderr"
-
-# Creation-workflow commands still require the directory.
-ARGS=(next-id)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "1" "next-id with absent dir still errors"
-assert_contains "$err" "does not exist" "next-id reports missing DECISIONS_DIR"
-
-ARGS=(get D001)
-run_decisions "$NO_DIR"
-assert_eq "$rc" "1" "get with absent dir still errors"
-assert_contains "$err" "does not exist" "get reports missing DECISIONS_DIR"
-
-# --- DECISIONS_DIR unset and auto-discovery finds nothing --------------------
 UNSET_DIR="$TMP_ROOT/unset-project"
 mkdir -p "$UNSET_DIR"
 
-ARGS=(search --issue PROJ-557)
-run_decisions "$UNSET_DIR"
-assert_eq "$rc" "0" "issue search with undiscovered dir exits 0"
-assert_eq "$out" "[]" "issue search with undiscovered dir emits empty array"
-assert_contains "$err" "no decisions directory found" "undiscovered dir noted on stderr"
-
-ARGS=(help)
-run_decisions "$UNSET_DIR"
-assert_eq "$rc" "0" "help works without a decisions dir"
-assert_contains "$out" "Decision Lookup Tool" "help prints usage without a decisions dir"
-
-# --- Existing directory: zero-match and match behavior unchanged -------------
 HAS_DIR="$TMP_ROOT/has-dir-project"
 mkdir -p "$HAS_DIR/docs/decisions"
 cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
@@ -121,41 +35,163 @@ cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-10 | D001 | PROJ-100 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
 EOF
 
-ARGS=(search "zzz nonexistent term")
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "zero-match keyword search in existing dir exits 0"
-assert_eq "$out" "[]" "zero-match keyword search emits empty array"
-assert_eq "$err" "" "zero-match keyword search emits no stderr note"
+NOT_A_DIR="$TMP_ROOT/not-a-dir"
+touch "$NOT_A_DIR"
 
-ARGS=(search --issue PROJ-999)
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "zero-match issue search in existing dir exits 0"
-assert_eq "$out" "[]" "zero-match issue search emits empty array"
-assert_eq "$err" "" "zero-match issue search emits no stderr note"
+run_decisions() {
+  local script="$1" state="$2"
+  shift 2
+  set +e
+  case "$state" in
+    configured-absent)
+      out=$( (cd "$NO_DIR" && env -u DECISIONS_DIR "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    undiscovered)
+      out=$( (cd "$UNSET_DIR" && env -u DECISIONS_DIR "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    existing)
+      out=$( (cd "$HAS_DIR" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    configured-file)
+      out=$( (cd "$NO_DIR" && env -u DECISIONS_DIR DECISIONS_DIR="$NOT_A_DIR" "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    *)
+      set -e
+      fail "unknown directory state: $state"
+      return
+      ;;
+  esac
+  rc=$?
+  set -e
+  err="$(<"$ERR_FILE")"
+}
 
-ARGS=(search "redis")
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "matching keyword search in existing dir exits 0"
-assert_contains "$out" '"D001"' "matching keyword search returns D001"
+record_row() {
+  local mode="$1" name="$2" actual="$3" expected="$4"
+  if [[ "$actual" == "$expected" ]]; then
+    if [[ "$mode" == normal ]]; then
+      pass "$name"
+    fi
+  else
+    if [[ "$mode" == normal ]]; then
+      fail "$name (expected: $expected; got: $actual)"
+    else
+      table_failures+="|$name|"
+    fi
+  fi
+}
 
-ARGS=(next-id)
-run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
-assert_eq "$rc" "0" "next-id in existing dir exits 0"
-assert_eq "$out" "D002" "next-id in existing dir returns D002"
+evaluate_directory_rows() {
+  local script="$1" mode="$2" only_row="${3:-}" name state action argument expected_status
+  local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr
+  local projected projection_rc actual expected
+  table_failures=""
+  while IFS='~' read -r name state action argument expected_status stdout_rule expected_stdout stderr_rule needle_one needle_two; do
+    if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
+      continue
+    fi
+    case "$action" in
+      issue) run_decisions "$script" "$state" search --issue "$argument" ;;
+      keyword) run_decisions "$script" "$state" search "$argument" ;;
+      list|next-id|help) run_decisions "$script" "$state" "$action" ;;
+      get) run_decisions "$script" "$state" get "$argument" ;;
+      *) fail "unknown directory-row action: $action"; continue ;;
+    esac
 
-# --- Configured path exists but is a file: hard error for every command ------
-touch "$TMP_ROOT/not-a-dir"
+    case "$stdout_rule" in
+      exact)
+        actual_stdout="$out"
+        ;;
+      contains)
+        actual_stdout=0
+        [[ "$out" == *"$expected_stdout"* ]] && actual_stdout=1
+        expected_stdout=1
+        ;;
+      ids)
+        set +e
+        projected=$(jq -cer 'if type == "array" then [.[].id] else error("not an array") end' <<<"$out" 2>/dev/null)
+        projection_rc=$?
+        set -e
+        actual_stdout="$projection_rc:$projected"
+        expected_stdout="0:$expected_stdout"
+        ;;
+      ignore)
+        actual_stdout=ignored
+        expected_stdout=ignored
+        ;;
+      *) fail "unknown stdout rule: $stdout_rule"; continue ;;
+    esac
 
-ARGS=(search --issue PROJ-557)
-run_decisions "$NO_DIR" DECISIONS_DIR="$TMP_ROOT/not-a-dir"
-assert_eq "$rc" "1" "search with file at DECISIONS_DIR exits nonzero"
-assert_eq "$out" "" "search with file at DECISIONS_DIR emits no result"
-assert_contains "$err" "is not a directory" "search with file at DECISIONS_DIR reports hard error"
+    case "$stderr_rule" in
+      contains)
+        actual_stderr=0
+        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1
+        expected=1
+        ;;
+      both)
+        actual_stderr=0,0
+        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1,0
+        [[ "$err" == *"$needle_one"* && "$err" == *"$needle_two"* ]] && actual_stderr=1,1
+        expected=1,1
+        ;;
+      empty)
+        actual_stderr="$err"
+        expected=""
+        ;;
+      ignore)
+        actual_stderr=ignored
+        expected=ignored
+        ;;
+      *) fail "unknown stderr rule: $stderr_rule"; continue ;;
+    esac
 
-ARGS=(next-id)
-run_decisions "$NO_DIR" DECISIONS_DIR="$TMP_ROOT/not-a-dir"
-assert_eq "$rc" "1" "next-id with file at DECISIONS_DIR exits nonzero"
-assert_contains "$err" "is not a directory" "next-id with file at DECISIONS_DIR reports hard error"
+    actual="$rc~$actual_stdout~$actual_stderr"
+    record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
+  done <<'CASES'
+configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~both~docs/decisions~not present
+configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~contains~not present~
+configured-absent-list~configured-absent~list~~0~exact~[]~contains~not present~
+configured-absent-next-id~configured-absent~next-id~~1~ignore~~contains~does not exist~
+configured-absent-get~configured-absent~get~D001~1~ignore~~contains~does not exist~
+undiscovered-issue~undiscovered~issue~PROJ-557~0~exact~[]~contains~no decisions directory found~
+help-without-directory~undiscovered~help~~0~contains~Decision Lookup Tool~ignore~~
+existing-keyword-miss~existing~keyword~zzz nonexistent term~0~exact~[]~empty~~
+existing-issue-miss~existing~issue~PROJ-999~0~exact~[]~empty~~
+existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
+existing-next-id~existing~next-id~~0~exact~D002~ignore~~
+configured-file-search~configured-file~issue~PROJ-557~1~exact~~contains~is not a directory~
+configured-file-next-id~configured-file~next-id~~1~ignore~~contains~is not a directory~
+CASES
+  if [[ "$mode" == control ]]; then
+    printf '%s' "$table_failures"
+  fi
+}
+
+echo "=== decisions directory-state rows ==="
+evaluate_directory_rows "$DECISIONS" normal
+
+echo "=== must-fail controls ==="
+old_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+old_branch+=$'\n    note_missing_decisions_dir\n'
+old_branch+="    echo '[]'"
+old_branch+=$'\n    return 0\n  fi\n\n  local all'
+new_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+new_branch+=$'\n    note_missing_decisions_dir\n'
+new_branch+="    echo '[]'"
+new_branch+=$'\n    return 1\n  fi\n\n  local all'
+status_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/absent-search-fails/decisions" "$old_branch" "$new_branch" 1)"
+failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-issue)"
+if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
+  pass "absent issue-search failure fails its row"
+else
+  fail "absent issue-search failure did not fail its row"
+fi
+failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-keyword)"
+if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
+  pass "absent keyword-search failure fails its row"
+else
+  fail "absent keyword-search failure did not fail its row"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -169,6 +169,7 @@ DIRECTORY_CASES
     [[ -n "$only_row" ]] && guard="directory table selected no row: $only_row"
     if [[ "$mode" == normal ]]; then
       fail "$guard"
+      return 1
     else
       printf 'TABLE_GUARD:%s' "$guard"
       return 1
@@ -182,35 +183,40 @@ DIRECTORY_CASES
 echo "=== decisions directory-state rows ==="
 evaluate_directory_rows "$DECISIONS" normal
 
-echo "=== must-fail controls ==="
-old_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
-old_branch+=$'\n    note_missing_decisions_dir\n'
-old_branch+="    echo '[]'"
-old_branch+=$'\n    return 0\n  fi\n\n  local all'
-new_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
-new_branch+=$'\n    note_missing_decisions_dir\n'
-new_branch+="    echo '[]'"
-new_branch+=$'\n    return 1\n  fi\n\n  local all'
-status_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/absent-search-fails/decisions" "$old_branch" "$new_branch" 1)"
-failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-issue)"
-if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
-  pass "absent issue-search failure fails its row"
-else
-  fail "absent issue-search failure did not fail its row"
-fi
-failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-keyword)"
-if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
-  pass "absent keyword-search failure fails its row"
-else
-  fail "absent keyword-search failure did not fail its row"
-fi
-
 if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  echo "=== must-fail controls ==="
+  old_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+  old_branch+=$'\n    note_missing_decisions_dir\n'
+  old_branch+="    echo '[]'"
+  old_branch+=$'\n    return 0\n  fi\n\n  local all'
+  new_branch='  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then'
+  new_branch+=$'\n    note_missing_decisions_dir\n'
+  new_branch+="    echo '[]'"
+  new_branch+=$'\n    return 1\n  fi\n\n  local all'
+  status_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/absent-search-fails/decisions" "$old_branch" "$new_branch" 1)"
+  failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-issue)"
+  if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
+    pass "absent issue-search failure fails its row"
+  else
+    fail "absent issue-search failure did not fail its row"
+  fi
+  failures="$(evaluate_directory_rows "$status_mutant" control configured-absent-keyword)"
+  if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
+    pass "absent keyword-search failure fails its row"
+  else
+    fail "absent keyword-search failure did not fail its row"
+  fi
+
   directory_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-directory-table/decider/tests/decider-search-missing-dir.test.sh" DIRECTORY_CASES)"
   if decider_test_fails_with "$directory_table_mutant" "directory table executed no rows"; then
     pass "an empty directory table fails its row-count guard"
   else
     fail "an empty directory table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  if decider_diagnostic_only_table_control "$directory_table_mutant" "$TMP_ROOT/empty-directory-table/decider/tests/diagnostic-only.test.sh" "directory table executed no rows" 1; then
+    pass "a directory-table diagnostic without a failure is rejected"
+  else
+    fail "a directory-table diagnostic without a failure satisfied the control ($DECIDER_CONTROL_DETAIL)"
   fi
   set +e
   selection_output="$(evaluate_directory_rows "$status_mutant" control unknown-directory-row 2>&1)"

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -84,12 +84,14 @@ record_row() {
 evaluate_directory_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name state action argument expected_status
   local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr
-  local projected projection_rc actual expected
+  local projected projection_rc actual expected guard
+  local executed_rows=0
   table_failures=""
   while IFS='~' read -r name state action argument expected_status stdout_rule expected_stdout stderr_rule needle_one needle_two; do
     if [[ -n "$only_row" && "$name" != "$only_row" ]]; then
       continue
     fi
+    executed_rows=$((executed_rows + 1))
     case "$action" in
       issue) run_decisions "$script" "$state" search --issue "$argument" ;;
       keyword) run_decisions "$script" "$state" search "$argument" ;;
@@ -147,7 +149,7 @@ evaluate_directory_rows() {
 
     actual="$rc~$actual_stdout~$actual_stderr"
     record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
-  done <<'CASES'
+  done <<'DIRECTORY_CASES'
 configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~both~docs/decisions~not present
 configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~contains~not present~
 configured-absent-list~configured-absent~list~~0~exact~[]~contains~not present~
@@ -161,7 +163,17 @@ existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
 existing-next-id~existing~next-id~~0~exact~D002~ignore~~
 configured-file-search~configured-file~issue~PROJ-557~1~exact~~contains~is not a directory~
 configured-file-next-id~configured-file~next-id~~1~ignore~~contains~is not a directory~
-CASES
+DIRECTORY_CASES
+  if [[ "$executed_rows" -eq 0 ]]; then
+    guard="directory table executed no rows"
+    [[ -n "$only_row" ]] && guard="directory table selected no row: $only_row"
+    if [[ "$mode" == normal ]]; then
+      fail "$guard"
+    else
+      printf 'TABLE_GUARD:%s' "$guard"
+      return 1
+    fi
+  fi
   if [[ "$mode" == control ]]; then
     printf '%s' "$table_failures"
   fi
@@ -191,6 +203,24 @@ if [[ "$failures" == *'|configured-absent-keyword|'* ]]; then
   pass "absent keyword-search failure fails its row"
 else
   fail "absent keyword-search failure did not fail its row"
+fi
+
+if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
+  directory_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-directory-table/decider/tests/decider-search-missing-dir.test.sh" DIRECTORY_CASES)"
+  if decider_test_fails_with "$directory_table_mutant" "directory table executed no rows"; then
+    pass "an empty directory table fails its row-count guard"
+  else
+    fail "an empty directory table missed its row-count guard ($DECIDER_CONTROL_DETAIL)"
+  fi
+  set +e
+  selection_output="$(evaluate_directory_rows "$status_mutant" control unknown-directory-row 2>&1)"
+  selection_rc=$?
+  set -e
+  if [[ "$selection_rc" -ne 0 && "$selection_output" == *"TABLE_GUARD:directory table selected no row: unknown-directory-row"* ]]; then
+    pass "an unknown directory row fails its selection guard"
+  else
+    fail "an unknown directory row missed its selection guard"
+  fi
 fi
 
 echo

--- a/skills/decider/tests/lib/mutate-script.sh
+++ b/skills/decider/tests/lib/mutate-script.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+decider_mutate_script() {
+  local source="$1" destination="$2" old="$3" new="$4" expected_count="$5"
+  local content="" rest="" prefix="" mutated="" count=0 destination_dir source_dir
+
+  if [[ -L "$source" ]]; then
+    printf 'refusing to mutate symlink: %s\n' "$source" >&2
+    return 1
+  fi
+  if ! content="$(<"$source")"; then
+    printf 'could not read mutation source: %s\n' "$source" >&2
+    return 1
+  fi
+
+  rest="$content"
+  while [[ "$rest" == *"$old"* ]]; do
+    prefix="${rest%%"$old"*}"
+    mutated+="$prefix$new"
+    rest="${rest#*"$old"}"
+    count=$((count + 1))
+  done
+  mutated+="$rest"
+
+  if [[ "$count" -ne "$expected_count" ]]; then
+    printf 'mutation match count: expected %s, got %s\n' "$expected_count" "$count" >&2
+    return 1
+  fi
+
+  destination_dir="${destination%/*}"
+  source_dir="${source%/*}"
+  if ! mkdir -p "$destination_dir"; then
+    printf 'could not create mutant directory: %s\n' "$destination_dir" >&2
+    return 1
+  fi
+  if ! cp -R "$source_dir/lib" "$destination_dir/lib"; then
+    printf 'could not copy mutation support files\n' >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$mutated" >"$destination"; then
+    printf 'could not write mutant: %s\n' "$destination" >&2
+    return 1
+  fi
+  if ! chmod +x "$destination"; then
+    printf 'could not mark mutant executable: %s\n' "$destination" >&2
+    return 1
+  fi
+
+  if cmp -s "$source" "$destination"; then
+    printf 'mutation changed no bytes: %s\n' "$destination" >&2
+    return 1
+  fi
+
+  printf '%s' "$destination"
+}

--- a/skills/decider/tests/lib/mutate-script.sh
+++ b/skills/decider/tests/lib/mutate-script.sh
@@ -33,9 +33,11 @@ decider_mutate_script() {
     printf 'could not create mutant directory: %s\n' "$destination_dir" >&2
     return 1
   fi
-  if ! cp -R "$source_dir/lib" "$destination_dir/lib"; then
-    printf 'could not copy mutation support files\n' >&2
-    return 1
+  if [[ "$source_dir" != "$destination_dir" ]]; then
+    if ! cp -R "$source_dir/lib" "$destination_dir/lib"; then
+      printf 'could not copy mutation support files\n' >&2
+      return 1
+    fi
   fi
   if ! printf '%s\n' "$mutated" >"$destination"; then
     printf 'could not write mutant: %s\n' "$destination" >&2
@@ -95,10 +97,32 @@ decider_empty_test_table() {
 decider_test_fails_with() {
   local test_script="$1" expected="$2" output status
   DECIDER_CONTROL_DETAIL=""
+  DECIDER_CONTROL_OUTPUT=""
+  DECIDER_CONTROL_STATUS=0
   set +e
   output=$(DECIDER_TABLE_CONTROL_RUN=1 "$test_script" 2>&1)
   status=$?
   set -e
+  DECIDER_CONTROL_OUTPUT="$output"
+  DECIDER_CONTROL_STATUS=$status
   DECIDER_CONTROL_DETAIL="status $status; output: $output"
   [[ "$status" -ne 0 && "$output" == *"$expected"* ]]
+}
+
+decider_diagnostic_only_table_control() {
+  local test_script="$1" destination="$2" expected="$3" expected_count="$4" mutant
+  local old='      fail "$guard"'$'\n''      return 1'
+  local new='      printf '\''  FAIL  %s\n'\'' "$guard"'$'\n''      return 0'
+
+  if ! mutant="$(decider_mutate_script "$test_script" "$destination" "$old" "$new" "$expected_count")"; then
+    return 1
+  fi
+  if ! bash -n "$mutant"; then
+    DECIDER_CONTROL_DETAIL="diagnostic-only table control did not compile"
+    return 1
+  fi
+  if decider_test_fails_with "$mutant" "$expected"; then
+    return 1
+  fi
+  [[ "$DECIDER_CONTROL_STATUS" -eq 0 && "$DECIDER_CONTROL_OUTPUT" == *"$expected"* ]]
 }

--- a/skills/decider/tests/lib/mutate-script.sh
+++ b/skills/decider/tests/lib/mutate-script.sh
@@ -53,3 +53,52 @@ decider_mutate_script() {
 
   printf '%s' "$destination"
 }
+
+decider_empty_test_table() {
+  local source="$1" destination="$2" delimiter="$3"
+  local content="" start after_start rows old new mutant source_dir source_skill_dir
+  local destination_dir destination_skill_dir
+
+  if ! content="$(<"$source")"; then
+    printf 'could not read table-control source: %s\n' "$source" >&2
+    return 1
+  fi
+  start="  done <<'$delimiter'"
+  after_start="${content#*"$start"$'\n'}"
+  if [[ "$after_start" == "$content" ]]; then
+    printf 'table start not found: %s\n' "$delimiter" >&2
+    return 1
+  fi
+  rows="${after_start%%$'\n'"$delimiter"*}"
+  if [[ "$rows" == "$after_start" ]]; then
+    printf 'table end not found: %s\n' "$delimiter" >&2
+    return 1
+  fi
+  old="$start"$'\n'"$rows"$'\n'"$delimiter"
+  new="$start"$'\n'"$delimiter"
+  if ! mutant="$(decider_mutate_script "$source" "$destination" "$old" "$new" 1)"; then
+    return 1
+  fi
+
+  source_dir="${source%/*}"
+  source_skill_dir="${source_dir%/*}"
+  destination_dir="${destination%/*}"
+  destination_skill_dir="${destination_dir%/*}"
+  if ! cp -R "$source_skill_dir/scripts" "$destination_skill_dir/scripts"; then
+    printf 'could not copy production scripts for table control\n' >&2
+    return 1
+  fi
+
+  printf '%s' "$mutant"
+}
+
+decider_test_fails_with() {
+  local test_script="$1" expected="$2" output status
+  DECIDER_CONTROL_DETAIL=""
+  set +e
+  output=$(DECIDER_TABLE_CONTROL_RUN=1 "$test_script" 2>&1)
+  status=$?
+  set -e
+  DECIDER_CONTROL_DETAIL="status $status; output: $output"
+  [[ "$status" -ne 0 && "$output" == *"$expected"* ]]
+}


### PR DESCRIPTION
KEN-1241 tests audit, lane F: Decider test cases now use named rows with independent controls.

## What changed

- Reshaped the Decider index, issue-action, next-ID, body-search, and missing-directory suites into visible named tables.
- Added exact result checks for identifier parsing and search ranking.
- Added row-count and row-selection guards so an empty table or unknown row cannot pass.
- Added a private mutation helper for the controls.
- Replayed each source test change into its tracked render.

## Must-fail controls

Each table rejects an independently emptied row list and an unknown row selector. The fix-head controls also retain the empty-table diagnostic while removing its failure, and confirm that no later control-mode evaluator can supply the accepted exit.

## Size

- Production lines added: 0.
- Test lines added: 904.
- Render-mirror lines added: 904.
- KEN-1241 states no expected-delta allowance.

## Test plan

- Preflight passed for 12 changed files.
- The original full guard passed its repository, Decider, Rust, cross-target, documentation, and workspace-test lanes, then exited 1 because the migrated checkout omitted `tsc`, `biome`, and `vitest`.
- After the authorized dependency restore, its unfinished UI type check, lint, and test commands passed at the same saved source head.
- `tools/guard --full` exited 0 at fix head `9a2159ac9b85f6c8bb37e0b3ee0a96091c88f3af`.
- The UI test command passed 159 files with 1286 tests.

## Reviewer round

One specialist reviewer-test round passed. The saved artifact remains valid after storage migration.

KEN-1241
