### PR TITLE
test(KEN-1241): reshape reviewer test cases

### DIFF
--- a/.agents/skills/reviewer/tests/measurement-fail-closed.test.sh
+++ b/.agents/skills/reviewer/tests/measurement-fail-closed.test.sh
@@ -1,275 +1,193 @@
 #!/usr/bin/env bash
-# Contract test for the fail-closed measurement rule: a run that produced no
-# samples is instrument failure, never a numeric or green result — and a zero
-# RESULT on a measured run is the opposite, a finding that has to reach the
-# orchestrator intact. Two halves, because the rule has two carriers:
-#
-#   a. Prose — the Ethos bullet in SKILL.md that binds every reviewer, and the
-#      schema doc's statement of both the rejection and the declaration that
-#      lets a reviewer keep its evidence.
-#   b. Behavior — orch's review-artifact-check rejecting a zero-sample artifact,
-#      accepting a measured one, and accepting a declared instrument failure. A
-#      guard proven in one direction only is a guard that could be passing
-#      vacuously, and the accepting cases are what pin WHICH number it reads.
-#
-# The behavioral half is skipped only for a reviewer-without-orch install (no
-# sibling skills/orch at all). When orch IS installed, a missing or
-# non-executable review-artifact-check is a failure, not a skip: that is
-# precisely the drift this suite exists to catch, and skipping on it would make
-# the branch fire only when it matters.
-#
-# The doc checks pin the schema's own names — `measurement_failed`, and the
-# `zero_sample`, `invalid_declaration` and `valid_undermeasured` states. The
-# gate's own behaviour is exercised against the script above, which is what
-# proves it.
+# Contract test for fail-closed reviewer measurements.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ORCH_DIR="$SKILL_DIR/../orch"
 CHECK="$ORCH_DIR/scripts/review-artifact-check"
-TMP_ROOT="$(mktemp -d)"
+TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0
 FAIL=0
+out=""
 
 pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "$2"; }
 
-require_fixed() {
-  local file="$1" needle="$2" desc="$3"
-  if grep -Fq -- "$needle" "$file"; then
-    pass "$desc"
+assert_row() {
+  table="$1" name="$2" actual="$3" expected="$4"
+  if [ "$actual" = "$expected" ]; then
+    pass "$table: $name"
   else
-    fail "$desc — missing in ${file#$SKILL_DIR/}"
+    fail "$table: $name" "expected <$expected>, got <$actual>; output: $out"
   fi
 }
 
-# artifact <name> <json> → prints the written path
+assert_table_executed() {
+  table="$1" rows="$2"
+  if [ "$rows" -gt 0 ]; then
+    pass "$table: executed rows"
+  else
+    fail "$table: executed rows" "the table executed no assertion row"
+  fi
+}
+
 artifact() {
-  local path="$TMP_ROOT/$1.json"
+  path="$TMP_ROOT/$1.json"
   printf '%s' "$2" > "$path"
   printf '%s' "$path"
 }
 
-# The reasons that mean "accepted". Exit status is the other half of the
-# contract — review-pr.md and submit-pr.md branch on it and orch's waiters use
-# it directly — so a failure that exits 0 while reporting a rejection, or
-# non-zero on an acceptance, has to fail here and not just look odd.
-is_accepting_reason() {
-  [[ "$1" == "valid" || "$1" == "valid_undermeasured" ]]
-}
-
-# expect_reason <artifact-path> <expected-reason> <desc>
-expect_reason() {
-  local path="$1" want="$2" desc="$3" out rc=0 got want_rc
-  set +e
-  out="$("$CHECK" --file "$path" 2>/dev/null)"
-  rc=$?
-  set -e
-  got="$(jq -r '.reason' <<<"$out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$got" == "$want" ]]; then
-    pass "$desc"
-  else
-    fail "$desc — expected reason=$want, got reason=$got (rc=$rc)"
-  fi
-  if is_accepting_reason "$want"; then
-    want_rc="exit 0"
-    [[ "$rc" -eq 0 ]] && pass "$desc (exits 0)" || fail "$desc — reason=$want is an acceptance but the check exited $rc"
-  else
-    want_rc="a non-zero exit"
-    [[ "$rc" -ne 0 ]] && pass "$desc (exits non-zero)" || fail "$desc — reason=$want is a rejection but the check exited 0"
+read_result() {
+  path="$1"
+  rc=0
+  out=""
+  out=$("$CHECK" --file "$path" 2>/dev/null) || rc=$?
+  reason=$(jq -r '.reason' <<<"$out" 2>/dev/null) || reason=unparseable
+  ok=$(jq -r '.ok' <<<"$out" 2>/dev/null) || ok=unparseable
+  declaration=$(jq -r 'if has("measurement_failed") then .measurement_failed else "ABSENT" end' <<<"$out" 2>/dev/null) || declaration=unparseable
+  consistent=no
+  if { [ "$ok" = true ] && [ "$rc" -eq 0 ]; } || { [ "$ok" = false ] && [ "$rc" -ne 0 ]; }; then
+    consistent=yes
   fi
 }
 
-# expect_field <artifact-path> <jq-filter> <expected> <desc>
-# No expected reason here, so the status is checked against the result's own
-# `.ok` — exit 0 exactly when the artifact was accepted.
-expect_field() {
-  local path="$1" filter="$2" want="$3" desc="$4" out got rc=0 ok
-  set +e
-  out="$("$CHECK" --file "$path" 2>/dev/null)"
-  rc=$?
-  set -e
-  got="$(jq -r "$filter" <<<"$out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$got" == "$want" ]]; then
-    pass "$desc"
+echo "=== documentation shape table ==="
+# These rows prove token presence only. The behavior table proves enforcement.
+documentation_rows=0
+while IFS=$'\t' read -r name relative_path token; do
+  if grep -Fq -- "$token" "$SKILL_DIR/$relative_path"; then
+    actual=present
   else
-    fail "$desc — expected '$want', got '$got'"
+    actual=missing
   fi
-  ok="$(jq -r '.ok' <<<"$out" 2>/dev/null || printf 'unparseable')"
-  if { [[ "$ok" == "true" && "$rc" -eq 0 ]] || [[ "$ok" == "false" && "$rc" -ne 0 ]]; }; then
-    pass "$desc (exit status agrees with .ok)"
-  else
-    fail "$desc — .ok=$ok but the check exited $rc"
-  fi
-}
+  out="$relative_path lacks $token"
+  assert_row "documentation shape" "$name" "$actual" present
+  documentation_rows=$((documentation_rows + 1))
+done <<'ROWS'
+reviewer skill names the declaration	SKILL.md	measurement_failed
+schema names the zero-sample rejection	schemas/review-finding.md	zero_sample
+schema names the declaration field	schemas/review-finding.md	measurement_failed
+schema names an invalid declaration	schemas/review-finding.md	invalid_declaration
+schema names accepted undermeasurement	schemas/review-finding.md	valid_undermeasured
+ROWS
+assert_table_executed "documentation shape" "$documentation_rows"
 
-DEGEN_N=1
-
-echo "=== reviewer measurement fail-closed contract ==="
-
-skill="$SKILL_DIR/SKILL.md"
-schema="$SKILL_DIR/schemas/review-finding.md"
-[[ -f "$skill" ]] || { echo "FAIL: SKILL.md not found" >&2; exit 1; }
-[[ -f "$schema" ]] || { echo "FAIL: schemas/review-finding.md not found" >&2; exit 1; }
-
-# --- a. the rule is stated where every reviewer loads it ---
-
-require_fixed "$skill" 'measurement_failed' 'Ethos names the declaration, so evidence is kept not deleted'
-require_fixed "$schema" 'zero_sample' 'schema doc names the rejection reason'
-require_fixed "$schema" 'measurement_failed' 'schema doc specifies the declaration field'
-require_fixed "$schema" 'invalid_declaration' 'schema doc names the bar a declaration must clear'
-require_fixed "$schema" 'valid_undermeasured' 'schema doc names the state a declaration produces'
-
-# --- b. the gate enforces it, in both directions ---
-
-if [[ ! -d "$ORCH_DIR" ]]; then
-  echo "  skip  sibling skills/orch is not installed (reviewer-without-orch)"
-elif [[ ! -x "$CHECK" ]]; then
-  fail "skills/orch is installed but review-artifact-check is missing or not executable at $CHECK"
+if [ ! -d "$ORCH_DIR" ]; then
+  printf '  skip  artifact tables (sibling skills/orch is not installed)\n'
+elif [ ! -x "$CHECK" ]; then
+  fail "artifact acceptance table" "skills/orch is installed but review-artifact-check is missing or not executable at $CHECK"
 else
-  # A zero SAMPLE COUNT is the failure shape: a selection or quoting fault runs
-  # nothing, the pipeline still exits 0, and the citation reads as evidence.
-  expect_reason \
-    "$(artifact zero-mutants '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0; stability: 10/10 at 16 threads"}')" \
-    zero_sample "gate rejects a zero-mutant mutation citation"
-  expect_reason \
-    "$(artifact zero-runs '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 0/0 at 16 threads"}')" \
-    zero_sample "gate rejects a zero-run stability citation"
-  expect_reason \
-    "$(artifact zero-threads '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 0 threads"}')" \
-    zero_sample "gate rejects elevated parallelism of zero threads"
-  expect_reason \
-    "$(artifact wrapped-citation '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/\n0"}')" \
-    zero_sample "gate sees a citation its author wrapped across a newline"
-  expect_reason \
-    "$(artifact zero-percentiles '{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":0}}}}')" \
-    zero_sample "gate rejects an all-zero benchmark percentile block"
-  expect_reason \
-    "$(artifact absent-percentiles '{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"regression_pct":0}}}')" \
-    zero_sample "gate rejects a perf payload that omits percentiles entirely"
+  echo "=== artifact acceptance and declaration table ==="
+  artifact_rows=0
+  while IFS=$'\t' read -r name body probe expected; do
+    path=$(artifact "$name" "$body") || {
+      fail "artifact acceptance and declaration: $name" "could not write fixture"
+      continue
+    }
+    read_result "$path"
+    case "$probe" in
+      reason)
+        actual="reason=$reason;rc=$rc"
+        ;;
+      declared)
+        actual="reason=$reason;rc=$rc;declaration=$declaration;ok=$ok;consistent=$consistent"
+        ;;
+      absent-declaration)
+        actual="declaration=$declaration;consistent=$consistent"
+        ;;
+      teaching)
+        teaches=$(jq -r '.detail | test("measurement_failed")' <<<"$out" 2>/dev/null) || teaches=unparseable
+        actual="teaches=$teaches;consistent=$consistent"
+        ;;
+      *)
+        actual="unknown-probe=$probe"
+        ;;
+    esac
+    assert_row "artifact acceptance and declaration" "$name" "$actual" "$expected"
+    artifact_rows=$((artifact_rows + 1))
+  done <<'ROWS'
+zero mutants	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0; stability: 10/10 at 16 threads"}	reason	reason=zero_sample;rc=1
+zero stability runs	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 0/0 at 16 threads"}	reason	reason=zero_sample;rc=1
+zero threads	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 0 threads"}	reason	reason=zero_sample;rc=1
+wrapped citation	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/\n0"}	reason	reason=zero_sample;rc=1
+zero percentiles	{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":0}}}}	reason	reason=zero_sample;rc=1
+absent percentiles	{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"regression_pct":0}}}	reason	reason=zero_sample;rc=1
+measured stability failure	{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 3/3; stability: 0/10 at 16 threads"}	reason	reason=valid;rc=0
+surviving mutants	{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 0/3; stability: 10/10 at 16 threads"}	reason	reason=valid;rc=0
+measured citation	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}	reason	reason=valid;rc=0
+measured percentiles	{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":4.2}}}}	reason	reason=valid;rc=0
+uncited artifact	{"agent":"reviewer-quality","verdict":"pass","summary":"no measurement in scope for this domain"}	reason	reason=valid;rc=0
+quoted in blocker	{"agent":"reviewer-test","verdict":"action_required","summary":"reviewed the gate","blockers":[{"id":1,"title":"t","location":"tests/x.sh","description":"the fixture uses mutation: killed 0/0 to prove the gate rejects","recommendation":"r","priority":3,"estimate":1}],"suggestions":[],"qa_metadata":{}}	reason	reason=valid;rc=0
+same text in summary	{"agent":"reviewer-test","verdict":"pass","summary":"the fixture uses mutation: killed 0/0 to prove the gate rejects","blockers":[],"suggestions":[],"qa_metadata":{}}	reason	reason=zero_sample;rc=1
+declared failure	{"agent":"reviewer-test","verdict":"action_required","summary":"harness produced nothing: mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}	declared	reason=valid_undermeasured;rc=0;declaration=cargo-mutants selected 0 mutants for the changed file;ok=true;consistent=yes
+tolerant shape adopts declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","measurement_failed":"cargo-mutants selected 0 mutants for this module"}	reason	reason=valid_undermeasured;rc=0
+pass verdict with declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}	reason	reason=valid_undermeasured;rc=0
+period declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"."}	reason	reason=invalid_declaration;rc=1
+n-a declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"n/a"}	reason	reason=invalid_declaration;rc=1
+none declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"none"}	reason	reason=invalid_declaration;rc=1
+unknown declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"unknown"}	reason	reason=invalid_declaration;rc=1
+whitespace declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"   "}	reason	reason=invalid_declaration;rc=1
+dashes declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"---"}	reason	reason=invalid_declaration;rc=1
+boolean declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":true}	reason	reason=invalid_declaration;rc=1
+numeric declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":0}	reason	reason=invalid_declaration;rc=1
+undeclared field stays absent	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}	absent-declaration	declaration=ABSENT;consistent=yes
+rejection teaches declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0"}	teaching	teaches=true;consistent=yes
+ROWS
+  assert_table_executed "artifact acceptance and declaration" "$artifact_rows"
 
