### PR TITLE
test(KEN-1241): reshape harness-ci test cases

### DIFF
--- a/skills/harness-ci/tests/event-ranges.test.sh
+++ b/skills/harness-ci/tests/event-ranges.test.sh
@@ -38,7 +38,9 @@ mg_mixed_head="$(git -C "$mg" rev-parse HEAD)"
 
 # label | verdict | repository | event | base | head
 # A head beginning with default: checks that ref out and omits --head.
+event_row_count=0
 while IFS='|' read -r label expected case_repo event case_base case_head; do
+  event_row_count=$((event_row_count + 1))
   case "$case_head" in
     default:*)
       git -C "$case_repo" checkout -q --detach "${case_head#default:}"
@@ -59,5 +61,6 @@ merge-group-mixed|false|$mg|merge_group|$mg_base|$mg_mixed_head
 default-head-render|true|$mg|merge_group|$mg_base|default:$mg_render_head
 default-head-mixed|false|$mg|merge_group|$mg_base|default:$mg_mixed_head
 CASES
+require_rows event-ranges "$event_row_count"
 
 report event-ranges

--- a/skills/harness-ci/tests/event-ranges.test.sh
+++ b/skills/harness-ci/tests/event-ranges.test.sh
@@ -1,68 +1,63 @@
 #!/usr/bin/env bash
-# Which range each event measures. pull_request takes the merge base, because
-# the base branch moves under an open PR. push and merge_group take the two
-# endpoints, because a force-push leaves the `before` sha off the head's
-# history and a merge base there is a commit the push already discarded.
+# Pull requests use a merge-base range. Pushes and merge groups use their two
+# endpoints so discarded force-push work still runs product checks.
 set -euo pipefail
 # shellcheck source=lib/sandbox.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
 
-# --- push: the force-push case ------------------------------------------
 repo="$(new_repo force-push)"
-commit_paths "$repo" "baseline" README.md
+commit_paths "$repo" baseline README.md
 fork="$(git -C "$repo" rev-parse HEAD)"
-
 git -C "$repo" checkout -q -b topic
 commit_paths "$repo" "product work" src/feature.rs
 before="$(git -C "$repo" rev-parse HEAD)"
-
-# The force-push: the product commit is dropped and replaced by a render-only
-# one, so the endpoints share only the fork point.
 git -C "$repo" reset -q --hard "$fork"
 commit_paths "$repo" "render only" .agents/skills/orch/SKILL.md
 after="$(git -C "$repo" rev-parse HEAD)"
 
-assert_verdict "a force-push that discards product work answers false" false \
-  --repo "$repo" --event push --base "$before" --head "$after"
-
 merge_base_view="$(git -C "$repo" diff --name-only --no-renames "$before...$after")"
-assert_eq "the merge-base range would have seen only the render" \
+assert_eq push-discards-product-merge-base-view \
   ".agents/skills/orch/SKILL.md" "$merge_base_view"
 
-# --- pull_request: the moving base branch --------------------------------
 pr="$(new_repo moving-base)"
-commit_paths "$pr" "baseline" README.md
-
+commit_paths "$pr" baseline README.md
 git -C "$pr" checkout -q -b feature
 commit_paths "$pr" "render only" .claude/agents/rust.md
 pr_head="$(git -C "$pr" rev-parse HEAD)"
-
 git -C "$pr" checkout -q main
 commit_paths "$pr" "unrelated product work on main" src/other.rs
 pr_base="$(git -C "$pr" rev-parse HEAD)"
 
-assert_verdict "a render-only PR is unaffected by base-branch commits" true \
-  --repo "$pr" --event pull_request --base "$pr_base" --head "$pr_head"
-
-assert_verdict "the same endpoints read end-to-end pick up the base's work" false \
-  --repo "$pr" --event push --base "$pr_base" --head "$pr_head"
-
-# --- merge_group: the endpoint form ---------------------------------------
 mg="$(new_repo merge-group)"
-commit_paths "$mg" "baseline" README.md
+commit_paths "$mg" baseline README.md
 mg_base="$(git -C "$mg" rev-parse HEAD)"
 commit_paths "$mg" "render only" .codex/agents/rust.md
-mg_head="$(git -C "$mg" rev-parse HEAD)"
-
-assert_verdict "a render-only merge group answers true" true \
-  --repo "$mg" --event merge_group --base "$mg_base" --head "$mg_head"
-
+mg_render_head="$(git -C "$mg" rev-parse HEAD)"
 commit_paths "$mg" "product work" src/main.rs
-assert_verdict "a mixed merge group answers false" false \
-  --repo "$mg" --event merge_group --base "$mg_base" --head HEAD
+mg_mixed_head="$(git -C "$mg" rev-parse HEAD)"
 
-# --head defaults to HEAD rather than requiring the caller to name it.
-assert_verdict "--head defaults to HEAD" false \
-  --repo "$mg" --event merge_group --base "$mg_base"
+# label | verdict | repository | event | base | head
+# A head beginning with default: checks that ref out and omits --head.
+while IFS='|' read -r label expected case_repo event case_base case_head; do
+  case "$case_head" in
+    default:*)
+      git -C "$case_repo" checkout -q --detach "${case_head#default:}"
+      assert_verdict "$label" "$expected" \
+        --repo "$case_repo" --event "$event" --base "$case_base"
+      ;;
+    *)
+      assert_verdict "$label" "$expected" \
+        --repo "$case_repo" --event "$event" --base "$case_base" --head "$case_head"
+      ;;
+  esac
+done <<CASES
+push-discards-product|false|$repo|push|$before|$after
+pr-moving-base|true|$pr|pull_request|$pr_base|$pr_head
+push-same-moving-base|false|$pr|push|$pr_base|$pr_head
+merge-group-render|true|$mg|merge_group|$mg_base|$mg_render_head
+merge-group-mixed|false|$mg|merge_group|$mg_base|$mg_mixed_head
+default-head-render|true|$mg|merge_group|$mg_base|default:$mg_render_head
+default-head-mixed|false|$mg|merge_group|$mg_base|default:$mg_mixed_head
+CASES
 
 report event-ranges

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -45,7 +45,9 @@ run_rejected_input() { # LABEL REPO EVENT BASE HEAD
 }
 
 # label | repository | event | base | head
+rejected_row_count=0
 while IFS='|' read -r label case_repo event case_base case_head; do
+  rejected_row_count=$((rejected_row_count + 1))
   run_rejected_input "$label" "$case_repo" "$event" "$case_base" "$case_head"
 done <<CASES
 schedule|$repo|schedule|$base|$head
@@ -62,6 +64,7 @@ non-checkout|$SANDBOX|push|$base|$head
 absent-checkout|$SANDBOX/absent|push|$base|$head
 unborn-checkout|$empty|push|HEAD|<default>
 CASES
+require_rows rejected-input "$rejected_row_count"
 
 # Two valid roots with no shared ancestor make the pull-request diff fail.
 orphan="$(new_repo unrelated-histories)"

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -1,106 +1,117 @@
 #!/usr/bin/env bash
