### PR TITLE
test(KEN-1241): isolate bounded snapshot tables

### DIFF
--- a/pi-extensions/pi-background-tasks/tests/bounded-snapshot-barrier.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/bounded-snapshot-barrier.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { applyCustomEntryWithBarrier } from "../extensions/persistence.js";
+import type { BackgroundTaskSnapshot } from "../extensions/types.js";
+import { boundedSnapshot } from "./fixtures/bounded-snapshot.js";
+
+test("custom entries restore the sidecar at bounded snapshot barriers", () => {
+	expect.hasAssertions();
+	for (const { name, initialIds, sidecarIds, entries, expected } of [
+		{
+			name: "older full snapshot is replaced by the later sidecar barrier",
+			initialIds: ["bg-new"],
+			sidecarIds: ["bg-new"],
+			entries: [
+				{ tasks: [boundedSnapshot({ id: "bg-old" })], updatedAt: 1 },
+				{ version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 999_999, fingerprint: "abc", counts: { tasks: 1 }, updatedAt: 2 },
+			],
+			expected: [["bg-old"], ["bg-new"]],
+		},
+		{
+			name: "barrier without a loaded sidecar preserves current tasks",
+			initialIds: ["bg-pre"],
+			sidecarIds: undefined,
+			entries: [{ version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 1, fingerprint: "x", counts: { tasks: 0 }, updatedAt: 0 }],
+			expected: [["bg-pre"]],
+		},
+		{
+			name: "barrier marker is independent of envelope version",
+			initialIds: ["bg-old"],
+			sidecarIds: ["bg-sidecar"],
+			entries: [{ version: 3, fullSnapshot: false, reason: "some-new-reason" }],
+			expected: [["bg-sidecar"]],
+		},
+	] as const) {
+		let current: BackgroundTaskSnapshot[] = initialIds.map((id) => boundedSnapshot({ id }));
+		const sidecarTasks = sidecarIds?.map((id) => boundedSnapshot({ id }));
+		const states = entries.map((data) => {
+			applyCustomEntryWithBarrier({
+				data,
+				sidecarLoaded: sidecarTasks !== undefined,
+				sidecarTasks,
+				clear: () => { current = []; },
+				apply: (snapshot) => { current.push(snapshot); },
+			});
+			return current.map((task) => task.id);
+		});
+		expect(states, name).toEqual(expected);
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/bounded-snapshot-manifest.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/bounded-snapshot-manifest.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { isBgTasksBoundedManifest } from "../extensions/persistence.js";
+
+test("bounded manifest recognition distinguishes snapshot envelopes", () => {
+	expect.hasAssertions();
+	for (const { name, value, expected } of [
+		{
+			name: "bounded manifest envelope",
+			value: { version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 999_999, fingerprint: "abc", counts: { tasks: 70 }, updatedAt: 0 },
+			expected: true,
+		},
+		{ name: "full snapshot envelope", value: { version: 1, tasks: [], updatedAt: 0 }, expected: false },
+		{ name: "other version is a barrier but not a recognized manifest", value: { version: 3, fullSnapshot: false, reason: "some-new-reason" }, expected: false },
+	] as const) {
+		expect(isBgTasksBoundedManifest(value), name).toBe(expected);
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
@@ -1,210 +1,115 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
 	BG_TASKS_SNAPSHOT_MAX_BYTES,
-	applyCustomEntryWithBarrier,
 	createPersistence,
 	isBgTasksBoundedManifest,
+	type BgTasksBoundedManifest,
+	type PersistenceDeps,
+	type PersistencePayload,
 } from "../extensions/persistence.js";
 import type { BackgroundTaskSnapshot } from "../extensions/types.js";
+import { boundedSnapshot } from "./fixtures/bounded-snapshot.js";
 
-function fakeSnapshot(overrides: Partial<BackgroundTaskSnapshot> = {}): BackgroundTaskSnapshot {
-	return {
-		command: "printf ready",
-		cwd: "/tmp/worktree",
-		exitCode: null,
-		exitNotified: false,
-		expiresAt: null,
-		id: overrides.id ?? "bg-1",
-		lastOutputAt: 0,
-		logFile: "/tmp/bg-1.log",
-		notifyMode: "always",
-		notifyOnExit: true,
-		notifyOnOutput: false,
-		outputBytes: 0,
-		pid: 1234,
-		startedAt: 1_700_000_000_000,
-		status: "completed",
-		title: "fake task",
-		updatedAt: 1_700_000_000_500,
-		voidedWakeSequences: [],
-		wakeEvents: [],
-		wakeSequence: 0,
-		...overrides,
-	};
+function withPersistenceContext(run: (ctx: NonNullable<ReturnType<PersistenceDeps["getActiveCtx"]>>, sidecarFile: string) => void): void {
+	const root = mkdtempSync(join(tmpdir(), "pi-bg-bounded-"));
+	const previousPiDir = process.env.PI_CODING_AGENT_DIR;
+	const previousDiagnosticLog = process.env.PI_BG_TASK_DIAGNOSTIC_LOG;
+	try {
+		const piDir = join(root, "agent");
+		process.env.PI_CODING_AGENT_DIR = piDir;
+		process.env.PI_BG_TASK_DIAGNOSTIC_LOG = join(root, "diagnostics.log");
+		const ctx = {
+			cwd: root,
+			sessionManager: {
+				getSessionId: () => "session",
+				getSessionFile: () => join(root, "session.jsonl"),
+			},
+		} as NonNullable<ReturnType<PersistenceDeps["getActiveCtx"]>>;
+		run(ctx, join(piDir, "kendex", "sessions", "session", "pi-background-tasks", "state.json"));
+	} finally {
+		if (previousPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousPiDir;
+		if (previousDiagnosticLog === undefined) delete process.env.PI_BG_TASK_DIAGNOSTIC_LOG;
+		else process.env.PI_BG_TASK_DIAGNOSTIC_LOG = previousDiagnosticLog;
+		rmSync(root, { recursive: true, force: true });
+	}
 }
 
-function fakeCtx(sessionId: string) {
-	const tempDir = mkdtempSync(join(tmpdir(), "pi-bg-persistence-"));
-	return {
-		cwd: tempDir,
-		sessionManager: {
-			getSessionId: () => sessionId,
-			getSessionFile: () => join(tempDir, `${sessionId}.jsonl`),
-		},
-	} as any;
-}
-
-describe("pi-background-tasks bounded snapshots", () => {
-	test("appendEntry skips identical successive task lists and re-fires on real change", () => {
-		const appended: { customType: string; payload: any }[] = [];
-		const ctx = fakeCtx("session-stable");
-		const stable: BackgroundTaskSnapshot = fakeSnapshot({ id: "bg-1", status: "running", updatedAt: 1 });
-		let snapshots: BackgroundTaskSnapshot[] = [stable];
+test("snapshot append decisions follow content changes", () => {
+	expect.hasAssertions();
+	withPersistenceContext((ctx, sidecarFile) => {
+		const appended: { customType: string; payload: unknown }[] = [];
+		let snapshots: BackgroundTaskSnapshot[] = [];
 		const persistence = createPersistence({
 			customType: "kendex-background-tasks:state",
 			getActiveCtx: () => ctx,
 			listSnapshots: () => snapshots,
-			pi: { appendEntry: (customType: string, payload: any) => appended.push({ customType, payload }) } as any,
+			pi: { appendEntry: (customType: string, payload: unknown) => appended.push({ customType, payload }) } as PersistenceDeps["pi"],
 		});
-
-		const first = persistence.persistSnapshots();
-		const second = persistence.persistSnapshots();
-		expect(first.appendEntry).toBe(true);
-		expect(first.appendReason).toBe("appended");
-		expect(second.appendEntry).toBe(true);
-		expect(second.appendReason).toBe("unchanged");
-		expect(appended).toHaveLength(1);
-
-		// Actual content change appends again.
-		snapshots = [fakeSnapshot({ id: "bg-1", status: "completed", updatedAt: 3 })];
-		const third = persistence.persistSnapshots();
-		expect(third.appendReason).toBe("appended");
-		expect(appended).toHaveLength(2);
+		for (const { name, status, updatedAt, appendReason, count } of [
+			{ name: "first snapshot appends", status: "running", updatedAt: 1, appendReason: "appended", count: 1 },
+			{ name: "identical snapshot does not append again", status: "running", updatedAt: 1, appendReason: "unchanged", count: 1 },
+			{ name: "changed snapshot appends again", status: "completed", updatedAt: 3, appendReason: "appended", count: 2 },
+		] as const) {
+			snapshots = [boundedSnapshot({ status, updatedAt })];
+			const result = persistence.persistSnapshots();
+			const sidecar = JSON.parse(readFileSync(sidecarFile, "utf8")) as PersistencePayload;
+			expect({ result, appendCount: appended.length, sidecarTasks: sidecar.tasks }, name).toEqual({
+				result: { appendEntry: true, sidecar: true, appendReason },
+				appendCount: count,
+				sidecarTasks: snapshots,
+			});
+		}
 	});
+});
 
-	test("payloads over the byte cap downgrade to a bounded manifest", () => {
-		const appended: { customType: string; payload: any }[] = [];
-		const ctx = fakeCtx("session-bloated");
-		// 70 completed tasks each carrying a 10 KiB heredoc command.
-		const heredoc = "x".repeat(10 * 1024);
-		const snapshots: BackgroundTaskSnapshot[] = Array.from({ length: 70 }, (_value, index) => fakeSnapshot({
-			id: `bg-${index}`,
-			command: heredoc,
-			logFile: `/tmp/bg-${index}.log`,
-			status: "completed",
-		}));
-		const persistence = createPersistence({
-			customType: "kendex-background-tasks:state",
-			getActiveCtx: () => ctx,
-			listSnapshots: () => snapshots,
-			pi: { appendEntry: (customType: string, payload: any) => appended.push({ customType, payload }) } as any,
+test("oversized snapshots append a bounded manifest", () => {
+	expect.hasAssertions();
+	for (const { name, taskCount } of [
+		{ name: "completed tasks with large commands", taskCount: 70 },
+		{ name: "large task list keeps a bounded fingerprint", taskCount: 1000 },
+	] as const) {
+		withPersistenceContext((ctx, sidecarFile) => {
+			const snapshots = Array.from({ length: taskCount }, (_, index) => boundedSnapshot({
+				id: `bg-${index}`,
+				command: "x".repeat(10 * 1024),
+				logFile: `/tmp/bg-${index}.log`,
+			}));
+			const appended: { customType: string; payload: unknown }[] = [];
+			const persistence = createPersistence({
+				customType: "kendex-background-tasks:state",
+				getActiveCtx: () => ctx,
+				listSnapshots: () => snapshots,
+				pi: { appendEntry: (customType: string, payload: unknown) => appended.push({ customType, payload }) } as PersistenceDeps["pi"],
+			});
+			const result = persistence.persistSnapshots();
+			const payload = appended[0]?.payload as BgTasksBoundedManifest | undefined;
+			const sidecar = JSON.parse(readFileSync(sidecarFile, "utf8")) as PersistencePayload;
+			expect({
+				result,
+				appendCount: appended.length,
+				manifest: isBgTasksBoundedManifest(payload),
+				taskCount: payload?.counts?.tasks,
+				originalExceedsCap: typeof payload?.byteSize === "number" && payload.byteSize > BG_TASKS_SNAPSHOT_MAX_BYTES,
+				manifestFitsCap: Buffer.byteLength(JSON.stringify(payload ?? null), "utf8") <= BG_TASKS_SNAPSHOT_MAX_BYTES,
+				fingerprint: payload?.fingerprint,
+				fingerprintFitsCap: typeof payload?.fingerprint === "string" && payload.fingerprint.length <= 128,
+				sidecarMatches: JSON.stringify(sidecar.tasks) === JSON.stringify(snapshots),
+			}, name).toEqual({
+				result: { appendEntry: true, sidecar: true, appendReason: "manifest" },
+				appendCount: 1,
+				manifest: true,
+				taskCount,
+				originalExceedsCap: true,
+				manifestFitsCap: true,
+				fingerprint: expect.stringMatching(/^[0-9a-f]+$/),
+				fingerprintFitsCap: true,
+				sidecarMatches: true,
+			});
 		});
-		const result = persistence.persistSnapshots();
-		expect(result.appendReason).toBe("manifest");
-		expect(appended).toHaveLength(1);
-		expect(isBgTasksBoundedManifest(appended[0].payload)).toBe(true);
-		expect(appended[0].payload.counts.tasks).toBe(70);
-		expect(appended[0].payload.byteSize).toBeGreaterThan(BG_TASKS_SNAPSHOT_MAX_BYTES);
-	});
-
-	test("bounded manifest itself stays under the byte cap regardless of payload size (kendex#183)", () => {
-		const appended: { customType: string; payload: any }[] = [];
-		const ctx = fakeCtx("session-massive");
-		// ~10 MB worst case: 1000 tasks * 10 KiB heredoc command each.
-		const heredoc = "x".repeat(10 * 1024);
-		const snapshots: BackgroundTaskSnapshot[] = Array.from({ length: 1000 }, (_value, index) => fakeSnapshot({
-			id: `bg-${index}`,
-			command: heredoc,
-			logFile: `/tmp/bg-${index}.log`,
-			status: "completed",
-		}));
-		const persistence = createPersistence({
-			customType: "kendex-background-tasks:state",
-			getActiveCtx: () => ctx,
-			listSnapshots: () => snapshots,
-			pi: { appendEntry: (customType: string, payload: any) => appended.push({ customType, payload }) } as any,
-		});
-		const result = persistence.persistSnapshots();
-		expect(result.appendReason).toBe("manifest");
-		expect(appended).toHaveLength(1);
-		const manifestBytes = Buffer.byteLength(JSON.stringify(appended[0].payload), "utf8");
-		expect(manifestBytes).toBeLessThanOrEqual(BG_TASKS_SNAPSHOT_MAX_BYTES);
-		// Fingerprint must be a fixed-size hex digest, not the full canonical JSON.
-		const fingerprint = appended[0].payload.fingerprint as string;
-		expect(fingerprint).toMatch(/^[0-9a-f]+$/);
-		expect(fingerprint.length).toBeLessThanOrEqual(128);
-	});
-
-	test("manifest type guard matches v2 fullSnapshot:false envelope only", () => {
-		const manifest = {
-			version: 2,
-			fullSnapshot: false,
-			reason: "payload-too-large" as const,
-			byteSize: 999_999,
-			fingerprint: "abc",
-			counts: { tasks: 70 },
-			updatedAt: Date.now(),
-		};
-		expect(isBgTasksBoundedManifest(manifest)).toBe(true);
-		expect(isBgTasksBoundedManifest({ version: 1, tasks: [], updatedAt: 0 })).toBe(false);
-	});
-
-	test("kendex#184: restore barrier - manifest entry re-applies sidecar state", () => {
-		// The branch contains [older-full-snapshot, later bounded manifest]. The
-		// sidecar has the latest task set. The barrier must prevent the older full
-		// snapshot from replacing that canonical state.
-		const sidecarTasks: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-new", status: "completed" })];
-		const olderTasks: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-old", status: "completed" })];
-		let current: BackgroundTaskSnapshot[] = [];
-		const clear = () => { current = []; };
-		const apply = (snapshot: BackgroundTaskSnapshot) => { current.push(snapshot); };
-
-		// Sidecar restore happened first (current = sidecar tasks).
-		current = [...sidecarTasks];
-
-		// Branch entry #1: older full snapshot. Expected to replace.
-		applyCustomEntryWithBarrier({
-			data: { tasks: olderTasks, updatedAt: 1 },
-			sidecarLoaded: true,
-			sidecarTasks,
-			clear,
-			apply,
-		});
-		expect(current.map((t) => t.id)).toEqual(["bg-old"]);
-
-		// Branch entry #2: bounded manifest. Expected to restore sidecar.
-		applyCustomEntryWithBarrier({
-			data: { version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 999_999, fingerprint: "abc", counts: { tasks: 1 }, updatedAt: 2 },
-			sidecarLoaded: true,
-			sidecarTasks,
-			clear,
-			apply,
-		});
-		expect(current.map((t) => t.id)).toEqual(["bg-new"]);
-	});
-
-	test("kendex#184: barrier without sidecar leaves state untouched (no crash)", () => {
-		let current: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-pre", status: "completed" })];
-		const clear = () => { current = []; };
-		const apply = (snapshot: BackgroundTaskSnapshot) => { current.push(snapshot); };
-		applyCustomEntryWithBarrier({
-			data: { version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 1, fingerprint: "x", counts: { tasks: 0 }, updatedAt: 0 },
-			sidecarLoaded: false,
-			sidecarTasks: undefined,
-			clear,
-			apply,
-		});
-		// Sidecar load failed earlier; manifest is a no-op so state is preserved.
-		expect(current.map((t) => t.id)).toEqual(["bg-pre"]);
-	});
-
-	test("kendex#184: forward-compat - any fullSnapshot:false manifest counts as barrier", () => {
-		const sidecarTasks: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-sidecar" })];
-		let current: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-old" })];
-		const clear = () => { current = []; };
-		const apply = (snapshot: BackgroundTaskSnapshot) => { current.push(snapshot); };
-		applyCustomEntryWithBarrier({
-			// Hypothetical future version 3 manifest.
-			data: { version: 3, fullSnapshot: false, reason: "some-new-reason" },
-			sidecarLoaded: true,
-			sidecarTasks,
-			clear,
-			apply,
-		});
-		expect(current.map((t) => t.id)).toEqual(["bg-sidecar"]);
-	});
+	}
 });

--- a/pi-extensions/pi-background-tasks/tests/fixtures/bounded-snapshot.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/bounded-snapshot.ts
@@ -1,0 +1,27 @@
+import type { BackgroundTaskSnapshot } from "../../extensions/types.js";
+
+export function boundedSnapshot(overrides: Partial<BackgroundTaskSnapshot> = {}): BackgroundTaskSnapshot {
+	return {
+		command: "printf ready",
+		cwd: "/tmp/worktree",
+		exitCode: null,
+		exitNotified: false,
+		expiresAt: null,
+		id: "bg-1",
+		lastOutputAt: 0,
+		logFile: "/tmp/bg-1.log",
+		notifyMode: "always",
+		notifyOnExit: true,
+		notifyOnOutput: false,
+		outputBytes: 0,
+		pid: 1234,
+		startedAt: 1_700_000_000_000,
+		status: "completed",
+		title: "fake task",
+		updatedAt: 1_700_000_000_500,
+		voidedWakeSequences: [],
+		wakeEvents: [],
+		wakeSequence: 0,
+		...overrides,
+	};
+}


### PR DESCRIPTION
Snapshot persistence tests previously used temporary session directories without isolating Pi storage or removing those directories. Each persistence fixture now owns its storage and diagnostic paths, restores inherited environment values, and removes its temporary directory after success or failure.

Append decisions, oversized payloads, manifest recognition and restore barriers use named tables. Each table rejects an empty or no-op assertion loop. The assertion map retains all 23 former comparisons. Production code is unchanged.

Validation: fresh full guard, preflight, document limits and Pi package policy pass after verified storage migration. Focused tests pass: 4 tests across 3 files with 11 aggregate assertions. Saved compiled controls detect behavior changes, empty tables and no-op assertions. Separate resource controls detect omitted cleanup and environment restoration. The specialist review passed without findings. Earlier pre-migration full-guard failures and success remain preserved separately.

## Size

0 production, 186 test and 0 render-mirror lines added. KEN-1241 states no line allowance.

KEN-1241