-  # ACCEPTING DIRECTION, part one: a zero RESULT on a measured run. SKILL.md
-  # calls a stability failure "never a pass" — the gate must let it through as
-  # the finding, and these two cases are what prove the gate reads the sample
-  # count rather than the result.
-  expect_reason \
-    "$(artifact measured-stability-failure '{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 3/3; stability: 0/10 at 16 threads"}')" \
-    valid "gate accepts stability 0/10 — ten measured runs, none passed"
-  expect_reason \
-    "$(artifact surviving-mutants '{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 0/3; stability: 10/10 at 16 threads"}')" \
-    valid "gate accepts mutation killed 0/3 — three mutants, none killed"
+  real_jq=$(command -v jq)
+  chatty_dir="$TMP_ROOT/jq-chatty"
+  broken_dir="$TMP_ROOT/jq-broken"
+  mkdir -p "$chatty_dir" "$broken_dir"
+  cat > "$chatty_dir/jq" <<SHIM
+#!/usr/bin/env bash
+echo "chatty jq diagnostic" >&2
+exec "$real_jq" "\$@"
+SHIM
+  cat > "$broken_dir/jq" <<SHIM
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  case "\$arg" in
+    *"gate:zero-sample"*) echo "jq: error: simulated torn read" >&2; exit 5 ;;
+  esac
+done
+exec "$real_jq" "\$@"
+SHIM
+  chmod +x "$chatty_dir/jq" "$broken_dir/jq"
+  clean=$(artifact clean-channel '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')
 
-  # ACCEPTING DIRECTION, part two: real samples, and no citation at all.
-  expect_reason \
-    "$(artifact measured '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')" \
-    valid "gate accepts a citation with real samples"
-  expect_reason \
-    "$(artifact measured-percentiles '{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":4.2}}}}')" \
-    valid "gate accepts a percentile block carrying a real number"
-  expect_reason \
-    "$(artifact uncited '{"agent":"reviewer-quality","verdict":"pass","summary":"no measurement in scope for this domain"}')" \
-    valid "gate leaves an artifact citing no measurement alone"
-
-  # QUOTING SOMEBODY ELSE'S ZEROED RUN. .summary and .qa_metadata carry the
-  # artifact's own measurements; the finding arrays describe the code under
-  # review, so numbers a reviewer is quoting go there and the gate stays out of
-  # the way. Both directions, or the scope is a comment rather than a rule.
-  expect_reason \
-    "$(artifact quoted-in-blocker '{"agent":"reviewer-test","verdict":"action_required","summary":"reviewed the gate","blockers":[{"id":1,"title":"t","location":"tests/x.sh","description":"the fixture uses mutation: killed 0/0 to prove the gate rejects","recommendation":"r","priority":3,"estimate":1}],"suggestions":[],"qa_metadata":{}}')" \
-    valid "a zeroed citation quoted inside a blocker is out of scope"
-  expect_reason \
-    "$(artifact same-text-in-summary '{"agent":"reviewer-test","verdict":"pass","summary":"the fixture uses mutation: killed 0/0 to prove the gate rejects","blockers":[],"suggestions":[],"qa_metadata":{}}')" \
-    zero_sample "the same text in .summary is the artifact's own measurement"
-
-  # THE FINDING CLASS THE GATE EXISTS TO PROMOTE. A reviewer whose OWN harness
-  # generated nothing must be able to report it WITH the numbers. The
-  # declaration is top-level — reaching it must not require adopting the qa
-  # shape and its finding-array contract — and it produces its own reason, so
-  # an orchestrator branching on reason cannot record the domain as clean.
-  declared="$(artifact declared-failure '{"agent":"reviewer-test","verdict":"action_required","summary":"harness produced nothing: mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}')"
-  expect_reason "$declared" valid_undermeasured "a declared instrument failure keeps its zero citation"
-  expect_field "$declared" '.measurement_failed' \
-    "cargo-mutants selected 0 mutants for the changed file" \
-    "the declaration is echoed back on the check's result"
-  expect_field "$declared" '.ok' true "a declared instrument failure is still an accepted artifact"
-
-  # Following the rejection's instruction from the tolerant shape must not
-  # dead-end in a second, different refusal.
-  expect_reason \
-    "$(artifact tolerant-adopts-escape '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","measurement_failed":"cargo-mutants selected 0 mutants for this module"}')" \
-    valid_undermeasured "an artifact with no qa_metadata can adopt the escape"
-
-  # A declaration next to verdict "pass" is not a plain green.
-  expect_reason \
-    "$(artifact declared-and-pass '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}')" \
-    valid_undermeasured "verdict pass beside a declaration is never reported as plain valid"
-
-  # MUST-FAIL CONTROLS on the escape: it has to SAY something, and it is
-  # refused on its own terms rather than silently ignored.
-  # The body is assembled outside the substitution: Bash 3.2 splits a `\"`
-  # inside "$( )" at the quote and hands expect_reason the wrong words.
-  for degenerate in '"."' '"n/a"' '"none"' '"unknown"' '"   "' '"---"' 'true' '0'; do
-    degenerate_body='{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":'"$degenerate"'}'
-    expect_reason \
-      "$(artifact "degenerate-$DEGEN_N" "$degenerate_body")" \
-      invalid_declaration "a declaration of $degenerate names no instrument and is refused"
-    DEGEN_N=$((DEGEN_N + 1))
-  done
-
-  expect_field \
-    "$(artifact undeclared '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')" \
-    'has("measurement_failed")' false \
-    "an artifact declaring nothing carries no measurement_failed field"
-
-  # The rejection has to teach the declaration. A diagnostic that only accuses
-  # the reviewer makes deleting the evidence the path of least resistance.
-  expect_field \
-    "$(artifact teaching '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0"}')" \
-    '.detail | test("measurement_failed")' true \
-    "the rejection names the declaration instead of only accusing the reviewer"
-
-  # A gate that could not run is not a clean artifact. Under a jq that fails
-  # only for this gate, the answer is a loud `invalid`, never an approval.
-  shim_dir="$TMP_ROOT/jqshim"
-  mkdir -p "$shim_dir"
-  real_jq="$(command -v jq)"
-  printf '#!/usr/bin/env bash\nfor a in "$@"; do\n  case "$a" in\n    *"gate:zero-sample"*) echo "jq: error: simulated torn read" >&2; exit 5 ;;\n  esac\ndone\nexec %s "$@"\n' "$real_jq" > "$shim_dir/jq"
-  chmod +x "$shim_dir/jq"
-  clean="$(artifact clean-for-shim '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')"
-
-  # A jq diagnostic that leaves the exit status alone is not a finding: it used
-  # to be merged into the answer and echoed as a fabricated declaration.
-  chatty_dir="$TMP_ROOT/jqchatty"
-  mkdir -p "$chatty_dir"
-  printf '#!/usr/bin/env bash\necho "chatty jq diagnostic" >&2\nexec %s "$@"\n' "$(command -v jq)" > "$chatty_dir/jq"
-  chmod +x "$chatty_dir/jq"
-  set +e
-  chatty_out="$(PATH="$chatty_dir:$PATH" "$CHECK" --file "$clean" 2>/dev/null)"
-  chatty_rc=$?
-  set -e
-  chatty_reason="$(jq -r '.reason' <<<"$chatty_out" 2>/dev/null || printf 'unparseable')"
-  chatty_decl="$(jq -r 'has("measurement_failed")' <<<"$chatty_out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$chatty_reason" == "valid" && "$chatty_rc" -eq 0 && "$chatty_decl" == "false" ]]; then
-    pass "jq stderr on a successful call is neither a finding nor a fabricated declaration"
-  else
-    fail "a jq stderr diagnostic leaked into the answer (reason=$chatty_reason, rc=$chatty_rc, declared=$chatty_decl)"
-  fi
-
-  set +e
-  shim_out="$(PATH="$shim_dir:$PATH" "$CHECK" --file "$clean" 2>/dev/null)"
-  shim_rc=$?
-  set -e
-  shim_reason="$(jq -r '.reason' <<<"$shim_out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$shim_reason" == "invalid" && "$shim_rc" -ne 0 ]]; then
-    pass "a gate that could not run is reported, never read as a clean artifact"
-  else
-    fail "a broken gate was not reported (reason=$shim_reason, rc=$shim_rc)"
-  fi
+  echo "=== jq output channel table ==="
+  channel_rows=0
+  while IFS=$'\t' read -r name shim expected; do
+    case "$shim" in
+      chatty) shim_path="$chatty_dir:$PATH" ;;
+      broken) shim_path="$broken_dir:$PATH" ;;
+      *) shim_path="$PATH" ;;
+    esac
+    rc=0
+    out=""
+    out=$(PATH="$shim_path" "$CHECK" --file "$clean" 2>/dev/null) || rc=$?
+    reason=$("$real_jq" -r '.reason' <<<"$out" 2>/dev/null) || reason=unparseable
+    declaration=$("$real_jq" -r 'if has("measurement_failed") then "present" else "absent" end' <<<"$out" 2>/dev/null) || declaration=unparseable
+    case "$shim" in
+      chatty) actual="reason=$reason;rc=$rc;declaration=$declaration" ;;
+      broken)
+        nonzero=no
+        [ "$rc" -eq 0 ] || nonzero=yes
+        actual="reason=$reason;nonzero=$nonzero"
+        ;;
+    esac
+    assert_row "jq output channel" "$name" "$actual" "$expected"
+    channel_rows=$((channel_rows + 1))
+  done <<'ROWS'
+successful stderr is not a finding	chatty	reason=valid;rc=0;declaration=absent
+broken gate fails closed	broken	reason=invalid;nonzero=yes
+ROWS
+  assert_table_executed "jq output channel" "$channel_rows"
 fi
 
-echo
-printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
-[[ "$FAIL" -eq 0 ]]
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -1,24 +1,52 @@
 #!/usr/bin/env bash
 # Behavioral suite for scripts/mutation-stability.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MS="$SCRIPT_DIR/../scripts/mutation-stability"
-PASS=0 FAIL=0 rc=0 out=""
-ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
-bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        $2"; }
-run_ms() {
-  sha="$1"; shift; rc=0
-  out=$("$MS" --worktree "$REPO" --sha "$sha" "$@" 2>&1) || rc=$?
+PASS=0
+FAIL=0
+rc=0
+out=""
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "$2"; }
+
+assert_row() {
+  table="$1" name="$2" actual="$3" expected="$4"
+  if [ "$actual" = "$expected" ]; then
+    pass "$table: $name"
+  else
+    fail "$table: $name" "expected <$expected>, got <$actual>; output: $out"
+  fi
 }
-is_rc() {
-  if [ "$rc" = "$1" ]; then ok "$2"; else bad "$2" "rc=$rc out=$out"; fi
+
+assert_case() {
+  name="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected <$expected>, got <$actual>; output: $out"
+  fi
 }
-has() {
-  case "$out" in *"$1"*) ok "$2";; *) bad "$2" "$out";; esac
+
+assert_table_executed() {
+  table="$1" rows="$2"
+  if [ "$rows" -gt 0 ]; then
+    pass "$table: executed rows"
+  else
+    fail "$table: executed rows" "the table executed no assertion row"
+  fi
 }