-# Everything the classifier cannot prove answers false, and answers it with a
-# clean exit so the caller's step stays green while every lane runs.
+# Inputs the classifier cannot prove answer false with a successful exit. This
+# runs every lane without turning a data problem into a wiring error.
 set -euo pipefail
 # shellcheck source=lib/sandbox.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
 
 repo="$(new_repo fail-closed)"
-commit_paths "$repo" "baseline" README.md
+commit_paths "$repo" baseline README.md
 base="$(git -C "$repo" rev-parse HEAD)"
 commit_paths "$repo" "render only" .agents/skills/orch/SKILL.md
 head="$(git -C "$repo" rev-parse HEAD)"
 
-# The control: these endpoints classify true, so every case below fails closed
-# on its own defect rather than on a diff that was never harness-only.
-assert_verdict "the control endpoints classify true" true \
+assert_verdict valid-endpoints true \
   --repo "$repo" --event push --base "$base" --head "$head"
 
 closed() { # LABEL ARGS...
   local label="$1" out status
   shift
-  set +e
-  out="$("$HARNESS_ONLY" "$@" 2>/dev/null)"
-  status=$?
-  set -e
+  if out="$("$HARNESS_ONLY" "$@" 2>/dev/null)"; then
+    status=0
+  else
+    status=$?
+  fi
   assert_eq "$label" "harness_only=false exit 0" "$out exit $status"
 }
 
-closed "an unclassified event" \
-  --repo "$repo" --event schedule --base "$base" --head "$head"
-closed "workflow_dispatch is not a classified event" \
-  --repo "$repo" --event workflow_dispatch --base "$base" --head "$head"
-closed "no base endpoint" --repo "$repo" --event push --head "$head"
-closed "an empty base endpoint" \
-  --repo "$repo" --event push --base "" --head "$head"
-closed "the all-zero base a first push sends" \
-  --repo "$repo" --event push \
-  --base 0000000000000000000000000000000000000000 --head "$head"
-closed "the all-zero head a branch-deletion push sends" \
-  --repo "$repo" --event push \
-  --base "$base" --head 0000000000000000000000000000000000000000
-closed "a base that names no object" \
-  --repo "$repo" --event push --base 1234567890123456789012345678901234567890 --head "$head"
-closed "a head that names no object" \
-  --repo "$repo" --event pull_request --base "$base" --head 1234567890123456789012345678901234567890
-closed "a base that is not a commit" \
-  --repo "$repo" --event push --base "$(git -C "$repo" rev-parse "HEAD^{tree}")" --head "$head"
-closed "an empty diff between identical endpoints" \
-  --repo "$repo" --event push --base "$head" --head "$head"
-closed "a --repo that is not a checkout" \
-  --repo "$SANDBOX" --event push --base "$base" --head "$head"
-closed "a --repo that does not exist" \
-  --repo "$SANDBOX/absent" --event push --base "$base" --head "$head"
-
-# A repository with no commits at all: HEAD resolves to nothing.
+tree_base="$(git -C "$repo" rev-parse "HEAD^{tree}")"
 empty="$(new_repo empty)"
-closed "a checkout with no commits" --repo "$empty" --event push --base HEAD
 
-# A diff git REFUSES rather than one it answers empty. Two roots share no
-# ancestor, so the three-dot form has no merge base to measure from and exits
-# non-zero with both endpoints perfectly readable.
+run_rejected_input() { # LABEL REPO EVENT BASE HEAD
+  local label="$1" case_repo="$2" event="$3" case_base="$4" case_head="$5"
+  local args=(--repo "$case_repo" --event "$event")
+  case "$case_base" in
+    '<omit>') ;;
+    '<empty>') args+=(--base "") ;;
+    *) args+=(--base "$case_base") ;;
+  esac
+  case "$case_head" in
+    '<default>') ;;
+    '<empty>') args+=(--head "") ;;
+    *) args+=(--head "$case_head") ;;
+  esac
+  closed "$label" "${args[@]}"
+}
+
+# label | repository | event | base | head
+while IFS='|' read -r label case_repo event case_base case_head; do
+  run_rejected_input "$label" "$case_repo" "$event" "$case_base" "$case_head"
+done <<CASES
+schedule|$repo|schedule|$base|$head
+workflow-dispatch|$repo|workflow_dispatch|$base|$head
+missing-base|$repo|push|<omit>|$head
+empty-base|$repo|push|<empty>|$head
+zero-base|$repo|push|0000000000000000000000000000000000000000|$head
+zero-head|$repo|push|$base|0000000000000000000000000000000000000000
+unknown-base|$repo|push|1234567890123456789012345678901234567890|$head
+unknown-head|$repo|pull_request|$base|1234567890123456789012345678901234567890
+tree-base|$repo|push|$tree_base|$head
+identical-endpoints|$repo|push|$head|$head
+non-checkout|$SANDBOX|push|$base|$head
+absent-checkout|$SANDBOX/absent|push|$base|$head
+unborn-checkout|$empty|push|HEAD|<default>
+CASES
+
+# Two valid roots with no shared ancestor make the pull-request diff fail.
 orphan="$(new_repo unrelated-histories)"
 commit_paths "$orphan" "first root" README.md
 root_a="$(git -C "$orphan" rev-parse HEAD)"
 git -C "$orphan" checkout -q --orphan second
 git -C "$orphan" rm -q -rf .
+write_inventory "$orphan"
 commit_paths "$orphan" "second root" .agents/skills/orch/SKILL.md
 root_b="$(git -C "$orphan" rev-parse HEAD)"
-git -C "$orphan" merge-base "$root_a" "$root_b" >/dev/null 2>&1 &&
-  { echo "FAIL: the fixture roots share a merge base" >&2; exit 1; }
-closed "a merge-base diff git refuses" \
+if git -C "$orphan" merge-base "$root_a" "$root_b" >/dev/null 2>&1; then
+  echo "FAIL: the fixture roots share a merge base" >&2
+  exit 1
+fi
+closed unrelated-histories \
   --repo "$orphan" --event pull_request --base "$root_a" --head "$root_b"
 
-# A path git has to quote arrives wrapped in double quotes, matches no harness
-# prefix, and answers false — the right answer for a path this line-oriented
-# reader cannot represent. The rest of the diff is render output, so only the
-# quoting decides the verdict.
+# Git quotes this product path. The fixture keeps the existing fail-closed
+# contract without claiming that quoting is the only rejection.
 quoted="$(new_repo quoted-path)"
-commit_paths "$quoted" "baseline" README.md
+commit_paths "$quoted" baseline README.md
 quoted_base="$(git -C "$quoted" rev-parse HEAD)"
-commit_paths "$quoted" "a render path git must quote" \
+commit_paths "$quoted" "quoted product path" \
   '.agents/skills/orch/we"ird.md' .agents/skills/orch/SKILL.md
 listed="$(git -C "$quoted" -c core.quotePath=false diff --name-only --no-renames "$quoted_base" HEAD)"
 case "$listed" in
   *'"'*) : ;;
   *) echo "FAIL: git did not quote the fixture path" >&2; exit 1 ;;
 esac
-closed "a path git had to quote" \
+closed git-quoted-path \
   --repo "$quoted" --event push --base "$quoted_base"
 
-# The reason reaches stderr, where the job log shows it.
-reason="$("$HARNESS_ONLY" --repo "$repo" --event schedule --base "$base" 2>&1 >/dev/null)"
+if reason="$("$HARNESS_ONLY" --repo "$repo" --event schedule --base "$base" 2>&1 >/dev/null)"; then
+  reason_status=0
+else
+  reason_status=$?
+fi
 case "$reason" in
-  *"event 'schedule'"*"running every lane"*)
-    assert_eq "the reason names the event and the consequence" pass pass ;;
-  *) assert_eq "the reason names the event and the consequence" pass "$reason" ;;
+  *"event 'schedule'"*"running every lane"*) reason_contract=present ;;
+  *) reason_contract="$reason" ;;
 esac
+assert_eq unsupported-event-report "present exit 0" \
+  "$reason_contract exit $reason_status"
 
 git -C "$repo" rm -q .kendex-generated.json
 git -C "$repo" commit -qm "missing inventory"
-closed "a missing generated inventory" --repo "$repo" --event push --base "$base"
-printf '%s\n' 'invalid' >"$repo/.kendex-generated.json"
+closed missing-head-inventory --repo "$repo" --event push --base "$base"
+printf '%s\n' invalid >"$repo/.kendex-generated.json"
 git -C "$repo" add -A
 git -C "$repo" commit -qm "invalid inventory"
-closed "an invalid generated inventory" --repo "$repo" --event push --base "$base"
+closed invalid-head-inventory --repo "$repo" --event push --base "$base"
+
 report fail-closed

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -2,13 +2,21 @@
 # Source adoption removes the file from the writer inventory.
 set -euo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
-repo="$(new_repo in-place)"
-commit_paths "$repo" baseline .agents/skills/orch/SKILL.md
-base="$(git -C "$repo" rev-parse HEAD)"
-commit_paths "$repo" render .agents/skills/orch/SKILL.md
-assert_verdict "recorded render skips product checks" true --repo "$repo" --event push --base "$base"
-jq 'map(select(. != ".agents/skills/orch/SKILL.md"))' "$repo/.kendex-generated.json" >"$repo/inventory.tmp"
-mv "$repo/inventory.tmp" "$repo/.kendex-generated.json"
-commit_paths "$repo" adoption .agents/skills/orch/SKILL.md
-assert_verdict "source adoption runs product checks" false --repo "$repo" --event push --base "$base"
+source_adoption_case() {
+  local repo base
+  repo="$(new_repo in-place)"
+  commit_paths "$repo" baseline .agents/skills/orch/SKILL.md
+  base="$(git -C "$repo" rev-parse HEAD)"
+  commit_paths "$repo" render .agents/skills/orch/SKILL.md
+  assert_verdict source-adoption-before true \
+    --repo "$repo" --event push --base "$base"
+  jq 'map(select(. != ".agents/skills/orch/SKILL.md"))' \
+    "$repo/.kendex-generated.json" >"$repo/inventory.tmp"
+  mv "$repo/inventory.tmp" "$repo/.kendex-generated.json"
+  commit_paths "$repo" adoption .agents/skills/orch/SKILL.md
+  assert_verdict source-adoption-after false \
+    --repo "$repo" --event push --base "$base"
+}
+
+source_adoption_case
 report in-place

--- a/skills/harness-ci/tests/lib/sandbox.sh
+++ b/skills/harness-ci/tests/lib/sandbox.sh
@@ -6,6 +6,8 @@
 # sourcing suite to have set it, which is also what every suite here sets.
 set -euo pipefail
 
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE GITHUB_OUTPUT
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
 HARNESS_ONLY="$(cd "$TEST_DIR/../scripts" && pwd)/harness-only"
 
@@ -22,16 +24,20 @@ fi
 cleanup() { rm -rf "$SANDBOX" 2>/dev/null || true; }
 trap cleanup EXIT
 
+write_inventory() { # REPO
+  # Fixture writer output. Product paths remain absent even inside a harness.
+  printf '%s\n' '[".kendex-generated.json",".agents/skills/orch/SKILL.md",".agents/skills/orch/app.ts",".agents/skills/orch/renamed.ts",".agents/skills/review-gate/scripts/lib/settings.sh",".claude/agents/rust.md",".codex/agents/rust.md",".opencode/agent/rust.md",".cursor/rules/rust.mdc",".pi/kendex/hooks/guard.ts",".pi/settings.json","opencode.json","opencode.jsonc",".gemini/settings.json",".github/agents/rust.agent.md","CLAUDE.md","runtime/agent.conf"]' >"$1/.kendex-generated.json"
+}
+
 # Fixture repositories carry their own identity and default branch so the
 # suite reads the same on a runner with no global git config.
 new_repo() { # NAME -> prints the repo path
   local repo="$SANDBOX/$1"
-  mkdir -p "$repo"
-  git -C "$repo" init -q -b main
-  git -C "$repo" config user.email harness-ci@example.invalid
-  git -C "$repo" config user.name "harness-ci tests"
-  # Fixture writer output. Product paths remain absent even inside a harness.
-  printf '%s\n' '[".kendex-generated.json",".agents/skills/orch/SKILL.md",".agents/skills/orch/app.ts",".agents/skills/orch/renamed.ts",".agents/skills/review-gate/scripts/lib/settings.sh",".claude/agents/rust.md",".codex/agents/rust.md",".opencode/agent/rust.md",".cursor/rules/rust.mdc",".pi/kendex/hooks/guard.ts",".pi/settings.json","opencode.json","opencode.jsonc",".gemini/settings.json",".github/agents/rust.agent.md","CLAUDE.md","runtime/agent.conf"]' >"$repo/.kendex-generated.json"
+  mkdir -p "$repo" || return
+  git -C "$repo" init -q -b main || return
+  git -C "$repo" config user.email harness-ci@example.invalid || return
+  git -C "$repo" config user.name "harness-ci tests" || return
+  write_inventory "$repo" || return
   printf '%s' "$repo"
 }
 