-lacks() {
-  case "$out" in *"$1"*) bad "$2" "$out";; *) ok "$2";; esac
+
+output_has() {
+  case "$out" in
+    *"$1"*) printf 'yes' ;;
+    *) printf 'no' ;;
+  esac
 }
+
 stopped() {
   pid="$1" attempts=0
   while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
@@ -28,31 +56,191 @@ stopped() {
   ! kill -0 "$pid" 2>/dev/null
 }
 
-# Every case up to the shared-cache block below builds with `true` or a `test`
-# — nothing that keeps a cache, so nothing the copy's mtime has to outrank.
-# The two blocks that DO put a whole-second cache behind the build clear this
-# again and spend the real wait.
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
+KILL_MUTATION='before=$(cksum < lib.sh) && matches=$(grep -cF '\''add() { echo $(( $1 + $2 )); }'\'' lib.sh) && [ "$matches" -eq 1 ] && sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak && after=$(cksum < lib.sh) && [ "$before" != "$after" ]'
+
+mutation_for() {
+  case "$1" in
+    kill) mutation="$KILL_MUTATION" ;;
+    decoy) mutation='printf '\''%s\n'\'' "# decoy: still says +" >> lib.sh' ;;
+    remove) mutation='rm lib.sh' ;;
+    none) mutation='true' ;;
+    *) fail "fixture mutation" "unknown mutation token: $1"; mutation='false' ;;
+  esac
+}
+
+run_ms() {
+  sha="$1"
+  shift
+  rc=0
+  out=""
+  out=$("$MS" --worktree "$REPO" --sha "$sha" "$@" 2>&1) || rc=$?
+}
+
+resolve_sha() {
+  case "$1" in
+    base) sha="$SHA_BASE" ;;
+    flaky) sha="$SHA_FLAKY" ;;
+    cached) sha="$SHA_CACHED" ;;
+    *) fail "fixture revision" "unknown revision token: $1"; sha="$SHA_BASE" ;;
+  esac
+}
+
+# The command and process tables use stub builds, so no copied source must
+# outrank a shared build cache. The shared-cache table restores the default.
 export MUTATION_STABILITY_SETTLE=0
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/ms-test.XXXXXX") || exit 2
 trap 'rm -rf "$TMP"' EXIT
+RUNTIME_TMP="$TMP/runtime"
+mkdir -p "$RUNTIME_TMP"
+export TMPDIR="$RUNTIME_TMP"
 REPO="$TMP/repo"
 mkdir -p "$REPO"
 git -C "$REPO" init -q
 printf 'add() { echo $(( $1 + $2 )); }\n' > "$REPO/lib.sh"
-cat > "$REPO/check.sh" <<'T'
+cat > "$REPO/check.sh" <<'CASE'
 . ./lib.sh
 [ "$(add 2 3)" = 5 ]
-T
-cat > "$REPO/hang.sh" <<'T'
+CASE
+cat > "$REPO/hang.sh" <<'CASE'
 echo $$ > "$HANG_PID_FILE"
 trap '' TERM
 while :; do :; done
-T
-# The launcher is told apart inside the trap, not while this file is sourced:
-# Bash 3.2 reports $0 as `bash` at that point, whatever script it is starting.
-# Every other shell disarms itself on its first command.
-cat > "$TMP/launch-window.bashenv" <<'T'
+CASE
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm base
+SHA_BASE=$(git -C "$REPO" rev-parse HEAD)
+
+cat > "$REPO/check.sh" <<'CASE'
+. ./lib.sh
+[ "$(add 2 3)" = 5 ] || exit 1
+[ ! -f .ran ] || exit 1
+touch .ran
+CASE
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
+SHA_FLAKY=$(git -C "$REPO" rev-parse HEAD)
+
+cat > "$REPO/check.sh" <<'CASE'
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+built=0
+if [ -f "$CACHE/built.sh" ]; then
+  built=$(file_mtime "$CACHE/built.sh") || exit 2
+fi
+source_time=$(file_mtime lib.sh) || exit 2
+[ "$source_time" -le "$built" ] || cp lib.sh "$CACHE/built.sh"
+. "$CACHE/built.sh"
+[ "$(add 2 3)" = 5 ]
+CASE
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
+SHA_CACHED=$(git -C "$REPO" rev-parse HEAD)
+
+echo "=== command outcome table ==="
+command_rows=0
+while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stability threads probe expected; do
+  resolve_sha "$revision"
+  mutation_for "$mutation_token"
+  if [ "$threads" = "default" ]; then
+    run_ms "$sha" --test "$test_cmd" --build "$build_cmd" --mutate "$mutation" --stability "$stability"
+  else
+    run_ms "$sha" --test "$test_cmd" --build "$build_cmd" --mutate "$mutation" --stability "$stability" --threads "$threads"
+  fi
+  case "$probe" in
+    exact-summary)
+      actual="rc=$rc;last=${out##*$'\n'}"
+      ;;
+    killed-zero)
+      actual="rc=$rc;killed-zero=$(output_has 'mutation: killed 0/1;')"
+      ;;
+    control-failure)
+      actual="rc=$rc;before-mutation=$(output_has 'before any mutation')"
+      ;;
+    empty-selection)
+      actual="rc=$rc;empty-selection=$(output_has 'filter selected no test');survived=$(output_has 'survived')"
+      ;;
+    invalid-mutant)
+      actual="rc=$rc;invalid-mutant=$(output_has 'invalid-mutant');killed=$(output_has 'killed')"
+      ;;
+    partial-stability)
+      actual="rc=$rc;partial=$(output_has 'stability: 1/3 at 2 threads')"
+      ;;
+    *)
+      actual="unknown-probe=$probe"
+      ;;
+  esac
+  assert_row "command outcome" "$name" "$actual" "$expected"
+  command_rows=$((command_rows + 1))
+done <<'ROWS'
+killed mutant	base	bash check.sh	true	kill	2	2	exact-summary	rc=0;last=mutation: killed 1/1; stability: 2/2 at 2 threads
+surviving decoy	base	bash check.sh	true	decoy	1	default	killed-zero	rc=1;killed-zero=yes
+red before mutation	base	false	true	none	1	default	control-failure	rc=2;before-mutation=yes
+empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;empty-selection=yes;survived=no
+non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;invalid-mutant=yes;killed=no
+partial stability	flaky	bash check.sh	true	kill	3	2	partial-stability	rc=1;partial=yes
+ROWS
+assert_table_executed "command outcome" "$command_rows"
+
+run_ms "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --timeout 0
+assert_case "numeric validator rejects zero" \
+  "rc=$rc;timeout-validator=$(output_has '--timeout wants a positive integer')" \
+  "rc=2;timeout-validator=yes"
+
+echo "=== settle validation table ==="
+settle_validation_rows=0
+while IFS=$'\t' read -r name value expected; do
+  rc=0
+  out=""
+  out=$(MUTATION_STABILITY_SETTLE="$value" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+  actual="rc=$rc;setting-named=$(output_has 'MUTATION_STABILITY_SETTLE wants a whole number of seconds')"
+  assert_row "settle validation" "$name" "$actual" "$expected"
+  settle_validation_rows=$((settle_validation_rows + 1))
+done <<'ROWS'
+non-numeric settle	soon	rc=2;setting-named=yes
+over-wide settle	18446744073709551616	rc=2;setting-named=yes
+ROWS
+assert_table_executed "settle validation" "$settle_validation_rows"
+
+sleep_bin="$TMP/sleepbin"
+sleep_log="$TMP/slept"
+real_sleep=$(command -v sleep)
+mkdir -p "$sleep_bin"
+cat > "$sleep_bin/sleep" <<CASE
+#!/bin/sh
+printf '%s\n' "\$1" >>"$sleep_log"
+case "\$1" in *.*) exec "$real_sleep" "\$@" ;; esac
+CASE
+chmod +x "$sleep_bin/sleep"
+
+echo "=== settle setting table ==="
+settle_setting_rows=0
+while IFS=$'\t' read -r name setting expected; do
+  : > "$sleep_log"
+  rc=0
+  out=""
+  if [ "$setting" = "unset" ]; then
+    out=$(env -u MUTATION_STABILITY_SETTLE PATH="$sleep_bin:$PATH" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 2>&1) || rc=$?
+  else
+    out=$(env MUTATION_STABILITY_SETTLE="$setting" PATH="$sleep_bin:$PATH" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 2>&1) || rc=$?
+  fi
+  whole_sleeps=$(awk '/^[0-9]+$/ { if (seen++) printf ","; printf "%s", $0 }' "$sleep_log") || whole_sleeps=unreadable
+  [ -n "$whole_sleeps" ] || whole_sleeps=absent
+  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-warning=$(output_has 'settle: 0')"
+  assert_row "settle setting" "$name" "$actual" "$expected"
+  settle_setting_rows=$((settle_setting_rows + 1))
+done <<'ROWS'
+default settle	unset	rc=0;whole-sleeps=1,1,1;skip-warning=no
+zero settle	0	rc=0;whole-sleeps=absent;skip-warning=yes
+ROWS
+assert_table_executed "settle setting" "$settle_setting_rows"
+
+cat > "$TMP/launch-window.bashenv" <<'CASE'
 set -T
 trap '
   case "$0" in
@@ -71,214 +259,153 @@ trap '
     *) trap - DEBUG ;;
   esac
 ' DEBUG
-T
-git -C "$REPO" add -A
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
-SHA=$(git -C "$REPO" rev-parse HEAD)
+CASE
 