@@ -64,9 +70,14 @@ assert_eq() { # LABEL EXPECTED ACTUAL
 }
 
 assert_verdict() { # LABEL true|false ARGS...
-  local label="$1" expected="$2"
+  local label="$1" expected="$2" out status
   shift 2
-  assert_eq "$label" "harness_only=$expected" "$(classify "$@")"
+  if out="$(classify "$@")"; then
+    status=0
+  else
+    status=$?
+  fi
+  assert_eq "$label" "harness_only=$expected exit 0" "$out exit $status"
 }
 
 report() { # SUITE

--- a/skills/harness-ci/tests/lib/sandbox.sh
+++ b/skills/harness-ci/tests/lib/sandbox.sh
@@ -69,6 +69,13 @@ assert_eq() { # LABEL EXPECTED ACTUAL
   fi
 }
 
+require_rows() { # TABLE COUNT
+  if [ "$2" -eq 0 ]; then
+    printf 'FAIL: %s table executed no rows\n' "$1" >&2
+    exit 1
+  fi
+}
+
 assert_verdict() { # LABEL true|false ARGS...
   local label="$1" expected="$2" out status
   shift 2

--- a/skills/harness-ci/tests/path-set.test.sh
+++ b/skills/harness-ci/tests/path-set.test.sh
@@ -21,7 +21,9 @@ case_verdict() { # LABEL EXPECTED PATH...
 }
 
 # label | verdict | changed paths
+path_row_count=0
 while IFS='|' read -r label expected paths; do
+  path_row_count=$((path_row_count + 1))
   # The table paths have no spaces. Word splitting makes each one an argument.
   # shellcheck disable=SC2086
   case_verdict "$label" "$expected" $paths
@@ -47,6 +49,7 @@ opencode.jsonc5|false|opencode.jsonc5
 .claudefoo|false|.claudefoo
 .agents|false|.agents
 CASES
+require_rows path-set "$path_row_count"
 
 # Seed the carrier manifest before changing its extension. Each verdict now
 # has one product path that can make it false.

--- a/skills/harness-ci/tests/path-set.test.sh
+++ b/skills/harness-ci/tests/path-set.test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # The path set: every render tree answers true, anything beside one answers
-# false, and the near misses that merely start with a render tree's name are
-# product paths like any other.
+# false, and near misses remain product paths.
 set -euo pipefail
 # shellcheck source=lib/sandbox.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
@@ -10,86 +9,77 @@ repo="$(new_repo path-set)"
 commit_paths "$repo" "baseline" README.md
 base="$(git -C "$repo" rev-parse HEAD)"
 
-# One commit per case, each measured against the same baseline, so a case
-# never inherits another's paths.
+# One commit per row, measured against the same baseline.
 case_verdict() { # LABEL EXPECTED PATH...
   local label="$1" expected="$2"
   shift 2
-  git -C "$repo" checkout -q -B "case" "$base"
+  git -C "$repo" checkout -q -B case "$base"
   git -C "$repo" clean -qfd
   commit_paths "$repo" "$label" "$@"
-  assert_verdict "$label" "$expected" --repo "$repo" --event push --base "$base" --head HEAD
+  assert_verdict "$label" "$expected" \
+    --repo "$repo" --event push --base "$base" --head HEAD
 }
 
-case_verdict "every render tree at once" true \
-  .agents/skills/orch/SKILL.md \
-  .claude/agents/rust.md \
-  .codex/agents/rust.md \
-  .opencode/agent/rust.md \
-  .cursor/rules/rust.mdc \
-  .pi/kendex/hooks/guard.ts \
-  opencode.json
+# label | verdict | changed paths
+while IFS='|' read -r label expected paths; do
+  # The table paths have no spaces. Word splitting makes each one an argument.
+  # shellcheck disable=SC2086
+  case_verdict "$label" "$expected" $paths
+done <<'CASES'
+generated-families|true|.agents/skills/orch/SKILL.md .claude/agents/rust.md .codex/agents/rust.md .opencode/agent/rust.md .cursor/rules/rust.mdc .pi/kendex/hooks/guard.ts opencode.json
+opencode-jsonc|true|opencode.jsonc
+opencode-both|true|opencode.json opencode.jsonc
+mixed-paths|false|.agents/skills/orch/SKILL.md src/main.rs
+product-only|false|src/main.rs
+deep-generated-path|true|.agents/skills/review-gate/scripts/lib/settings.sh
+pi-runtime-config|true|.pi/settings.json
+generated-outside-harness|true|runtime/agent.conf
+generated-configs-and-shim|true|.gemini/settings.json .github/agents/rust.agent.md CLAUDE.md
+unrecorded-harness-source|false|.claude/source.ts
+carrier-manifest|false|.pi/packages/example/package.json
+.agentsfoo/notes.md|false|.agentsfoo/notes.md
+.agents-old/notes.md|false|.agents-old/notes.md
+opencode.json.bak|false|opencode.json.bak
+ui/opencode.json|false|ui/opencode.json
+opencode.jsonc.bak|false|opencode.jsonc.bak
+ui/opencode.jsonc|false|ui/opencode.jsonc
+opencode.jsonc5|false|opencode.jsonc5
+.claudefoo|false|.claudefoo
+.agents|false|.agents
+CASES
 
-# kendex writes opencode.jsonc where a project carries that spelling instead,
-# so both names are the one OpenCode config.
-case_verdict "the jsonc spelling of the config" true opencode.jsonc
-case_verdict "both spellings side by side" true opencode.json opencode.jsonc
-
-case_verdict "a render path beside a product path" false \
-  .agents/skills/orch/SKILL.md src/main.rs
-
-case_verdict "product paths alone" false src/main.rs
-
-case_verdict "deeply nested render output" true \
-  .agents/skills/review-gate/scripts/lib/settings.sh
-
-case_verdict "Pi runtime config is generated" true .pi/settings.json
-case_verdict "writer output outside harness folders" true runtime/agent.conf
-case_verdict "Gemini, Copilot, and instruction shims are writer output" true .gemini/settings.json .github/agents/rust.agent.md CLAUDE.md
-case_verdict "unrecorded code in a harness folder runs product checks" false .claude/source.ts
-case_verdict "a carrier package remains source" false \
-  .pi/packages/example/package.json
-
-git -C "$repo" checkout -q -B "case" "$base"
+# Seed the carrier manifest before changing its extension. Each verdict now
+# has one product path that can make it false.
+git -C "$repo" checkout -q -B case "$base"
 git -C "$repo" clean -qfd
 mkdir -p "$repo/.pi/packages/example/extensions"
 printf '%s\n' '{"name":"example","scripts":{"test":"node test.js"},"pi":{"extensions":["extensions/main.ts"]}}' >"$repo/.pi/packages/example/package.json"
-printf '%s\n' 'export const active = true;' >"$repo/.pi/packages/example/extensions/main.ts"
 git -C "$repo" add -A
-git -C "$repo" commit -q -m "Pi source package"
+git -C "$repo" commit -q -m "seed Pi carrier"
 package_base="$(git -C "$repo" rev-parse HEAD)"
-assert_verdict "a tested Pi extension is product source" false \
-  --repo "$repo" --event push --base "$base" --head "$package_base"
+commit_paths "$repo" "create Pi source" .pi/packages/example/extensions/main.ts
+assert_verdict carrier-extension-create false \
+  --repo "$repo" --event push --base "$package_base" --head HEAD
+extension_head="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" rm -q .pi/packages/example/extensions/main.ts
 git -C "$repo" commit -q -m "delete Pi source"
-assert_verdict "deleting tested Pi extension code is a product change" false \
-  --repo "$repo" --event push --base "$package_base" --head HEAD
+assert_verdict carrier-extension-delete false \
+  --repo "$repo" --event push --base "$extension_head" --head HEAD
 
-# The near misses. A prefix match without the separator is a different path,
-# and a suffix past the filename is a different file.
-case_verdict ".agentsfoo is not .agents/" false .agentsfoo/notes.md
-case_verdict ".agents-old is not .agents/" false .agents-old/notes.md
-case_verdict "opencode.json.bak is not opencode.json" false opencode.json.bak
-case_verdict "a nested opencode.json is not the root one" false ui/opencode.json
-case_verdict "opencode.jsonc.bak is not opencode.jsonc" false opencode.jsonc.bak
-case_verdict "a nested opencode.jsonc is not the root one" false ui/opencode.jsonc
-case_verdict "opencode.jsonc5 is not opencode.jsonc" false opencode.jsonc5
-case_verdict ".claudefoo is not .claude/" false .claudefoo
-case_verdict "a bare .agents file is not the tree" false .agents
-
-# A deletion is a change like any other: removing a product file cannot read
-# as harness-only merely because the change touches nothing outside the render.
-git -C "$repo" checkout -q -B "case" "$base"
+# Deletion uses the base inventory.
+git -C "$repo" checkout -q -B case "$base"
 git -C "$repo" rm -q README.md
 git -C "$repo" commit -q -m "delete the product file"
-assert_verdict "a product deletion answers false" false \
+assert_verdict product-delete false \
   --repo "$repo" --event push --base "$base" --head HEAD
 
-git -C "$repo" checkout -q -B "case" "$base"
+# A path first claimed by the head inventory remains product work.
+git -C "$repo" checkout -q -B case "$base"
 git -C "$repo" clean -qfd
 jq '. + ["src/claimed.rs"]' "$repo/.kendex-generated.json" >"$repo/inventory.tmp"
 mv "$repo/inventory.tmp" "$repo/.kendex-generated.json"
 commit_paths "$repo" "product claims generated ownership" src/claimed.rs
-assert_verdict "head-only generated claims run product checks" false --repo "$repo" --event push --base "$base" --head HEAD
+assert_verdict ownership-gain false \
+  --repo "$repo" --event push --base "$base" --head HEAD
 
 report path-set

--- a/skills/harness-ci/tests/rename-into-render.test.sh
+++ b/skills/harness-ci/tests/rename-into-render.test.sh
@@ -32,7 +32,9 @@ git -C "$repo" commit -q -m "move generated output to product"
 generated_to_product="$(git -C "$repo" rev-parse HEAD)"
 
 # label | verdict | base | head
+move_row_count=0
 while IFS='|' read -r label expected case_base case_head; do
+  move_row_count=$((move_row_count + 1))
   assert_verdict "$label" "$expected" \
     --repo "$repo" --event push --base "$case_base" --head "$case_head"
 done <<CASES
@@ -40,5 +42,6 @@ product-to-generated|false|$product_base|$product_to_generated
 generated-to-generated|true|$product_to_generated|$generated_to_generated
 generated-to-product|false|$generated_to_generated|$generated_to_product
 CASES
+require_rows move "$move_row_count"
 
 report rename-into-render

--- a/skills/harness-ci/tests/rename-into-render.test.sh
+++ b/skills/harness-ci/tests/rename-into-render.test.sh
@@ -1,47 +1,44 @@
 #!/usr/bin/env bash
-# --no-renames is load-bearing. Moving a product file INTO a render tree
-# deletes source; with rename detection on, git lists only the post-image and
-# the diff reads as render-only, so the lanes that would have judged the
-# deletion never run.
+# Rename detection must stay off. A product file moved into a generated path
+# still deletes product source and must run product checks.
 set -euo pipefail
 # shellcheck source=lib/sandbox.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
 
 repo="$(new_repo rename)"
-commit_paths "$repo" "baseline" src/app.ts .agents/skills/orch/SKILL.md
-base="$(git -C "$repo" rev-parse HEAD)"
+commit_paths "$repo" baseline src/app.ts .agents/skills/orch/SKILL.md
+product_base="$(git -C "$repo" rev-parse HEAD)"
 
 mkdir -p "$repo/.agents/skills/orch"
 git -C "$repo" mv src/app.ts .agents/skills/orch/app.ts
-git -C "$repo" commit -q -m "move a product file into the render"
+git -C "$repo" commit -q -m "move product into generated output"
+product_to_generated="$(git -C "$repo" rev-parse HEAD)"
 
-assert_verdict "a product file moved into the render answers false" false \
-  --repo "$repo" --event push --base "$base" --head HEAD
-
-# The control: with rename detection left on, the same diff lists one path and
-# every path it lists is a render path. That is the wrong answer this flag
-# exists to prevent, so the suite pins it rather than trusting the comment.
-detected="$(git -C "$repo" diff --name-only "$base" HEAD)"
-assert_eq "rename detection alone would list only the post-image" \
+detected="$(git -C "$repo" diff --name-only "$product_base" "$product_to_generated")"
+assert_eq product-to-generated-rename-view \
   ".agents/skills/orch/app.ts" "$detected"
 
-undetected="$(git -C "$repo" diff --name-only --no-renames "$base" HEAD | sort | tr '\n' ' ')"
-assert_eq "--no-renames lists the deletion too" \
+undetected="$(git -C "$repo" diff --name-only --no-renames "$product_base" "$product_to_generated" | sort | tr '\n' ' ')"
+assert_eq product-to-generated-no-renames-view \
   ".agents/skills/orch/app.ts src/app.ts " "$undetected"
 
-# A move that stays inside the render is still render-only.
-inside_base="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" mv .agents/skills/orch/app.ts .agents/skills/orch/renamed.ts
-git -C "$repo" commit -q -m "move inside the render"
-assert_verdict "a move within the render stays true" true \
-  --repo "$repo" --event push --base "$inside_base" --head HEAD
+git -C "$repo" commit -q -m "move inside generated output"
+generated_to_generated="$(git -C "$repo" rev-parse HEAD)"
 
-# And a render file moved OUT to a product path is a product change.
-out_base="$(git -C "$repo" rev-parse HEAD)"
 mkdir -p "$repo/src"
 git -C "$repo" mv .agents/skills/orch/renamed.ts src/renamed.ts
-git -C "$repo" commit -q -m "move out of the render"
-assert_verdict "a move out of the render answers false" false \
-  --repo "$repo" --event push --base "$out_base" --head HEAD
+git -C "$repo" commit -q -m "move generated output to product"
+generated_to_product="$(git -C "$repo" rev-parse HEAD)"
+
+# label | verdict | base | head
+while IFS='|' read -r label expected case_base case_head; do
+  assert_verdict "$label" "$expected" \
+    --repo "$repo" --event push --base "$case_base" --head "$case_head"
+done <<CASES
+product-to-generated|false|$product_base|$product_to_generated
+generated-to-generated|true|$product_to_generated|$generated_to_generated
+generated-to-product|false|$generated_to_generated|$generated_to_product
+CASES
 
 report rename-into-render

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -45,7 +45,9 @@ run_argument_case() { # LABEL KIND OPTION VALUE
 }
 
 # label | shape | option under test | value
+argument_row_count=0
 while IFS='|' read -r label kind option value; do
+  argument_row_count=$((argument_row_count + 1))
   run_argument_case "$label" "$kind" "$option" "$value"
 done <<'CASES'
 unknown-flag|unknown|<none>|<none>
@@ -64,6 +66,7 @@ flag-value-head|flag-value|--head|--output
 flag-value-repo|flag-value|--repo|--head
 flag-value-output|flag-value|--output|--head
 CASES
+require_rows argument "$argument_row_count"
 
 if verdict_dash="$(classify --repo "$repo" --event push --base "$base" --head -)"; then
   dash_status=0
@@ -134,7 +137,9 @@ verdict_bytes=6861726e6573735f6f6e6c793d747275650a
 append_bytes=6f746865725f6b65793d6b6570740a6861726e6573735f6f6e6c793d747275650a
 
 # label | mode | stdout bytes | explicit-output bytes | environment-output bytes
+output_row_count=0
 while IFS='|' read -r label mode expected_stdout expected_explicit expected_env; do
+  output_row_count=$((output_row_count + 1))
   run_output_case "$label" "$mode" "$expected_stdout" "$expected_explicit" "$expected_env"
 done <<CASES
 explicit-output-append|explicit-append|$verdict_bytes|$append_bytes|
@@ -142,6 +147,7 @@ environment-output|environment|$verdict_bytes||$verdict_bytes
 explicit-output-precedence|explicit-precedence|$verdict_bytes|$verdict_bytes|
 stdout-only|stdout-only|$verdict_bytes||
 CASES
+require_rows output "$output_row_count"
 
 if paths="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>&1 >/dev/null)"; then
   paths_status=0

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
-# A wiring error is not a verdict. A bad call exits 2 with nothing on stdout,
-# so the caller's step goes red instead of quietly running every lane forever.
-# And the verdict reaches the file the caller named, beside stdout.
+# Wiring errors exit with no verdict. Successful classifications write the
+# same verdict to stdout and to the selected output file.
 set -euo pipefail
 # shellcheck source=lib/sandbox.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
 
 repo="$(new_repo wiring)"
-commit_paths "$repo" "baseline" README.md
+commit_paths "$repo" baseline README.md
 base="$(git -C "$repo" rev-parse HEAD)"
 commit_paths "$repo" "render only" .agents/skills/orch/SKILL.md
 
-# Bounded: an argument loop that fails to consume its input hangs rather than
-# exits, and a hung CI step is the failure this catches. macOS ships no
-# timeout, and the suite still runs there without the bound.
 bounded() { # ARGS...
   if command -v timeout >/dev/null 2>&1; then
     timeout 30 "$@"
@@ -25,96 +21,149 @@ bounded() { # ARGS...
 wiring() { # LABEL ARGS...
   local label="$1" out status
   shift
-  set +e
-  out="$(bounded "$HARNESS_ONLY" "$@" 2>/dev/null)"
-  status=$?
-  set -e
+  if out="$(bounded "$HARNESS_ONLY" "$@" 2>/dev/null)"; then
+    status=0
+  else
+    status=$?
+  fi
   assert_eq "$label" "exit 2 stdout=''" "exit $status stdout='$out'"
 }
 
-wiring "an unknown flag" --repo "$repo" --event push --base "$base" --nope
-wiring "a positional argument" --repo "$repo" --event push "$base"
-wiring "no --event at all" --repo "$repo" --base "$base"
-wiring "an empty --event" --repo "$repo" --event "" --base "$base"
-wiring "--event with no value" --repo "$repo" --base "$base" --event
-wiring "--base with no value" --repo "$repo" --event push --base
-wiring "--head with no value" --repo "$repo" --event push --base "$base" --head
-wiring "--repo with no value" --event push --base "$base" --repo
-wiring "--output with no value" --repo "$repo" --event push --base "$base" --output
-wiring "an empty --head" --repo "$repo" --event push --base "$base" --head ""
+run_argument_case() { # LABEL KIND OPTION VALUE
+  local label="$1" kind="$2" option="$3" value="$4"
+  local args=(--repo "$repo" --event push --base "$base")
+  case "$kind" in
+    unknown) args+=(--nope) ;;
+    positional) args+=("$base") ;;
+    missing-event) args=(--repo "$repo" --base "$base") ;;
+    empty-value) args+=("$option" "") ;;
+    missing-value) args+=("$option") ;;
+    flag-value) args+=("$option" "$value") ;;
+    *) echo "FAIL: unknown argument case '$kind'" >&2; exit 1 ;;
+  esac
+  wiring "$label" "${args[@]}"
+}
 