-run_ms "$SHA" --test 'bash check.sh' --build 'true' \
-  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 2 --threads 2
-is_rc 0 "killed mutant exits 0"
-# The LAST line, not the whole stream: the run may say something on stderr
-# first — a skipped settle boundary does — and the claim here is the shape of
-# the verdict this script ends on.
-if [ "${out##*$'\n'}" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
-
-run_ms "$SHA" --test 'bash check.sh' --build 'true' \
-  --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1
-is_rc 1 "surviving decoy mutant exits 1"
-has "mutation: killed 0/1;" "survivor reported as killed 0/1"
-
-run_ms "$SHA" --test 'false' --build 'true' --mutate 'true' --stability 1
-is_rc 2 "red-before-mutation control exits 2"
-has "before any mutation" "control names the instrument failure"
-
-run_ms "$SHA" \
-  --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
-  --build 'true' --mutate 'true' --stability 1
-is_rc 2 "an empty Cargo selection exits 2"
-has "filter selected no test" "an empty selection has its own outcome"
-lacks "survived" "an empty selection is never a surviving mutant"
-
-run_ms "$SHA" --test 'true' --build 'test -f lib.sh' \
-  --mutate 'rm lib.sh' --stability 1
-is_rc 2 "a non-compiling mutant exits 2"
-has "invalid-mutant" "a build failure reports invalid-mutant"
-lacks "killed" "a non-compiling mutant is never killed"
-
-# One invalid input proves the shared positive-integer validator.
-run_ms "$SHA" --test 'true' --build 'true' --mutate 'true' --timeout 0
-is_rc 2 "the numeric validator rejects zero"
-
-# The settle has its own validator: it admits the 0 the shared one refuses,
-# and refuses everything that is not a count of seconds.
-rc=0
-out=$(MUTATION_STABILITY_SETTLE=soon "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-is_rc 2 "a settle that is not a number of seconds exits 2"
-has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the rejected settle is named"
-
-# Width is part of that grammar: unrefused, this figure is one the shell's
-# tests read as an error and sleep waits out, so the run hangs on its first
-# write to a copy instead of reporting the setting.
-rc=0
-out=$(MUTATION_STABILITY_SETTLE=18446744073709551616 "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-is_rc 2 "a settle too wide for the arithmetic exits 2"
-has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the over-wide settle is named"
-
-# And 0 really skips the wait rather than merely shortening it. What the run
-# asked for is read off a sleep stub: the settle is the only whole-second
-# sleeper in the script, and the sub-second waits are its own polls, which the
-# stub still performs so the run behaves normally.
-mkdir -p "$TMP/sleepbin"
-cat >"$TMP/sleepbin/sleep" <<SH
-#!/bin/sh
-printf '%s\n' "\$1" >>"$TMP/slept"
-case "\$1" in *.*) exec $(command -v sleep) "\$@" ;; esac
-SH
-chmod +x "$TMP/sleepbin/sleep"
-# WANT is the number of seconds the run should have asked for, or `absent` for
-# no whole-second wait at all. The figure and not just its shape: a default
-# silently changed from 1 to 30 is still a whole number, and would read green.
-settle_arm() { # DESC EXPECTATION(seconds|absent) env-argument...
-  desc="$1"; want="$2"; shift 2
-  : >"$TMP/slept"
-  rc=0
-  out=$(env "$@" PATH="$TMP/sleepbin:$PATH" "$MS" \
-    --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' --build 'true' \
-    --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-    --stability 1 --threads 2 2>&1) || rc=$?
-  is_rc 0 "control: $desc still reaches its verdict"
-  found="$(grep -xE '[0-9]+' "$TMP/slept" | head -1 || true)"
-  [ -n "$found" ] || found=absent
-  if [ "$found" = "$want" ]; then ok "$desc"; else
-    bad "$desc" "whole-second wait $found; slept: $(tr '\n' ' ' <"$TMP/slept")"
+observe_timeout() {
+  export HANG_PID_FILE="$TMP/timeout-child.pid"
+  rm -f "$HANG_PID_FILE"
+  run_ms "$SHA_BASE" --test 'true' --build 'bash hang.sh & wait' --mutate 'true' --stability 1 --timeout 1
+  child=$(sed -n '1p' "$HANG_PID_FILE" 2>/dev/null || true)
+  child_stopped=no
+  if [ -n "$child" ] && stopped "$child"; then
+    child_stopped=yes
+  elif [ -n "$child" ]; then
+    kill -KILL "$child" 2>/dev/null || true
   fi
+  actual="rc=$rc;timeout=$(output_has 'timed out after 1s');child-stopped=$child_stopped"
 }
-settle_arm "the default settle waits one whole second" 1 -u MUTATION_STABILITY_SETTLE
-lacks "settle: 0" "the default run says nothing about a skipped boundary"
-settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
-# A verdict reached without the boundary has to be identifiable afterwards:
-# where BUILD does share a cache, a reused binary reads as a survivor and
-# nothing else in the output says why.
-has "settle: 0 — copies are not mtime-separated" \
-  "a skipped boundary is named in the run's own output"
 
-# one timeout control also checks adoption under a non-reaping PID 1.
-export HANG_PID_FILE="$TMP/timeout-child.pid"
-if command -v unshare >/dev/null 2>&1 \
-  && command -v python3 >/dev/null 2>&1 \
-  && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+observe_launch_window() {
+  export HANG_PID_FILE="$TMP/launch-window-child.pid"
+  export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
+  rm -f "$HANG_PID_FILE" "$LAUNCH_WINDOW_SIGNALLED"
   rc=0
-  out=$(unshare --user --map-root-user --pid --fork --mount-proc \
-    python3 -c '
+  out=""
+  BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'bash hang.sh & wait' --mutate 'true' --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
+  child=$(sed -n '1p' "$HANG_PID_FILE" 2>/dev/null || true)
+  signalled=no
+  [ ! -f "$LAUNCH_WINDOW_SIGNALLED" ] || signalled=yes
+  child_stopped=no
+  if [ -n "$child" ] && stopped "$child"; then
+    child_stopped=yes
+  elif [ -n "$child" ]; then
+    kill -KILL "$child" 2>/dev/null || true
+  fi
+  child_recorded=no
+  [ -z "$child" ] || child_recorded=yes
+  actual="rc=$rc;signalled=$signalled;child-recorded=$child_recorded;child-stopped=$child_stopped"
+}
+
+namespace_available=no
+if command -v unshare >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+  namespace_available=yes
+fi
+
+observe_namespace() {
+  export HANG_PID_FILE="$TMP/namespace-child.pid"
+  rm -f "$HANG_PID_FILE"
+  rc=0
+  out=""
+  out=$(unshare --user --map-root-user --pid --fork --mount-proc python3 -c '
 import glob, os, subprocess, sys, time
-env = os.environ.copy()
 run = subprocess.run([
     sys.argv[1], "--worktree", sys.argv[2], "--sha", sys.argv[3],
     "--test", "true", "--build", "bash hang.sh & wait",
     "--mutate", "true", "--stability", "1", "--timeout", "1",
-], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+], env=os.environ.copy(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 time.sleep(0.1)
 zombies = []
 for path in glob.glob("/proc/[0-9]*/stat"):
     try:
         fields = open(path).read().split()
         if fields[2] == "Z" and fields[3] == "1":
-            zombies.append((fields[0], fields[1], fields[4]))
+            zombies.append(fields[0])
     except (IndexError, OSError):
         pass
-if run.returncode != 2:
-    print("timeout exit: expected 2, got %s" % run.returncode)
-if "timed out after 1s" not in run.stderr:
-    print("missing timeout diagnostic: %s" % run.stderr)
-if zombies:
-    print("non-reaping PID 1 adopted zombies: %r" % (zombies,))
-sys.exit(0 if run.returncode == 2 and "timed out after 1s" in run.stderr and not zombies else 1)
-' "$MS" "$REPO" "$SHA" 2>&1) || rc=$?
-  is_rc 0 "a timed-out child leaves no zombies under non-reaping PID 1"
-else
-  run_ms "$SHA" --test 'true' --build 'bash hang.sh & wait' \
-    --mutate 'true' --stability 1 --timeout 1
-  is_rc 2 "a hanging child times out"
-  has "timed out after 1s" "the timeout is reported"
-  child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-  if [ -n "$child" ] && stopped "$child"; then
-    ok "the timed-out child is reaped"
-  else
-    bad "the timed-out child is reaped" "pid=${child:-missing}"
-    [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
-  fi
-fi
+print("inner-rc=%s;timeout=%s;zombies=%s" % (
+    run.returncode,
+    "yes" if "timed out after 1s" in run.stderr else "no",
+    "none" if not zombies else "present",
+))
+' "$MS" "$REPO" "$SHA_BASE" 2>&1) || rc=$?
+  actual="outer-rc=$rc;${out##*$'\n'}"
+}
 
-# One signal-gap control covers cancellation before process ownership lands.
-export HANG_PID_FILE="$TMP/launch-window-child.pid"
-export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
-rc=0
-BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'true' --build 'bash hang.sh & wait' --mutate 'true' \
-  --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
-child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ "$rc" = 143 ] && [ -f "$LAUNCH_WINDOW_SIGNALLED" ] \
-  && [ -n "$child" ] && stopped "$child"; then
-  ok "launch-window cancellation records ownership and reaps the command"
-else
-  bad "launch-window cancellation records ownership and reaps the command" \
-    "rc=$rc signal_file=$LAUNCH_WINDOW_SIGNALLED pid=${child:-missing}"
-  [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
-fi
+echo "=== process cleanup table ==="
+process_rows=0
+while IFS=$'\t' read -r name kind expected; do
+  case "$kind" in
+    timeout) observe_timeout ;;
+    launch-window) observe_launch_window ;;
+    namespace)
+      if [ "$namespace_available" = no ]; then
+        printf '  skip  process cleanup: %s (private PID namespaces unavailable)\n' "$name"
+        continue
+      fi
+      observe_namespace
+      ;;
+    *) actual="unknown-kind=$kind" ;;
+  esac
+  assert_row "process cleanup" "$name" "$actual" "$expected"
+  process_rows=$((process_rows + 1))
+done <<'ROWS'
+timed-out child exits, reports, and stops	timeout	rc=2;timeout=yes;child-stopped=yes
+launch-window cancellation owns and stops its child	launch-window	rc=143;signalled=yes;child-recorded=yes;child-stopped=yes
+non-reaping PID 1 adopts no zombie	namespace	outer-rc=0;inner-rc=2;timeout=yes;zombies=none
+ROWS
+assert_table_executed "process cleanup" "$process_rows"
 
-# A rerun that fails only after the first clean pass reports partial stability.
-cat > "$REPO/check.sh" <<'T'
-. ./lib.sh
-[ "$(add 2 3)" = 5 ] || exit 1
-[ ! -f .ran ] || exit 1
-touch .ran
-T
-git -C "$REPO" add -A
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
-SHA2=$(git -C "$REPO" rev-parse HEAD)
-run_ms "$SHA2" --test 'bash check.sh' --build 'true' \
-  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 3 --threads 2
-is_rc 1 "stability failure exits 1 even with the mutant killed"
-has "stability: 1/3 at 2 threads" "partial stability is reported as Y/N"
-
-# Shared whole-second caches must rebuild for mutant and clean copies. This is
-# the wait's whole reason, so from here the default settle is what runs.
 unset MUTATION_STABILITY_SETTLE
 export CACHE="$TMP/build-cache"
-mkdir -p "$CACHE"
-cat > "$REPO/check.sh" <<'T'
-built=0
-[ ! -f "$CACHE/built.sh" ] || built=$(stat -c %Y "$CACHE/built.sh")
-[ "$(stat -c %Y lib.sh)" -le "$built" ] || cp lib.sh "$CACHE/built.sh"
-. "$CACHE/built.sh"
-[ "$(add 2 3)" = 5 ]
-T
-git -C "$REPO" add -A
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
-SHA3=$(git -C "$REPO" rev-parse HEAD)
-run_ms "$SHA3" --test 'bash check.sh' --build 'true' \
-  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 3 --threads 2
-is_rc 0 "a shared whole-second build cache reaches the right verdict"
-has "mutation: killed 1/1" "the mutant build rebuilds instead of reusing the control"
-has "stability: 3/3 at 2 threads" "the clean copy rebuilds instead of reusing the mutant"
 
-kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-  --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
-root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
-if [ -d "$root/clean" ]; then
-  gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))
-  rm -rf "$root"
-  if [ "$gap" -ge 1 ]; then ok "each copy outranks the one before"; else bad "each copy outranks the one before" "gap=${gap}s"; fi
-else
-  bad "each copy outranks the one before" "--keep printed no temp dir: $kept"
-fi
+observe_cache_verdict() {
+  rm -rf "$CACHE"
+  mkdir -p "$CACHE"
+  run_ms "$SHA_CACHED" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 3 --threads 2
+  actual="rc=$rc;killed=$(output_has 'mutation: killed 1/1');stable=$(output_has 'stability: 3/3 at 2 threads')"
+}
 
-echo "$PASS passed, $FAIL failed"
-[ "$FAIL" = 0 ] || exit 1
+observe_kept_copies() {
+  rm -rf "$CACHE"
+  mkdir -p "$CACHE"
+  rc=0
+  out=""
+  kept=$("$MS" --worktree "$REPO" --sha "$SHA_CACHED" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 --keep 2>&1 >/dev/null) || rc=$?
+  root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p') || root=""
+  clean_present=no
+  gap_ok=no
+  case "$root" in
+    "$RUNTIME_TMP"/mutation-stability.*)
+      if [ -d "$root/clean" ]; then
+        clean_present=yes
+        mutant_time=$(file_mtime "$root/mutant/check.sh") || mutant_time=unreadable
+        clean_time=$(file_mtime "$root/clean/check.sh") || clean_time=unreadable
+        if [ "$mutant_time" != unreadable ] && [ "$clean_time" != unreadable ] && [ $((clean_time - mutant_time)) -ge 1 ]; then
+          gap_ok=yes
+        fi
+      fi
+      rm -rf "$root"
+      ;;
+  esac
+  out="$kept"
+  actual="rc=$rc;clean-present=$clean_present;mtime-gap=$gap_ok"
+}
+
+echo "=== shared build cache table ==="
+cache_rows=0
+while IFS=$'\t' read -r name kind expected; do
+  case "$kind" in
+    verdict) observe_cache_verdict ;;
+    keep) observe_kept_copies ;;
+    *) actual="unknown-kind=$kind" ;;
+  esac
+  assert_row "shared build cache" "$name" "$actual" "$expected"
+  cache_rows=$((cache_rows + 1))
+done <<'ROWS'
+mutant and clean copies both rebuild	verdict	rc=0;killed=yes;stable=yes
+kept copy times advance	keep	rc=0;clean-present=yes;mtime-gap=yes
+ROWS
+assert_table_executed "shared build cache" "$cache_rows"
+
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" = 0 ]

--- a/skills/reviewer/tests/measurement-fail-closed.test.sh
+++ b/skills/reviewer/tests/measurement-fail-closed.test.sh
@@ -1,275 +1,193 @@
 #!/usr/bin/env bash