-# A flag where a value belongs. Consuming it would classify '--base' as an
-# unrecognised event and hand back a verdict for a call that named no event.
-wiring "--event followed by another flag" --repo "$repo" --event --base "$base"
-wiring "--base followed by another flag" --repo "$repo" --event push --base --head
-wiring "--head followed by another flag" \
-  --repo "$repo" --event push --base "$base" --head --output
-wiring "--repo followed by another flag" --repo --event push --base "$base"
-wiring "--output followed by another flag" \
-  --repo "$repo" --event push --base "$base" --output --head
+# label | shape | option under test | value
+while IFS='|' read -r label kind option value; do
+  run_argument_case "$label" "$kind" "$option" "$value"
+done <<'CASES'
+unknown-flag|unknown|<none>|<none>
+positional-argument|positional|<none>|<none>
+missing-event|missing-event|--event|<none>
+empty-event|empty-value|--event|<empty>
+missing-event-value|missing-value|--event|<none>
+missing-base-value|missing-value|--base|<none>
+missing-head-value|missing-value|--head|<none>
+missing-repo-value|missing-value|--repo|<none>
+missing-output-value|missing-value|--output|<none>
+empty-head|empty-value|--head|<empty>
+flag-value-event|flag-value|--event|--head
+flag-value-base|flag-value|--base|--head
+flag-value-head|flag-value|--head|--output
+flag-value-repo|flag-value|--repo|--head
+flag-value-output|flag-value|--output|--head
+CASES
 