-# Contract test for the fail-closed measurement rule: a run that produced no
-# samples is instrument failure, never a numeric or green result — and a zero
-# RESULT on a measured run is the opposite, a finding that has to reach the
-# orchestrator intact. Two halves, because the rule has two carriers:
-#
-#   a. Prose — the Ethos bullet in SKILL.md that binds every reviewer, and the
-#      schema doc's statement of both the rejection and the declaration that
-#      lets a reviewer keep its evidence.
-#   b. Behavior — orch's review-artifact-check rejecting a zero-sample artifact,
-#      accepting a measured one, and accepting a declared instrument failure. A
-#      guard proven in one direction only is a guard that could be passing
-#      vacuously, and the accepting cases are what pin WHICH number it reads.
-#
-# The behavioral half is skipped only for a reviewer-without-orch install (no
-# sibling skills/orch at all). When orch IS installed, a missing or
-# non-executable review-artifact-check is a failure, not a skip: that is
-# precisely the drift this suite exists to catch, and skipping on it would make
-# the branch fire only when it matters.
-#
-# The doc checks pin the schema's own names — `measurement_failed`, and the
-# `zero_sample`, `invalid_declaration` and `valid_undermeasured` states. The
-# gate's own behaviour is exercised against the script above, which is what
-# proves it.
+# Contract test for fail-closed reviewer measurements.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ORCH_DIR="$SKILL_DIR/../orch"
 CHECK="$ORCH_DIR/scripts/review-artifact-check"
-TMP_ROOT="$(mktemp -d)"
+TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0
 FAIL=0
+out=""
 
 pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "$2"; }
 
-require_fixed() {
-  local file="$1" needle="$2" desc="$3"
-  if grep -Fq -- "$needle" "$file"; then
-    pass "$desc"
+assert_row() {
+  table="$1" name="$2" actual="$3" expected="$4"
+  if [ "$actual" = "$expected" ]; then
+    pass "$table: $name"
   else
-    fail "$desc — missing in ${file#$SKILL_DIR/}"
+    fail "$table: $name" "expected <$expected>, got <$actual>; output: $out"
   fi
 }
 
-# artifact <name> <json> → prints the written path
+assert_table_executed() {
+  table="$1" rows="$2"
+  if [ "$rows" -gt 0 ]; then
+    pass "$table: executed rows"
+  else
+    fail "$table: executed rows" "the table executed no assertion row"
+  fi
+}
+
 artifact() {
-  local path="$TMP_ROOT/$1.json"
+  path="$TMP_ROOT/$1.json"
   printf '%s' "$2" > "$path"
   printf '%s' "$path"
 }
 
-# The reasons that mean "accepted". Exit status is the other half of the
-# contract — review-pr.md and submit-pr.md branch on it and orch's waiters use
-# it directly — so a failure that exits 0 while reporting a rejection, or
-# non-zero on an acceptance, has to fail here and not just look odd.
-is_accepting_reason() {
-  [[ "$1" == "valid" || "$1" == "valid_undermeasured" ]]
-}
-
-# expect_reason <artifact-path> <expected-reason> <desc>
-expect_reason() {
-  local path="$1" want="$2" desc="$3" out rc=0 got want_rc
-  set +e
-  out="$("$CHECK" --file "$path" 2>/dev/null)"
-  rc=$?
-  set -e
-  got="$(jq -r '.reason' <<<"$out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$got" == "$want" ]]; then
-    pass "$desc"
-  else
-    fail "$desc — expected reason=$want, got reason=$got (rc=$rc)"
-  fi
-  if is_accepting_reason "$want"; then
-    want_rc="exit 0"
-    [[ "$rc" -eq 0 ]] && pass "$desc (exits 0)" || fail "$desc — reason=$want is an acceptance but the check exited $rc"
-  else
-    want_rc="a non-zero exit"
-    [[ "$rc" -ne 0 ]] && pass "$desc (exits non-zero)" || fail "$desc — reason=$want is a rejection but the check exited 0"
+read_result() {
+  path="$1"
+  rc=0
+  out=""
+  out=$("$CHECK" --file "$path" 2>/dev/null) || rc=$?
+  reason=$(jq -r '.reason' <<<"$out" 2>/dev/null) || reason=unparseable
+  ok=$(jq -r '.ok' <<<"$out" 2>/dev/null) || ok=unparseable
+  declaration=$(jq -r 'if has("measurement_failed") then .measurement_failed else "ABSENT" end' <<<"$out" 2>/dev/null) || declaration=unparseable
+  consistent=no
+  if { [ "$ok" = true ] && [ "$rc" -eq 0 ]; } || { [ "$ok" = false ] && [ "$rc" -ne 0 ]; }; then
+    consistent=yes
   fi
 }
 
-# expect_field <artifact-path> <jq-filter> <expected> <desc>
-# No expected reason here, so the status is checked against the result's own
-# `.ok` — exit 0 exactly when the artifact was accepted.
-expect_field() {
-  local path="$1" filter="$2" want="$3" desc="$4" out got rc=0 ok
-  set +e
-  out="$("$CHECK" --file "$path" 2>/dev/null)"
-  rc=$?
-  set -e
-  got="$(jq -r "$filter" <<<"$out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$got" == "$want" ]]; then
-    pass "$desc"
+echo "=== documentation shape table ==="
+# These rows prove token presence only. The behavior table proves enforcement.
+documentation_rows=0
+while IFS=$'\t' read -r name relative_path token; do
+  if grep -Fq -- "$token" "$SKILL_DIR/$relative_path"; then
+    actual=present
   else
-    fail "$desc — expected '$want', got '$got'"
+    actual=missing
   fi
-  ok="$(jq -r '.ok' <<<"$out" 2>/dev/null || printf 'unparseable')"
-  if { [[ "$ok" == "true" && "$rc" -eq 0 ]] || [[ "$ok" == "false" && "$rc" -ne 0 ]]; }; then
-    pass "$desc (exit status agrees with .ok)"
-  else
-    fail "$desc — .ok=$ok but the check exited $rc"
-  fi
-}
+  out="$relative_path lacks $token"
+  assert_row "documentation shape" "$name" "$actual" present
+  documentation_rows=$((documentation_rows + 1))
+done <<'ROWS'
+reviewer skill names the declaration	SKILL.md	measurement_failed
+schema names the zero-sample rejection	schemas/review-finding.md	zero_sample
+schema names the declaration field	schemas/review-finding.md	measurement_failed
+schema names an invalid declaration	schemas/review-finding.md	invalid_declaration
+schema names accepted undermeasurement	schemas/review-finding.md	valid_undermeasured
+ROWS
+assert_table_executed "documentation shape" "$documentation_rows"
 
-DEGEN_N=1
-
-echo "=== reviewer measurement fail-closed contract ==="
-
-skill="$SKILL_DIR/SKILL.md"
-schema="$SKILL_DIR/schemas/review-finding.md"
-[[ -f "$skill" ]] || { echo "FAIL: SKILL.md not found" >&2; exit 1; }
-[[ -f "$schema" ]] || { echo "FAIL: schemas/review-finding.md not found" >&2; exit 1; }
-
-# --- a. the rule is stated where every reviewer loads it ---
-
-require_fixed "$skill" 'measurement_failed' 'Ethos names the declaration, so evidence is kept not deleted'
-require_fixed "$schema" 'zero_sample' 'schema doc names the rejection reason'
-require_fixed "$schema" 'measurement_failed' 'schema doc specifies the declaration field'
-require_fixed "$schema" 'invalid_declaration' 'schema doc names the bar a declaration must clear'
-require_fixed "$schema" 'valid_undermeasured' 'schema doc names the state a declaration produces'
-
-# --- b. the gate enforces it, in both directions ---
-
-if [[ ! -d "$ORCH_DIR" ]]; then
-  echo "  skip  sibling skills/orch is not installed (reviewer-without-orch)"
-elif [[ ! -x "$CHECK" ]]; then
-  fail "skills/orch is installed but review-artifact-check is missing or not executable at $CHECK"
+if [ ! -d "$ORCH_DIR" ]; then
+  printf '  skip  artifact tables (sibling skills/orch is not installed)\n'
+elif [ ! -x "$CHECK" ]; then
+  fail "artifact acceptance table" "skills/orch is installed but review-artifact-check is missing or not executable at $CHECK"
 else
-  # A zero SAMPLE COUNT is the failure shape: a selection or quoting fault runs
-  # nothing, the pipeline still exits 0, and the citation reads as evidence.
-  expect_reason \
-    "$(artifact zero-mutants '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0; stability: 10/10 at 16 threads"}')" \
-    zero_sample "gate rejects a zero-mutant mutation citation"
-  expect_reason \
-    "$(artifact zero-runs '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 0/0 at 16 threads"}')" \
-    zero_sample "gate rejects a zero-run stability citation"
-  expect_reason \
-    "$(artifact zero-threads '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 0 threads"}')" \
-    zero_sample "gate rejects elevated parallelism of zero threads"
-  expect_reason \
-    "$(artifact wrapped-citation '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/\n0"}')" \
-    zero_sample "gate sees a citation its author wrapped across a newline"
-  expect_reason \
-    "$(artifact zero-percentiles '{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":0}}}}')" \
-    zero_sample "gate rejects an all-zero benchmark percentile block"
-  expect_reason \
-    "$(artifact absent-percentiles '{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"regression_pct":0}}}')" \
-    zero_sample "gate rejects a perf payload that omits percentiles entirely"
+  echo "=== artifact acceptance and declaration table ==="
+  artifact_rows=0
+  while IFS=$'\t' read -r name body probe expected; do
+    path=$(artifact "$name" "$body") || {
+      fail "artifact acceptance and declaration: $name" "could not write fixture"
+      continue
+    }
+    read_result "$path"
+    case "$probe" in
+      reason)
+        actual="reason=$reason;rc=$rc"
+        ;;
+      declared)
+        actual="reason=$reason;rc=$rc;declaration=$declaration;ok=$ok;consistent=$consistent"
+        ;;
+      absent-declaration)
+        actual="declaration=$declaration;consistent=$consistent"
+        ;;
+      teaching)
+        teaches=$(jq -r '.detail | test("measurement_failed")' <<<"$out" 2>/dev/null) || teaches=unparseable
+        actual="teaches=$teaches;consistent=$consistent"
+        ;;
+      *)
+        actual="unknown-probe=$probe"
+        ;;
+    esac
+    assert_row "artifact acceptance and declaration" "$name" "$actual" "$expected"
+    artifact_rows=$((artifact_rows + 1))
+  done <<'ROWS'
+zero mutants	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0; stability: 10/10 at 16 threads"}	reason	reason=zero_sample;rc=1
+zero stability runs	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 0/0 at 16 threads"}	reason	reason=zero_sample;rc=1
+zero threads	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 0 threads"}	reason	reason=zero_sample;rc=1
+wrapped citation	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/\n0"}	reason	reason=zero_sample;rc=1
+zero percentiles	{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":0}}}}	reason	reason=zero_sample;rc=1
+absent percentiles	{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"regression_pct":0}}}	reason	reason=zero_sample;rc=1
+measured stability failure	{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 3/3; stability: 0/10 at 16 threads"}	reason	reason=valid;rc=0
+surviving mutants	{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 0/3; stability: 10/10 at 16 threads"}	reason	reason=valid;rc=0
+measured citation	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}	reason	reason=valid;rc=0
+measured percentiles	{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":4.2}}}}	reason	reason=valid;rc=0
+uncited artifact	{"agent":"reviewer-quality","verdict":"pass","summary":"no measurement in scope for this domain"}	reason	reason=valid;rc=0
+quoted in blocker	{"agent":"reviewer-test","verdict":"action_required","summary":"reviewed the gate","blockers":[{"id":1,"title":"t","location":"tests/x.sh","description":"the fixture uses mutation: killed 0/0 to prove the gate rejects","recommendation":"r","priority":3,"estimate":1}],"suggestions":[],"qa_metadata":{}}	reason	reason=valid;rc=0
+same text in summary	{"agent":"reviewer-test","verdict":"pass","summary":"the fixture uses mutation: killed 0/0 to prove the gate rejects","blockers":[],"suggestions":[],"qa_metadata":{}}	reason	reason=zero_sample;rc=1
+declared failure	{"agent":"reviewer-test","verdict":"action_required","summary":"harness produced nothing: mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}	declared	reason=valid_undermeasured;rc=0;declaration=cargo-mutants selected 0 mutants for the changed file;ok=true;consistent=yes
+tolerant shape adopts declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","measurement_failed":"cargo-mutants selected 0 mutants for this module"}	reason	reason=valid_undermeasured;rc=0
+pass verdict with declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}	reason	reason=valid_undermeasured;rc=0
+period declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"."}	reason	reason=invalid_declaration;rc=1
+n-a declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"n/a"}	reason	reason=invalid_declaration;rc=1
+none declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"none"}	reason	reason=invalid_declaration;rc=1
+unknown declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"unknown"}	reason	reason=invalid_declaration;rc=1
+whitespace declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"   "}	reason	reason=invalid_declaration;rc=1
+dashes declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"---"}	reason	reason=invalid_declaration;rc=1
+boolean declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":true}	reason	reason=invalid_declaration;rc=1
+numeric declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":0}	reason	reason=invalid_declaration;rc=1
+undeclared field stays absent	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}	absent-declaration	declaration=ABSENT;consistent=yes
+rejection teaches declaration	{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0"}	teaching	teaches=true;consistent=yes
+ROWS
+  assert_table_executed "artifact acceptance and declaration" "$artifact_rows"
 
-  # ACCEPTING DIRECTION, part one: a zero RESULT on a measured run. SKILL.md
-  # calls a stability failure "never a pass" — the gate must let it through as
-  # the finding, and these two cases are what prove the gate reads the sample
-  # count rather than the result.
-  expect_reason \
-    "$(artifact measured-stability-failure '{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 3/3; stability: 0/10 at 16 threads"}')" \
-    valid "gate accepts stability 0/10 — ten measured runs, none passed"
-  expect_reason \
-    "$(artifact surviving-mutants '{"agent":"reviewer-test","verdict":"action_required","summary":"mutation: killed 0/3; stability: 10/10 at 16 threads"}')" \
-    valid "gate accepts mutation killed 0/3 — three mutants, none killed"
+  real_jq=$(command -v jq)
+  chatty_dir="$TMP_ROOT/jq-chatty"
+  broken_dir="$TMP_ROOT/jq-broken"
+  mkdir -p "$chatty_dir" "$broken_dir"
+  cat > "$chatty_dir/jq" <<SHIM
+#!/usr/bin/env bash
+echo "chatty jq diagnostic" >&2
+exec "$real_jq" "\$@"
+SHIM
+  cat > "$broken_dir/jq" <<SHIM
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  case "\$arg" in
+    *"gate:zero-sample"*) echo "jq: error: simulated torn read" >&2; exit 5 ;;
+  esac
+done
+exec "$real_jq" "\$@"
+SHIM
+  chmod +x "$chatty_dir/jq" "$broken_dir/jq"
+  clean=$(artifact clean-channel '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')
 
-  # ACCEPTING DIRECTION, part two: real samples, and no citation at all.
-  expect_reason \
-    "$(artifact measured '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')" \
-    valid "gate accepts a citation with real samples"
-  expect_reason \
-    "$(artifact measured-percentiles '{"agent":"reviewer-perf","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"qa_metadata":{"perf_qa":{"percentiles":{"p50":0,"p99":4.2}}}}')" \
-    valid "gate accepts a percentile block carrying a real number"
-  expect_reason \
-    "$(artifact uncited '{"agent":"reviewer-quality","verdict":"pass","summary":"no measurement in scope for this domain"}')" \
-    valid "gate leaves an artifact citing no measurement alone"
-
-  # QUOTING SOMEBODY ELSE'S ZEROED RUN. .summary and .qa_metadata carry the
-  # artifact's own measurements; the finding arrays describe the code under
-  # review, so numbers a reviewer is quoting go there and the gate stays out of
-  # the way. Both directions, or the scope is a comment rather than a rule.
-  expect_reason \
-    "$(artifact quoted-in-blocker '{"agent":"reviewer-test","verdict":"action_required","summary":"reviewed the gate","blockers":[{"id":1,"title":"t","location":"tests/x.sh","description":"the fixture uses mutation: killed 0/0 to prove the gate rejects","recommendation":"r","priority":3,"estimate":1}],"suggestions":[],"qa_metadata":{}}')" \
-    valid "a zeroed citation quoted inside a blocker is out of scope"
-  expect_reason \
-    "$(artifact same-text-in-summary '{"agent":"reviewer-test","verdict":"pass","summary":"the fixture uses mutation: killed 0/0 to prove the gate rejects","blockers":[],"suggestions":[],"qa_metadata":{}}')" \
-    zero_sample "the same text in .summary is the artifact's own measurement"
-
-  # THE FINDING CLASS THE GATE EXISTS TO PROMOTE. A reviewer whose OWN harness
-  # generated nothing must be able to report it WITH the numbers. The
-  # declaration is top-level — reaching it must not require adopting the qa
-  # shape and its finding-array contract — and it produces its own reason, so
-  # an orchestrator branching on reason cannot record the domain as clean.
-  declared="$(artifact declared-failure '{"agent":"reviewer-test","verdict":"action_required","summary":"harness produced nothing: mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}')"
-  expect_reason "$declared" valid_undermeasured "a declared instrument failure keeps its zero citation"
-  expect_field "$declared" '.measurement_failed' \
-    "cargo-mutants selected 0 mutants for the changed file" \
-    "the declaration is echoed back on the check's result"
-  expect_field "$declared" '.ok' true "a declared instrument failure is still an accepted artifact"
-
-  # Following the rejection's instruction from the tolerant shape must not
-  # dead-end in a second, different refusal.
-  expect_reason \
-    "$(artifact tolerant-adopts-escape '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","measurement_failed":"cargo-mutants selected 0 mutants for this module"}')" \
-    valid_undermeasured "an artifact with no qa_metadata can adopt the escape"
-
-  # A declaration next to verdict "pass" is not a plain green.
-  expect_reason \
-    "$(artifact declared-and-pass '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":"cargo-mutants selected 0 mutants for the changed file"}')" \
-    valid_undermeasured "verdict pass beside a declaration is never reported as plain valid"
-
-  # MUST-FAIL CONTROLS on the escape: it has to SAY something, and it is
-  # refused on its own terms rather than silently ignored.
-  # The body is assembled outside the substitution: Bash 3.2 splits a `\"`
-  # inside "$( )" at the quote and hands expect_reason the wrong words.
-  for degenerate in '"."' '"n/a"' '"none"' '"unknown"' '"   "' '"---"' 'true' '0'; do
-    degenerate_body='{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":'"$degenerate"'}'
-    expect_reason \
-      "$(artifact "degenerate-$DEGEN_N" "$degenerate_body")" \
-      invalid_declaration "a declaration of $degenerate names no instrument and is refused"
-    DEGEN_N=$((DEGEN_N + 1))
-  done
-
-  expect_field \
-    "$(artifact undeclared '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')" \
-    'has("measurement_failed")' false \
-    "an artifact declaring nothing carries no measurement_failed field"
-
-  # The rejection has to teach the declaration. A diagnostic that only accuses
-  # the reviewer makes deleting the evidence the path of least resistance.
-  expect_field \
-    "$(artifact teaching '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0"}')" \
-    '.detail | test("measurement_failed")' true \
-    "the rejection names the declaration instead of only accusing the reviewer"
-
-  # A gate that could not run is not a clean artifact. Under a jq that fails
-  # only for this gate, the answer is a loud `invalid`, never an approval.
-  shim_dir="$TMP_ROOT/jqshim"
-  mkdir -p "$shim_dir"
-  real_jq="$(command -v jq)"
-  printf '#!/usr/bin/env bash\nfor a in "$@"; do\n  case "$a" in\n    *"gate:zero-sample"*) echo "jq: error: simulated torn read" >&2; exit 5 ;;\n  esac\ndone\nexec %s "$@"\n' "$real_jq" > "$shim_dir/jq"
-  chmod +x "$shim_dir/jq"
-  clean="$(artifact clean-for-shim '{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 3/3; stability: 10/10 at 16 threads"}')"
-
-  # A jq diagnostic that leaves the exit status alone is not a finding: it used
-  # to be merged into the answer and echoed as a fabricated declaration.
-  chatty_dir="$TMP_ROOT/jqchatty"
-  mkdir -p "$chatty_dir"
-  printf '#!/usr/bin/env bash\necho "chatty jq diagnostic" >&2\nexec %s "$@"\n' "$(command -v jq)" > "$chatty_dir/jq"
-  chmod +x "$chatty_dir/jq"
-  set +e
-  chatty_out="$(PATH="$chatty_dir:$PATH" "$CHECK" --file "$clean" 2>/dev/null)"
-  chatty_rc=$?
-  set -e
-  chatty_reason="$(jq -r '.reason' <<<"$chatty_out" 2>/dev/null || printf 'unparseable')"
-  chatty_decl="$(jq -r 'has("measurement_failed")' <<<"$chatty_out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$chatty_reason" == "valid" && "$chatty_rc" -eq 0 && "$chatty_decl" == "false" ]]; then
-    pass "jq stderr on a successful call is neither a finding nor a fabricated declaration"
-  else
-    fail "a jq stderr diagnostic leaked into the answer (reason=$chatty_reason, rc=$chatty_rc, declared=$chatty_decl)"
-  fi
-
-  set +e
-  shim_out="$(PATH="$shim_dir:$PATH" "$CHECK" --file "$clean" 2>/dev/null)"
-  shim_rc=$?
-  set -e
-  shim_reason="$(jq -r '.reason' <<<"$shim_out" 2>/dev/null || printf 'unparseable')"
-  if [[ "$shim_reason" == "invalid" && "$shim_rc" -ne 0 ]]; then
-    pass "a gate that could not run is reported, never read as a clean artifact"
-  else
-    fail "a broken gate was not reported (reason=$shim_reason, rc=$shim_rc)"
-  fi
+  echo "=== jq output channel table ==="
+  channel_rows=0
+  while IFS=$'\t' read -r name shim expected; do
+    case "$shim" in
+      chatty) shim_path="$chatty_dir:$PATH" ;;
+      broken) shim_path="$broken_dir:$PATH" ;;
+      *) shim_path="$PATH" ;;
+    esac
+    rc=0
+    out=""
+    out=$(PATH="$shim_path" "$CHECK" --file "$clean" 2>/dev/null) || rc=$?
+    reason=$("$real_jq" -r '.reason' <<<"$out" 2>/dev/null) || reason=unparseable
+    declaration=$("$real_jq" -r 'if has("measurement_failed") then "present" else "absent" end' <<<"$out" 2>/dev/null) || declaration=unparseable
+    case "$shim" in
+      chatty) actual="reason=$reason;rc=$rc;declaration=$declaration" ;;
+      broken)
+        nonzero=no
+        [ "$rc" -eq 0 ] || nonzero=yes
+        actual="reason=$reason;nonzero=$nonzero"
+        ;;
+    esac
+    assert_row "jq output channel" "$name" "$actual" "$expected"
+    channel_rows=$((channel_rows + 1))
+  done <<'ROWS'
+successful stderr is not a finding	chatty	reason=valid;rc=0;declaration=absent
+broken gate fails closed	broken	reason=invalid;nonzero=yes
+ROWS
+  assert_table_executed "jq output channel" "$channel_rows"
 fi
 
-echo
-printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
-[[ "$FAIL" -eq 0 ]]
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -1,24 +1,52 @@
 #!/usr/bin/env bash
 # Behavioral suite for scripts/mutation-stability.
 set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MS="$SCRIPT_DIR/../scripts/mutation-stability"
-PASS=0 FAIL=0 rc=0 out=""
-ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
-bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        $2"; }
-run_ms() {
-  sha="$1"; shift; rc=0
-  out=$("$MS" --worktree "$REPO" --sha "$sha" "$@" 2>&1) || rc=$?
+PASS=0
+FAIL=0
+rc=0
+out=""
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "$2"; }
+
+assert_row() {
+  table="$1" name="$2" actual="$3" expected="$4"
+  if [ "$actual" = "$expected" ]; then
+    pass "$table: $name"
+  else
+    fail "$table: $name" "expected <$expected>, got <$actual>; output: $out"
+  fi
 }
-is_rc() {
-  if [ "$rc" = "$1" ]; then ok "$2"; else bad "$2" "rc=$rc out=$out"; fi
+
+assert_case() {
+  name="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected <$expected>, got <$actual>; output: $out"
+  fi
 }
-has() {
-  case "$out" in *"$1"*) ok "$2";; *) bad "$2" "$out";; esac
+
+assert_table_executed() {
+  table="$1" rows="$2"
+  if [ "$rows" -gt 0 ]; then
+    pass "$table: executed rows"
+  else
+    fail "$table: executed rows" "the table executed no assertion row"
+  fi
 }
-lacks() {
-  case "$out" in *"$1"*) bad "$2" "$out";; *) ok "$2";; esac
+
+output_has() {
+  case "$out" in
+    *"$1"*) printf 'yes' ;;
+    *) printf 'no' ;;
+  esac
 }