-# A lone dash and a dash-led path are values, not flags: only a flag shape
-# (a dash with something after it) is refused.
-verdict_dash="$(classify --repo "$repo" --event push --base "$base" --head "-" || true)"
-assert_eq "a lone dash is taken as a value" "harness_only=false" "$verdict_dash"
+if verdict_dash="$(classify --repo "$repo" --event push --base "$base" --head -)"; then
+  dash_status=0
+else
+  dash_status=$?
+fi
+assert_eq lone-dash-value "harness_only=false exit 0" \
+  "$verdict_dash exit $dash_status"
 
-# An --output the process cannot append to is wiring, not data: the caller
-# asked for a file and would otherwise get silence.
 unwritable="$SANDBOX/no-such-dir/out.txt"
-wiring "an unwritable --output" \
+wiring output-parent-absent \
   --repo "$repo" --event push --base "$base" --output "$unwritable"
 
-# A file that OPENS and then refuses the write. A zero-length probe passes on
-# /dev/full, so this is the case that proves the verdict reaches the file
-# before stdout rather than after. Linux only; announced when absent.
 if [ -c /dev/full ]; then
-  wiring "an --output that accepts the open and fails the write" \
+  wiring output-write-fails \
     --repo "$repo" --event push --base "$base" --output /dev/full
 else
   echo "  SKIP: no /dev/full, the full-device case did not run"
 fi
 
-# --output appends beside stdout and keeps what the file already held.
-out_file="$SANDBOX/github_output"
-printf 'other_key=kept\n' >"$out_file"
-verdict="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" --output "$out_file" 2>/dev/null)"
-assert_eq "--output leaves the verdict on stdout too" "harness_only=true" "$verdict"
-assert_eq "--output appends without clobbering" \
-  "other_key=kept harness_only=true" "$(tr '\n' ' ' <"$out_file" | sed -e 's/ $//')"
+file_bytes() { # FILE
+  od -An -tx1 "$1" | tr -d ' \n'
+}
 