+
 stopped() {
   pid="$1" attempts=0
   while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
@@ -28,31 +56,191 @@ stopped() {
   ! kill -0 "$pid" 2>/dev/null
 }
 
-# Every case up to the shared-cache block below builds with `true` or a `test`
-# — nothing that keeps a cache, so nothing the copy's mtime has to outrank.
-# The two blocks that DO put a whole-second cache behind the build clear this
-# again and spend the real wait.
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
+KILL_MUTATION='before=$(cksum < lib.sh) && matches=$(grep -cF '\''add() { echo $(( $1 + $2 )); }'\'' lib.sh) && [ "$matches" -eq 1 ] && sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak && after=$(cksum < lib.sh) && [ "$before" != "$after" ]'
+
+mutation_for() {
+  case "$1" in
+    kill) mutation="$KILL_MUTATION" ;;
+    decoy) mutation='printf '\''%s\n'\'' "# decoy: still says +" >> lib.sh' ;;
+    remove) mutation='rm lib.sh' ;;
+    none) mutation='true' ;;
+    *) fail "fixture mutation" "unknown mutation token: $1"; mutation='false' ;;
+  esac
+}
+
+run_ms() {
+  sha="$1"
+  shift
+  rc=0
+  out=""
+  out=$("$MS" --worktree "$REPO" --sha "$sha" "$@" 2>&1) || rc=$?
+}
+
+resolve_sha() {
+  case "$1" in
+    base) sha="$SHA_BASE" ;;
+    flaky) sha="$SHA_FLAKY" ;;
+    cached) sha="$SHA_CACHED" ;;
+    *) fail "fixture revision" "unknown revision token: $1"; sha="$SHA_BASE" ;;
+  esac
+}
+
+# The command and process tables use stub builds, so no copied source must
+# outrank a shared build cache. The shared-cache table restores the default.
 export MUTATION_STABILITY_SETTLE=0
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/ms-test.XXXXXX") || exit 2
 trap 'rm -rf "$TMP"' EXIT
+RUNTIME_TMP="$TMP/runtime"
+mkdir -p "$RUNTIME_TMP"
+export TMPDIR="$RUNTIME_TMP"
 REPO="$TMP/repo"
 mkdir -p "$REPO"
 git -C "$REPO" init -q
 printf 'add() { echo $(( $1 + $2 )); }\n' > "$REPO/lib.sh"
-cat > "$REPO/check.sh" <<'T'
+cat > "$REPO/check.sh" <<'CASE'
 . ./lib.sh
 [ "$(add 2 3)" = 5 ]
-T
-cat > "$REPO/hang.sh" <<'T'
+CASE
+cat > "$REPO/hang.sh" <<'CASE'
 echo $$ > "$HANG_PID_FILE"
 trap '' TERM
 while :; do :; done
-T
-# The launcher is told apart inside the trap, not while this file is sourced:
-# Bash 3.2 reports $0 as `bash` at that point, whatever script it is starting.
-# Every other shell disarms itself on its first command.
-cat > "$TMP/launch-window.bashenv" <<'T'
+CASE
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm base
+SHA_BASE=$(git -C "$REPO" rev-parse HEAD)
+
+cat > "$REPO/check.sh" <<'CASE'
+. ./lib.sh
+[ "$(add 2 3)" = 5 ] || exit 1
+[ ! -f .ran ] || exit 1
+touch .ran
+CASE
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
+SHA_FLAKY=$(git -C "$REPO" rev-parse HEAD)
+
+cat > "$REPO/check.sh" <<'CASE'
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+built=0
+if [ -f "$CACHE/built.sh" ]; then
+  built=$(file_mtime "$CACHE/built.sh") || exit 2
+fi
+source_time=$(file_mtime lib.sh) || exit 2
+[ "$source_time" -le "$built" ] || cp lib.sh "$CACHE/built.sh"
+. "$CACHE/built.sh"
+[ "$(add 2 3)" = 5 ]
+CASE
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
+SHA_CACHED=$(git -C "$REPO" rev-parse HEAD)
+
+echo "=== command outcome table ==="
+command_rows=0
+while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stability threads probe expected; do
+  resolve_sha "$revision"
+  mutation_for "$mutation_token"
+  if [ "$threads" = "default" ]; then
+    run_ms "$sha" --test "$test_cmd" --build "$build_cmd" --mutate "$mutation" --stability "$stability"
+  else
+    run_ms "$sha" --test "$test_cmd" --build "$build_cmd" --mutate "$mutation" --stability "$stability" --threads "$threads"
+  fi
+  case "$probe" in
+    exact-summary)
+      actual="rc=$rc;last=${out##*$'\n'}"
+      ;;
+    killed-zero)
+      actual="rc=$rc;killed-zero=$(output_has 'mutation: killed 0/1;')"
+      ;;
+    control-failure)
+      actual="rc=$rc;before-mutation=$(output_has 'before any mutation')"
+      ;;
+    empty-selection)
+      actual="rc=$rc;empty-selection=$(output_has 'filter selected no test');survived=$(output_has 'survived')"
+      ;;
+    invalid-mutant)
+      actual="rc=$rc;invalid-mutant=$(output_has 'invalid-mutant');killed=$(output_has 'killed')"
+      ;;
+    partial-stability)
+      actual="rc=$rc;partial=$(output_has 'stability: 1/3 at 2 threads')"
+      ;;
+    *)
+      actual="unknown-probe=$probe"
+      ;;
+  esac
+  assert_row "command outcome" "$name" "$actual" "$expected"
+  command_rows=$((command_rows + 1))
+done <<'ROWS'
+killed mutant	base	bash check.sh	true	kill	2	2	exact-summary	rc=0;last=mutation: killed 1/1; stability: 2/2 at 2 threads
+surviving decoy	base	bash check.sh	true	decoy	1	default	killed-zero	rc=1;killed-zero=yes
+red before mutation	base	false	true	none	1	default	control-failure	rc=2;before-mutation=yes
+empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;empty-selection=yes;survived=no
+non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;invalid-mutant=yes;killed=no
+partial stability	flaky	bash check.sh	true	kill	3	2	partial-stability	rc=1;partial=yes
+ROWS
+assert_table_executed "command outcome" "$command_rows"
+
+run_ms "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --timeout 0
+assert_case "numeric validator rejects zero" \
+  "rc=$rc;timeout-validator=$(output_has '--timeout wants a positive integer')" \
+  "rc=2;timeout-validator=yes"
+
+echo "=== settle validation table ==="
+settle_validation_rows=0
+while IFS=$'\t' read -r name value expected; do
+  rc=0
+  out=""
+  out=$(MUTATION_STABILITY_SETTLE="$value" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+  actual="rc=$rc;setting-named=$(output_has 'MUTATION_STABILITY_SETTLE wants a whole number of seconds')"
+  assert_row "settle validation" "$name" "$actual" "$expected"
+  settle_validation_rows=$((settle_validation_rows + 1))
+done <<'ROWS'
+non-numeric settle	soon	rc=2;setting-named=yes
+over-wide settle	18446744073709551616	rc=2;setting-named=yes
+ROWS
+assert_table_executed "settle validation" "$settle_validation_rows"
+
+sleep_bin="$TMP/sleepbin"
+sleep_log="$TMP/slept"
+real_sleep=$(command -v sleep)
+mkdir -p "$sleep_bin"
+cat > "$sleep_bin/sleep" <<CASE
+#!/bin/sh
+printf '%s\n' "\$1" >>"$sleep_log"
+case "\$1" in *.*) exec "$real_sleep" "\$@" ;; esac
+CASE
+chmod +x "$sleep_bin/sleep"
+
+echo "=== settle setting table ==="
+settle_setting_rows=0
+while IFS=$'\t' read -r name setting expected; do
+  : > "$sleep_log"
+  rc=0
+  out=""
+  if [ "$setting" = "unset" ]; then
+    out=$(env -u MUTATION_STABILITY_SETTLE PATH="$sleep_bin:$PATH" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 2>&1) || rc=$?
+  else
+    out=$(env MUTATION_STABILITY_SETTLE="$setting" PATH="$sleep_bin:$PATH" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 2>&1) || rc=$?
+  fi
+  whole_sleeps=$(awk '/^[0-9]+$/ { if (seen++) printf ","; printf "%s", $0 }' "$sleep_log") || whole_sleeps=unreadable
+  [ -n "$whole_sleeps" ] || whole_sleeps=absent
+  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-warning=$(output_has 'settle: 0')"
+  assert_row "settle setting" "$name" "$actual" "$expected"
+  settle_setting_rows=$((settle_setting_rows + 1))
+done <<'ROWS'
+default settle	unset	rc=0;whole-sleeps=1,1,1;skip-warning=no
+zero settle	0	rc=0;whole-sleeps=absent;skip-warning=yes
+ROWS
+assert_table_executed "settle setting" "$settle_setting_rows"
+
+cat > "$TMP/launch-window.bashenv" <<'CASE'
 set -T
 trap '
   case "$0" in
@@ -71,214 +259,153 @@ trap '
     *) trap - DEBUG ;;
   esac
 ' DEBUG
-T
-git -C "$REPO" add -A
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
-SHA=$(git -C "$REPO" rev-parse HEAD)
+CASE
 
-run_ms "$SHA" --test 'bash check.sh' --build 'true' \
-  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 2 --threads 2
-is_rc 0 "killed mutant exits 0"
-# The LAST line, not the whole stream: the run may say something on stderr
-# first — a skipped settle boundary does — and the claim here is the shape of
-# the verdict this script ends on.
-if [ "${out##*$'\n'}" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
-
-run_ms "$SHA" --test 'bash check.sh' --build 'true' \
-  --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1
-is_rc 1 "surviving decoy mutant exits 1"
-has "mutation: killed 0/1;" "survivor reported as killed 0/1"
-
-run_ms "$SHA" --test 'false' --build 'true' --mutate 'true' --stability 1
-is_rc 2 "red-before-mutation control exits 2"
-has "before any mutation" "control names the instrument failure"
-
-run_ms "$SHA" \
-  --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
-  --build 'true' --mutate 'true' --stability 1
-is_rc 2 "an empty Cargo selection exits 2"
-has "filter selected no test" "an empty selection has its own outcome"
-lacks "survived" "an empty selection is never a surviving mutant"
-
-run_ms "$SHA" --test 'true' --build 'test -f lib.sh' \
-  --mutate 'rm lib.sh' --stability 1
-is_rc 2 "a non-compiling mutant exits 2"
-has "invalid-mutant" "a build failure reports invalid-mutant"
-lacks "killed" "a non-compiling mutant is never killed"
-
-# One invalid input proves the shared positive-integer validator.
-run_ms "$SHA" --test 'true' --build 'true' --mutate 'true' --timeout 0
-is_rc 2 "the numeric validator rejects zero"
-
-# The settle has its own validator: it admits the 0 the shared one refuses,
-# and refuses everything that is not a count of seconds.
-rc=0
-out=$(MUTATION_STABILITY_SETTLE=soon "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-is_rc 2 "a settle that is not a number of seconds exits 2"
-has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the rejected settle is named"
-
-# Width is part of that grammar: unrefused, this figure is one the shell's
-# tests read as an error and sleep waits out, so the run hangs on its first
-# write to a copy instead of reporting the setting.
-rc=0
-out=$(MUTATION_STABILITY_SETTLE=18446744073709551616 "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-is_rc 2 "a settle too wide for the arithmetic exits 2"
-has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the over-wide settle is named"
-
-# And 0 really skips the wait rather than merely shortening it. What the run
-# asked for is read off a sleep stub: the settle is the only whole-second
-# sleeper in the script, and the sub-second waits are its own polls, which the
-# stub still performs so the run behaves normally.
-mkdir -p "$TMP/sleepbin"
-cat >"$TMP/sleepbin/sleep" <<SH
-#!/bin/sh
-printf '%s\n' "\$1" >>"$TMP/slept"
-case "\$1" in *.*) exec $(command -v sleep) "\$@" ;; esac
-SH
-chmod +x "$TMP/sleepbin/sleep"
-# WANT is the number of seconds the run should have asked for, or `absent` for
-# no whole-second wait at all. The figure and not just its shape: a default
-# silently changed from 1 to 30 is still a whole number, and would read green.
-settle_arm() { # DESC EXPECTATION(seconds|absent) env-argument...
-  desc="$1"; want="$2"; shift 2
-  : >"$TMP/slept"
-  rc=0
-  out=$(env "$@" PATH="$TMP/sleepbin:$PATH" "$MS" \
-    --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' --build 'true' \
-    --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-    --stability 1 --threads 2 2>&1) || rc=$?
-  is_rc 0 "control: $desc still reaches its verdict"
-  found="$(grep -xE '[0-9]+' "$TMP/slept" | head -1 || true)"
-  [ -n "$found" ] || found=absent
-  if [ "$found" = "$want" ]; then ok "$desc"; else
-    bad "$desc" "whole-second wait $found; slept: $(tr '\n' ' ' <"$TMP/slept")"
+observe_timeout() {
+  export HANG_PID_FILE="$TMP/timeout-child.pid"
+  rm -f "$HANG_PID_FILE"
+  run_ms "$SHA_BASE" --test 'true' --build 'bash hang.sh & wait' --mutate 'true' --stability 1 --timeout 1
+  child=$(sed -n '1p' "$HANG_PID_FILE" 2>/dev/null || true)
+  child_stopped=no
+  if [ -n "$child" ] && stopped "$child"; then
+    child_stopped=yes
+  elif [ -n "$child" ]; then
+    kill -KILL "$child" 2>/dev/null || true
   fi
+  actual="rc=$rc;timeout=$(output_has 'timed out after 1s');child-stopped=$child_stopped"
 }
-settle_arm "the default settle waits one whole second" 1 -u MUTATION_STABILITY_SETTLE
-lacks "settle: 0" "the default run says nothing about a skipped boundary"
-settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
-# A verdict reached without the boundary has to be identifiable afterwards:
-# where BUILD does share a cache, a reused binary reads as a survivor and
-# nothing else in the output says why.
-has "settle: 0 — copies are not mtime-separated" \
-  "a skipped boundary is named in the run's own output"
 
-# one timeout control also checks adoption under a non-reaping PID 1.
-export HANG_PID_FILE="$TMP/timeout-child.pid"
-if command -v unshare >/dev/null 2>&1 \
-  && command -v python3 >/dev/null 2>&1 \
-  && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+observe_launch_window() {
+  export HANG_PID_FILE="$TMP/launch-window-child.pid"
+  export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
+  rm -f "$HANG_PID_FILE" "$LAUNCH_WINDOW_SIGNALLED"
   rc=0
-  out=$(unshare --user --map-root-user --pid --fork --mount-proc \
-    python3 -c '
+  out=""
+  BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'bash hang.sh & wait' --mutate 'true' --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
+  child=$(sed -n '1p' "$HANG_PID_FILE" 2>/dev/null || true)
+  signalled=no
+  [ ! -f "$LAUNCH_WINDOW_SIGNALLED" ] || signalled=yes
+  child_stopped=no
+  if [ -n "$child" ] && stopped "$child"; then
+    child_stopped=yes
+  elif [ -n "$child" ]; then
+    kill -KILL "$child" 2>/dev/null || true
+  fi
+  child_recorded=no
+  [ -z "$child" ] || child_recorded=yes
+  actual="rc=$rc;signalled=$signalled;child-recorded=$child_recorded;child-stopped=$child_stopped"
+}
+
+namespace_available=no
+if command -v unshare >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+  namespace_available=yes
+fi
+
+observe_namespace() {
+  export HANG_PID_FILE="$TMP/namespace-child.pid"
+  rm -f "$HANG_PID_FILE"
+  rc=0
+  out=""
+  out=$(unshare --user --map-root-user --pid --fork --mount-proc python3 -c '
 import glob, os, subprocess, sys, time
-env = os.environ.copy()
 run = subprocess.run([
     sys.argv[1], "--worktree", sys.argv[2], "--sha", sys.argv[3],
     "--test", "true", "--build", "bash hang.sh & wait",
     "--mutate", "true", "--stability", "1", "--timeout", "1",
-], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+], env=os.environ.copy(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 time.sleep(0.1)
 zombies = []
 for path in glob.glob("/proc/[0-9]*/stat"):
     try:
         fields = open(path).read().split()
         if fields[2] == "Z" and fields[3] == "1":
-            zombies.append((fields[0], fields[1], fields[4]))
+            zombies.append(fields[0])
     except (IndexError, OSError):
         pass
-if run.returncode != 2:
-    print("timeout exit: expected 2, got %s" % run.returncode)
-if "timed out after 1s" not in run.stderr:
-    print("missing timeout diagnostic: %s" % run.stderr)
-if zombies:
-    print("non-reaping PID 1 adopted zombies: %r" % (zombies,))
-sys.exit(0 if run.returncode == 2 and "timed out after 1s" in run.stderr and not zombies else 1)
-' "$MS" "$REPO" "$SHA" 2>&1) || rc=$?
-  is_rc 0 "a timed-out child leaves no zombies under non-reaping PID 1"
-else
-  run_ms "$SHA" --test 'true' --build 'bash hang.sh & wait' \
-    --mutate 'true' --stability 1 --timeout 1
-  is_rc 2 "a hanging child times out"
-  has "timed out after 1s" "the timeout is reported"
-  child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-  if [ -n "$child" ] && stopped "$child"; then
-    ok "the timed-out child is reaped"
-  else
-    bad "the timed-out child is reaped" "pid=${child:-missing}"
-    [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
-  fi
-fi
+print("inner-rc=%s;timeout=%s;zombies=%s" % (
+    run.returncode,
+    "yes" if "timed out after 1s" in run.stderr else "no",
+    "none" if not zombies else "present",
+))
+' "$MS" "$REPO" "$SHA_BASE" 2>&1) || rc=$?
+  actual="outer-rc=$rc;${out##*$'\n'}"
+}
 
-# One signal-gap control covers cancellation before process ownership lands.
-export HANG_PID_FILE="$TMP/launch-window-child.pid"
-export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
-rc=0
-BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'true' --build 'bash hang.sh & wait' --mutate 'true' \
-  --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
-child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ "$rc" = 143 ] && [ -f "$LAUNCH_WINDOW_SIGNALLED" ] \
-  && [ -n "$child" ] && stopped "$child"; then
-  ok "launch-window cancellation records ownership and reaps the command"
-else
-  bad "launch-window cancellation records ownership and reaps the command" \
-    "rc=$rc signal_file=$LAUNCH_WINDOW_SIGNALLED pid=${child:-missing}"
-  [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
-fi
+echo "=== process cleanup table ==="
+process_rows=0
+while IFS=$'\t' read -r name kind expected; do
+  case "$kind" in
+    timeout) observe_timeout ;;
+    launch-window) observe_launch_window ;;
+    namespace)
+      if [ "$namespace_available" = no ]; then
+        printf '  skip  process cleanup: %s (private PID namespaces unavailable)\n' "$name"
+        continue
+      fi
+      observe_namespace
+      ;;
+    *) actual="unknown-kind=$kind" ;;
+  esac
+  assert_row "process cleanup" "$name" "$actual" "$expected"
+  process_rows=$((process_rows + 1))
+done <<'ROWS'
+timed-out child exits, reports, and stops	timeout	rc=2;timeout=yes;child-stopped=yes
+launch-window cancellation owns and stops its child	launch-window	rc=143;signalled=yes;child-recorded=yes;child-stopped=yes
+non-reaping PID 1 adopts no zombie	namespace	outer-rc=0;inner-rc=2;timeout=yes;zombies=none
+ROWS
+assert_table_executed "process cleanup" "$process_rows"
 
-# A rerun that fails only after the first clean pass reports partial stability.
-cat > "$REPO/check.sh" <<'T'
-. ./lib.sh
-[ "$(add 2 3)" = 5 ] || exit 1
-[ ! -f .ran ] || exit 1
-touch .ran
-T
-git -C "$REPO" add -A
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
-SHA2=$(git -C "$REPO" rev-parse HEAD)
-run_ms "$SHA2" --test 'bash check.sh' --build 'true' \
-  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 3 --threads 2
-is_rc 1 "stability failure exits 1 even with the mutant killed"
-has "stability: 1/3 at 2 threads" "partial stability is reported as Y/N"
-
-# Shared whole-second caches must rebuild for mutant and clean copies. This is
-# the wait's whole reason, so from here the default settle is what runs.
 unset MUTATION_STABILITY_SETTLE
 export CACHE="$TMP/build-cache"
-mkdir -p "$CACHE"
-cat > "$REPO/check.sh" <<'T'
-built=0
-[ ! -f "$CACHE/built.sh" ] || built=$(stat -c %Y "$CACHE/built.sh")
-[ "$(stat -c %Y lib.sh)" -le "$built" ] || cp lib.sh "$CACHE/built.sh"
-. "$CACHE/built.sh"
-[ "$(add 2 3)" = 5 ]
-T
-git -C "$REPO" add -A
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
-SHA3=$(git -C "$REPO" rev-parse HEAD)
-run_ms "$SHA3" --test 'bash check.sh' --build 'true' \
-  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 3 --threads 2
-is_rc 0 "a shared whole-second build cache reaches the right verdict"
-has "mutation: killed 1/1" "the mutant build rebuilds instead of reusing the control"
-has "stability: 3/3 at 2 threads" "the clean copy rebuilds instead of reusing the mutant"
 
-kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-  --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-  --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
-root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
-if [ -d "$root/clean" ]; then
-  gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))
-  rm -rf "$root"
-  if [ "$gap" -ge 1 ]; then ok "each copy outranks the one before"; else bad "each copy outranks the one before" "gap=${gap}s"; fi
-else
-  bad "each copy outranks the one before" "--keep printed no temp dir: $kept"
-fi
+observe_cache_verdict() {
+  rm -rf "$CACHE"
+  mkdir -p "$CACHE"
+  run_ms "$SHA_CACHED" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 3 --threads 2
+  actual="rc=$rc;killed=$(output_has 'mutation: killed 1/1');stable=$(output_has 'stability: 3/3 at 2 threads')"
+}
 
-echo "$PASS passed, $FAIL failed"
-[ "$FAIL" = 0 ] || exit 1
+observe_kept_copies() {
+  rm -rf "$CACHE"
+  mkdir -p "$CACHE"
+  rc=0
+  out=""
+  kept=$("$MS" --worktree "$REPO" --sha "$SHA_CACHED" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 --keep 2>&1 >/dev/null) || rc=$?
+  root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p') || root=""
+  clean_present=no
+  gap_ok=no
+  case "$root" in
+    "$RUNTIME_TMP"/mutation-stability.*)
+      if [ -d "$root/clean" ]; then
+        clean_present=yes
+        mutant_time=$(file_mtime "$root/mutant/check.sh") || mutant_time=unreadable
+        clean_time=$(file_mtime "$root/clean/check.sh") || clean_time=unreadable
+        if [ "$mutant_time" != unreadable ] && [ "$clean_time" != unreadable ] && [ $((clean_time - mutant_time)) -ge 1 ]; then
+          gap_ok=yes
+        fi
+      fi
+      rm -rf "$root"
+      ;;
+  esac
+  out="$kept"
+  actual="rc=$rc;clean-present=$clean_present;mtime-gap=$gap_ok"
+}
+
+echo "=== shared build cache table ==="
+cache_rows=0
+while IFS=$'\t' read -r name kind expected; do
+  case "$kind" in
+    verdict) observe_cache_verdict ;;
+    keep) observe_kept_copies ;;
+    *) actual="unknown-kind=$kind" ;;
+  esac
+  assert_row "shared build cache" "$name" "$actual" "$expected"
+  cache_rows=$((cache_rows + 1))
+done <<'ROWS'
+mutant and clean copies both rebuild	verdict	rc=0;killed=yes;stable=yes
+kept copy times advance	keep	rc=0;clean-present=yes;mtime-gap=yes
+ROWS
+assert_table_executed "shared build cache" "$cache_rows"
+
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
KEN-1241 tests audit, lane F: Reviewer test cases now use named rows and isolated command outcomes.

## What changed

- Reshaped measurement-failure and mutation-stability cases into visible named tables.
- Isolated Git state, command status, process cleanup, and build-cache behavior.
- Preserved each prior assertion in a named row.
- Replayed each source test change into its tracked render.

## Must-fail controls

All eight named tables have their own zero-row guard. Each guard records a failure before the suite exit, so a later successful check cannot hide an empty table.

## Size

- Production lines added: 0.
- Test lines added: 502.
- Render-mirror lines added: 502.
- KEN-1241 states no expected-delta allowance.

## Test plan

- Preflight passed for 4 changed files.
- `tools/guard --full` exited 0 after the storage migration and dependency restore.
- The changed Reviewer suites passed 57 checks.
- The UI test command passed 159 files with 1286 tests.

## Reviewer round

One specialist reviewer-test round passed. The saved artifact remains valid after storage migration.

KEN-1241