-# With no --output, the file is $GITHUB_OUTPUT — what a workflow step sets.
-env_file="$SANDBOX/env_output"
-: >"$env_file"
-GITHUB_OUTPUT="$env_file" "$HARNESS_ONLY" --repo "$repo" --event push --base "$base" >/dev/null 2>&1
-assert_eq "GITHUB_OUTPUT receives the verdict" "harness_only=true" "$(cat "$env_file")"
+run_output_case() { # LABEL MODE EXPECTED_STDOUT EXPECTED_EXPLICIT EXPECTED_ENV
+  local label="$1" mode="$2" expected_stdout="$3"
+  local expected_explicit="$4" expected_env="$5"
+  local case_dir="$SANDBOX/output-$label" stdout_file explicit_file env_file status actual
+  mkdir -p "$case_dir"
+  stdout_file="$case_dir/stdout"
+  explicit_file="$case_dir/explicit"
+  env_file="$case_dir/env"
+  : >"$explicit_file"
+  : >"$env_file"
 
-override="$SANDBOX/override_output"
-: >"$override"
-: >"$env_file"
-GITHUB_OUTPUT="$env_file" "$HARNESS_ONLY" --repo "$repo" --event push --base "$base" \
-  --output "$override" >/dev/null 2>&1
-assert_eq "--output wins over GITHUB_OUTPUT" "harness_only=true" "$(cat "$override")"
-assert_eq "--output leaves GITHUB_OUTPUT untouched" "" "$(cat "$env_file")"
+  case "$mode" in
+    explicit-append)
+      printf 'other_key=kept\n' >"$explicit_file"
+      if env -u GITHUB_OUTPUT "$HARNESS_ONLY" \
+        --repo "$repo" --event push --base "$base" --output "$explicit_file" \
+        >"$stdout_file" 2>/dev/null; then status=0; else status=$?; fi
+      ;;
+    environment)
+      if GITHUB_OUTPUT="$env_file" "$HARNESS_ONLY" \
+        --repo "$repo" --event push --base "$base" \
+        >"$stdout_file" 2>/dev/null; then status=0; else status=$?; fi
+      ;;
+    explicit-precedence)
+      if GITHUB_OUTPUT="$env_file" "$HARNESS_ONLY" \
+        --repo "$repo" --event push --base "$base" --output "$explicit_file" \
+        >"$stdout_file" 2>/dev/null; then status=0; else status=$?; fi
+      ;;
+    stdout-only)
+      if env -u GITHUB_OUTPUT "$HARNESS_ONLY" \
+        --repo "$repo" --event push --base "$base" \
+        >"$stdout_file" 2>/dev/null; then status=0; else status=$?; fi
+      ;;
+    *) echo "FAIL: unknown output case '$mode'" >&2; exit 1 ;;
+  esac
 
-# With neither, stdout is the whole contract and nothing is written anywhere.
-lone="$(env -u GITHUB_OUTPUT "$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>/dev/null)"
-assert_eq "no output file is required" "harness_only=true" "$lone"
+  actual="exit=$status stdout=$(file_bytes "$stdout_file") explicit=$(file_bytes "$explicit_file") env=$(file_bytes "$env_file")"
+  assert_eq "$label" \
+    "exit=0 stdout=$expected_stdout explicit=$expected_explicit env=$expected_env" \
+    "$actual"
+}
 
-# stdout carries the verdict line and nothing else; the changed paths are
-# stderr's, so `$(harness-only …)` is safe to read directly.
-assert_eq "stdout is the verdict line alone" "1" \
-  "$(printf '%s\n' "$lone" | wc -l | tr -d ' ')"
-paths="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>&1 >/dev/null)"
+verdict_bytes=6861726e6573735f6f6e6c793d747275650a
+append_bytes=6f746865725f6b65793d6b6570740a6861726e6573735f6f6e6c793d747275650a
+
+# label | mode | stdout bytes | explicit-output bytes | environment-output bytes
+while IFS='|' read -r label mode expected_stdout expected_explicit expected_env; do
+  run_output_case "$label" "$mode" "$expected_stdout" "$expected_explicit" "$expected_env"
+done <<CASES
+explicit-output-append|explicit-append|$verdict_bytes|$append_bytes|
+environment-output|environment|$verdict_bytes||$verdict_bytes
+explicit-output-precedence|explicit-precedence|$verdict_bytes|$verdict_bytes|
+stdout-only|stdout-only|$verdict_bytes||
+CASES
+
+if paths="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>&1 >/dev/null)"; then
+  paths_status=0
+else
+  paths_status=$?
+fi
 case "$paths" in
-  *"changed: .agents/skills/orch/SKILL.md"*)
-    assert_eq "the changed paths reach stderr" pass pass ;;
-  *) assert_eq "the changed paths reach stderr" pass "$paths" ;;
+  *"changed: .agents/skills/orch/SKILL.md"*) paths_contract=present ;;
+  *) paths_contract="$paths" ;;
 esac
+assert_eq changed-path-stderr "present exit 0" \
+  "$paths_contract exit $paths_status"
 
-help_out="$("$HARNESS_ONLY" --help)"
+if help_out="$("$HARNESS_ONLY" --help)"; then
+  help_status=0
+else
+  help_status=$?
+fi
 case "$help_out" in
-  "Usage: harness-only"*) assert_eq "--help prints the usage" pass pass ;;
-  *) assert_eq "--help prints the usage" pass "$help_out" ;;
+  "Usage: harness-only"*) help_contract=usage ;;
+  *) help_contract="$help_out" ;;
 esac
+assert_eq help "usage exit 0" "$help_contract exit $help_status"
 
 report wiring-errors

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -41,7 +41,9 @@ commit_paths "$parser_repo" render .agents/skills/orch/SKILL.md
 parser_head="$(git -C "$parser_repo" rev-parse HEAD)"
 probe_value="$SANDBOX/probe-value"
 parser_rejections=""
+documented_option_row_count=0
 for flag in $(printf '%s\n' "$blocks" | grep -oE '(^|[[:space:]])--[a-z-]+' | tr -d ' ' | sort -u); do
+  documented_option_row_count=$((documented_option_row_count + 1))
   if "$HARNESS_ONLY" --repo "$parser_repo" --event push \
     --base "$parser_base" --head "$parser_head" "$flag" "$probe_value" \
     >/dev/null 2>&1; then
@@ -53,7 +55,60 @@ for flag in $(printf '%s\n' "$blocks" | grep -oE '(^|[[:space:]])--[a-z-]+' | tr
     parser_rejections="$parser_rejections $flag:$parser_status"
   fi
 done
+require_rows documented-option "$documented_option_row_count"
 assert_eq "the shapes pass only flags the script accepts" "" "$parser_rejections"
+
+# A syntactically valid copy with an extractor that matches no options must
+# stop at the row floor. The copy omits this control to avoid nesting.
+# empty-documented-options-control:start
+control_root="$SANDBOX/empty-documented-options"
+cp -R "$TEST_DIR/.." "$control_root"
+control_script="$control_root/tests/wiring-shapes-empty-options.test.sh"
+if ! awk '
+  BEGIN { in_control = 0; option_loops = 0 }
+  /^# empty-documented-options-control:start$/ { in_control = 1; next }
+  /^# empty-documented-options-control:end$/ { in_control = 0; next }
+  in_control { next }
+  /^for flag in / {
+    needle = "--[a-z-]+"
+    position = index($0, needle)
+    if (position == 0) exit 2
+    $0 = substr($0, 1, position - 1) "##[a-z-]+" substr($0, position + length(needle))
+    option_loops += 1
+  }
+  { print }
+  END { if (in_control || option_loops != 1) exit 2 }
+' "$TEST_DIR/wiring-shapes.test.sh" >"$control_script"; then
+  echo "could not build the empty documented-option control" >&2
+  exit 1
+fi
+if cmp -s "$TEST_DIR/wiring-shapes.test.sh" "$control_script"; then
+  echo "the empty documented-option control changed no source" >&2
+  exit 1
+fi
+if bash -n "$control_script"; then
+  control_compile_status=0
+else
+  control_compile_status=$?
+fi
+assert_eq "the empty documented-option control compiles" 0 "$control_compile_status"
+[ "$control_compile_status" -eq 0 ] || exit 1
+control_status=0
+if bash "$control_script" >"$control_root/stdout" 2>"$control_root/stderr"; then
+  control_status=0
+else
+  control_status=$?
+fi
+assert_eq "an empty documented-option table fails itself" 1 "$control_status"
+if control_stderr="$(cat "$control_root/stderr")"; then
+  :
+else
+  echo "could not read the empty documented-option control diagnostic" >&2
+  exit 1
+fi
+assert_eq "the empty documented-option table names its failure" \
+  "FAIL: documented-option table executed no rows" "$control_stderr"
+# empty-documented-options-control:end
 
 # The push endpoints come from the event payload, with `github.sha` LAST. On a
 # branch-deletion push `github.event.after` is the all-zero sha and

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -31,15 +31,29 @@ assert_eq "the shapes name one script path" ".agents/skills/harness-ci/scripts/h
 assert_eq "that path is the one this package ships" "yes" \
   "$([ -x "$TEST_DIR/../scripts/harness-only" ] && echo yes || echo no)"
 
-# Every flag the shapes pass is one the script accepts.
-unknown_flags=""
+# Pass each extracted option to the real parser. A documented unknown option
+# must produce the wiring-error status instead of being accepted by a copy of
+# the parser's option list here.
+parser_repo="$(new_repo wiring-shapes-parser)"
+commit_paths "$parser_repo" baseline README.md
+parser_base="$(git -C "$parser_repo" rev-parse HEAD)"
+commit_paths "$parser_repo" render .agents/skills/orch/SKILL.md
+parser_head="$(git -C "$parser_repo" rev-parse HEAD)"
+probe_value="$SANDBOX/probe-value"
+parser_rejections=""
 for flag in $(printf '%s\n' "$blocks" | grep -oE '(^|[[:space:]])--[a-z-]+' | tr -d ' ' | sort -u); do
-  case "$flag" in
-    --event | --base | --head | --repo | --output) ;;
-    *) unknown_flags="$unknown_flags $flag" ;;
-  esac
+  if "$HARNESS_ONLY" --repo "$parser_repo" --event push \
+    --base "$parser_base" --head "$parser_head" "$flag" "$probe_value" \
+    >/dev/null 2>&1; then
+    parser_status=0
+  else
+    parser_status=$?
+  fi
+  if [ "$parser_status" != 0 ]; then
+    parser_rejections="$parser_rejections $flag:$parser_status"
+  fi
 done
-assert_eq "the shapes pass only flags the script accepts" "" "$unknown_flags"
+assert_eq "the shapes pass only flags the script accepts" "" "$parser_rejections"
 
 # The push endpoints come from the event payload, with `github.sha` LAST. On a
 # branch-deletion push `github.event.after` is the all-zero sha and
@@ -60,9 +74,10 @@ assert_eq "every HEAD expression tries github.event.after before github.sha" "" 
 # assertion that stops at `!= 'success' ||` would not see it.
 doc="$(cat "$WIRING")"
 case "$doc" in
-  *"SECOND gate"*) ;;
-  *) assert_eq "the two-gate variant is documented" "present" "absent" ;;
+  *"SECOND gate"*) second_gate=present ;;
+  *) second_gate=absent ;;
 esac
+assert_eq "the two-gate variant is documented" "present" "$second_gate"
 
 wrong_if="  if: \${{ !cancelled() && needs.changes.outputs.frontend == 'true' && !(needs.changes.result == 'success' && needs.changes.outputs.harness_only == 'true') }}"
 right_if="  if: \${{ !cancelled() && (needs.changes.result != 'success' || (needs.changes.outputs.frontend == 'true' && needs.changes.outputs.harness_only != 'true')) }}"
@@ -77,7 +92,7 @@ assert_eq "the working form is shown verbatim, exactly once" 1 \
 # what is pinned, not just its presence somewhere in the file.
 assert_eq "the WRONG label sits on the line above the fail-open form" \
   "  # WRONG when a family predicate is present" \
-  "$(printf '%s\n' "$doc" | grep -B1 -xF "$wrong_if" | head -1)"
+  "$(awk -v target="$wrong_if" '$0 == target { print previous } { previous = $0 }' "$WIRING")"
 
 # Indentation is checked structurally rather than by parsing: every block here
 # steps by two spaces, so an odd indent or a tab is hand-edit damage. This


### PR DESCRIPTION
KEN-1241 tests audit, lane F: Harness-CI test cases now use named rows with independent controls.

## What changed

- Reshaped event, path, move, argument, and output cases into visible named tables.
- Preserved the existing fail-closed, in-place, and workflow-wiring assertions.
- Made fixture setup fail closed and isolated it from inherited Git and GitHub output state.
- Preserved the classifier exit status when the tests capture its verdict.
- Added a row-count guard to every owned named table, including the retained documented-option table.

## Must-fail controls

Each table rejects an independently emptied row list. The retained documented-option table fails through its own guard before later controls can supply the accepted exit. The private controls compile before execution.

## Size

- Production lines added: 0.
- Test lines added: 445.
- Render-mirror lines added: 0.
- KEN-1241 states no expected-delta allowance.

## Test plan

- Preflight passed for 8 changed files at current head `d82436412fdcf6fbaa4aa7579430179075ae6565`.
- `tools/guard --full` exited 0 at fix head `cc52648a985ee2b4be2f6d7ef76389de2f78d091`.
- The changed Harness-CI suites passed with 8 event rows, 19 fail-closed checks, 2 in-place checks, 24 path-set rows, 5 rename rows, 24 wiring-error rows, and 15 wiring-shape checks.
- The UI test command passed 159 files with 1286 tests.
- Root's focused Harness-CI proof passed every changed suite at the fix head. Its receipt is `tmp/root-audit-proofs/harness-ci.json`.
- The Harness-CI source bytes are unchanged after the required rebase to current head `d82436412fdcf6fbaa4aa7579430179075ae6565`.

## Reviewer round

One specialist reviewer-test round passed. The narrow same-class fix receipt passed. The saved artifacts remain valid after storage migration and the source-identical rebase.

KEN-1241
