### PR TITLE
test(KEN-1241): the sticky-comment readers as one table of rows

### DIFF
--- a/.agents/skills/github/tests/sticky-verdict.test.sh
+++ b/.agents/skills/github/tests/sticky-verdict.test.sh
@@ -1,66 +1,105 @@
 #!/usr/bin/env bash
-# Unit tests for the two sticky-comment readers in github-api.sh:
-# `compute_sticky_verdict_from_body`, which turns a review comment body into
-# approved/changes/pending, and `select_sticky_comment_from_comments`, whose
-# known-bot fallback must not adopt an unrelated bot's status comment.
-# Fixture-driven — no `gh` calls.
+# sticky-verdict: the two sticky-comment readers in github-api.sh.
+# `compute_sticky_verdict_from_body` turns a review comment body into one of
+# approved/changes/pending; `select_sticky_comment_from_comments`, whose
+# known-bot fallback must not adopt an unrelated bot's status comment, is
+# driven by fixtures below the table. Both are pure string functions: no gh,
+# no network.
 #
-# Run:  bash skills/github/tests/sticky-verdict.test.sh
+# A row is `label|body|verdict`:
+#   body     the comment body, `\n` standing for a newline as GitHub delivers
+#            it; `@<name>` is the first comment's body in fixtures/<name>.json
+#   verdict  the word the reader prints: approved, changes or pending
 set -euo pipefail
+
+# The lib reads the repository root through git at source time; a suite
+# running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which would point that read elsewhere.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES="$TEST_DIR/fixtures"
 LIB="$TEST_DIR/../scripts/lib/github-api.sh"
-
-# The lib resolves PROJECT_ROOT itself at source time; both readers under
-# test are pure string functions that never reach it, gh, or the network.
 # shellcheck source=/dev/null
 source "$LIB"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
+  fi
+}
 
 # Read up front so a missing or unreadable fixture fails the suite under
 # set -e rather than passing an empty body into an assertion.
 summary_fixture="$(cat "$FIXTURES/claude_review_summary_comments.json")"
 untrusted_fixture="$(cat "$FIXTURES/untrusted_status_comments.json")"
 
-PASS=0
-FAIL=0
-
-assert_eq() {
-    local got="$1" want="$2" name="$3"
-    if [[ "$got" == "$want" ]]; then
-        PASS=$((PASS + 1))
-        printf '  ok    %s\n' "$name"
-    else
-        FAIL=$((FAIL + 1))
-        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-    fi
+body_of() {
+  case "$1" in
+    @*) jq -r '.[0].body' "$FIXTURES/${1#@}.json" ;;
+    *) printf '%b' "$1" ;;
+  esac
 }
 
-verdict() { compute_sticky_verdict_from_body "$1"; }
+run() {
+  printf 'verdict=%s' "$(compute_sticky_verdict_from_body "$(body_of "$1")")"
+}
 
-echo "=== compute_sticky_verdict_from_body ==="
-assert_eq "$(verdict "View job\n- [ ] todo")" "pending" "checklist with no review section = pending"
-assert_eq "$(verdict "## Review\n✅ Approved")" "approved" "review section + ✅ + approved = approved"
-assert_eq "$(verdict "## Review\n⚠️ changes requested")" "changes" "review section + ⚠️ = changes"
-assert_eq "$(verdict "## Review\n✅ Approved with ⚠️ caveats")" "changes" "mixed signals = changes"
-summary_body="$(jq -r '.[0].body' <<<"$summary_fixture")"
-assert_eq "$(verdict "$summary_body")" "approved" "Claude Review Summary approved despite unrelated changes prose"
-assert_eq "$(verdict "Verdict: changes")" "changes" "bare Verdict: changes = changes"
-assert_eq "$(verdict "Status: changes")" "changes" "bare Status: changes = changes"
-assert_eq "$(verdict "Recommendation: approve")" "approved" "bare Recommendation: approve = approved"
-assert_eq "$(verdict "Recommendation: do not approve")" "changes" "negated Recommendation approval = changes"
-assert_eq "$(verdict "Verdict: approval not recommended")" "changes" "approval-not-recommended verdict = changes"
-assert_eq "$(verdict "Status: pending approval")" "pending" "pending approval directive stays pending"
-assert_eq "$(verdict "Status: approval required")" "pending" "approval required directive stays pending"
-assert_eq "$(verdict "Verdict: approved; no changes requested but cannot merge")" "changes" "real blocker wins over approved plus no changes requested"
-assert_eq "$(verdict "Status: not ready for approval")" "pending" "not-ready-for-approval text stays pending"
-assert_eq "$(verdict "Status: not yet approved")" "pending" "not-yet-approved text stays pending"
-assert_eq "$(verdict "Status: not ready to approve")" "pending" "not-ready-to-approve text stays pending"
-assert_eq "$(verdict "Verdict: approval denied")" "changes" "approval denied text = changes"
-assert_eq "$(verdict "Verdict: approval withheld")" "changes" "approval withheld text = changes"
-assert_eq "$(verdict "Verdict: rejected")" "changes" "rejected verdict = changes"
-assert_eq "$(verdict "Verdict: denied")" "changes" "denied verdict = changes"
-assert_eq "$(verdict "Recommendation: no approval")" "changes" "no approval text = changes"
+run_table() {
+  local title="$1" rows="$2" label body verdict got row field before=$((PASS + FAIL))
+  echo "=== $title ==="
+  while IFS= read -r row; do
+    [[ "$row" != "" ]] || continue
+    IFS='|' read -r label body verdict <<<"$row"
+    for field in "$label" "$body" "$verdict"; do
+      [[ "$field" != "" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    got="$(run "$body")"
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${GITHUB_TABLE_PROBE:-}" == 1 ]]; then
+      printf '%s => %s\n' "$label" "$got"
+      continue
+    fi
+    assert_eq "$got" "verdict=$verdict" "$label"
+  done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt "$before" ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+}
+
+run_table "compute_sticky_verdict_from_body" "\
+an empty body is pending|\\n|pending
+a checklist under a job link with no review section is pending|View job\\n- [ ] todo|pending
+a review section carrying a check mark and approved is approved|## Review\\n✅ Approved|approved
+a check-mark approval line outside any section is approved|Looks good.\\n✅ Approved|approved
+a review section carrying a warning sign is changes|## Review\\n⚠️ changes requested|changes
+mixed signals under one section are changes|## Review\\n✅ Approved with ⚠️ caveats|changes
+the review summary fixture is approved despite prose mentioning changes|@claude_review_summary_comments|approved
+a blocker sentence under a review summary heading is changes|### Review Summary\\nThis PR cannot merge until the flaky test is fixed.|changes
+a bare Verdict: changes is changes|Verdict: changes|changes
+a bare Status: changes is changes|Status: changes|changes
+a bare Recommendation: approve is approved|Recommendation: approve|approved
+a negated recommendation to approve is changes|Recommendation: do not approve|changes
+an approval-not-recommended verdict is changes|Verdict: approval not recommended|changes
+a pending-approval status stays pending|Status: pending approval|pending
+an approval-required status stays pending|Status: approval required|pending
+a pending clause outranks approval text|## Review\\n✅ Approved for merge, awaiting approval from a maintainer|pending
+a real blocker wins over approved plus no changes requested|Verdict: approved; no changes requested but cannot merge|changes
+a not-ready-for-approval status stays pending|Status: not ready for approval|pending
+a not-yet-approved status stays pending|Status: not yet approved|pending
+a not-ready-to-approve status stays pending|Status: not ready to approve|pending
+an approval-denied verdict is changes|Verdict: approval denied|changes
+an approval-withheld verdict is changes|Verdict: approval withheld|changes
+a rejected verdict is changes|Verdict: rejected|changes
+a denied verdict is changes|Verdict: denied|changes
+a no-approval recommendation is changes|Recommendation: no approval|changes
+"
 
 echo
 echo "=== select_sticky_comment_from_comments ==="
@@ -72,7 +111,5 @@ assert_eq "$selected" "" "known-bot fallback ignores a non-review bot status com
 selected=$(select_sticky_comment_from_comments "$summary_fixture" "claude[bot]" false)
 assert_eq "$(jq -r '.user.login' <<<"$selected")" "claude[bot]" "the requested bot's own review summary is selected"
 
-echo
-echo "----"
-printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/github/tests/sticky-verdict.test.sh
+++ b/.agents/skills/github/tests/sticky-verdict.test.sh
@@ -75,10 +75,10 @@ run_table() {
 
 run_table "compute_sticky_verdict_from_body" "\
 an empty body is pending|\\n|pending
-a checklist under a job link with no review section is pending|View job\\n- [ ] todo|pending
+a checklist with no review signal is pending|Checklist\\n- [ ] todo|pending
 a review section carrying a check mark and approved is approved|## Review\\n✅ Approved|approved
 a check-mark approval line outside any section is approved|Looks good.\\n✅ Approved|approved
-a review section carrying a warning sign is changes|## Review\\n⚠️ changes requested|changes
+a review section carrying a warning sign is changes|## Review\\n⚠️ Please take another look|changes
 mixed signals under one section are changes|## Review\\n✅ Approved with ⚠️ caveats|changes
 the review summary fixture is approved despite prose mentioning changes|@claude_review_summary_comments|approved
 a blocker sentence under a review summary heading is changes|### Review Summary\\nThis PR cannot merge until the flaky test is fixed.|changes

--- a/skills/github/tests/sticky-verdict.test.sh
+++ b/skills/github/tests/sticky-verdict.test.sh
@@ -1,66 +1,105 @@
 #!/usr/bin/env bash
-# Unit tests for the two sticky-comment readers in github-api.sh:
-# `compute_sticky_verdict_from_body`, which turns a review comment body into
-# approved/changes/pending, and `select_sticky_comment_from_comments`, whose
-# known-bot fallback must not adopt an unrelated bot's status comment.
-# Fixture-driven — no `gh` calls.
+# sticky-verdict: the two sticky-comment readers in github-api.sh.
+# `compute_sticky_verdict_from_body` turns a review comment body into one of
+# approved/changes/pending; `select_sticky_comment_from_comments`, whose
+# known-bot fallback must not adopt an unrelated bot's status comment, is
+# driven by fixtures below the table. Both are pure string functions: no gh,
+# no network.
 #
-# Run:  bash skills/github/tests/sticky-verdict.test.sh
+# A row is `label|body|verdict`:
+#   body     the comment body, `\n` standing for a newline as GitHub delivers
+#            it; `@<name>` is the first comment's body in fixtures/<name>.json
+#   verdict  the word the reader prints: approved, changes or pending
 set -euo pipefail
+
+# The lib reads the repository root through git at source time; a suite
+# running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which would point that read elsewhere.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES="$TEST_DIR/fixtures"
 LIB="$TEST_DIR/../scripts/lib/github-api.sh"
-
-# The lib resolves PROJECT_ROOT itself at source time; both readers under
-# test are pure string functions that never reach it, gh, or the network.
 # shellcheck source=/dev/null
 source "$LIB"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
+  fi
+}
 
 # Read up front so a missing or unreadable fixture fails the suite under
 # set -e rather than passing an empty body into an assertion.
 summary_fixture="$(cat "$FIXTURES/claude_review_summary_comments.json")"
 untrusted_fixture="$(cat "$FIXTURES/untrusted_status_comments.json")"
 
-PASS=0
-FAIL=0
-
-assert_eq() {
-    local got="$1" want="$2" name="$3"
-    if [[ "$got" == "$want" ]]; then
-        PASS=$((PASS + 1))
-        printf '  ok    %s\n' "$name"
-    else
-        FAIL=$((FAIL + 1))
-        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-    fi
+body_of() {
+  case "$1" in
+    @*) jq -r '.[0].body' "$FIXTURES/${1#@}.json" ;;
+    *) printf '%b' "$1" ;;
+  esac
 }
 
-verdict() { compute_sticky_verdict_from_body "$1"; }
+run() {
+  printf 'verdict=%s' "$(compute_sticky_verdict_from_body "$(body_of "$1")")"
+}
 
-echo "=== compute_sticky_verdict_from_body ==="
-assert_eq "$(verdict "View job\n- [ ] todo")" "pending" "checklist with no review section = pending"
-assert_eq "$(verdict "## Review\n✅ Approved")" "approved" "review section + ✅ + approved = approved"
-assert_eq "$(verdict "## Review\n⚠️ changes requested")" "changes" "review section + ⚠️ = changes"
-assert_eq "$(verdict "## Review\n✅ Approved with ⚠️ caveats")" "changes" "mixed signals = changes"
-summary_body="$(jq -r '.[0].body' <<<"$summary_fixture")"
-assert_eq "$(verdict "$summary_body")" "approved" "Claude Review Summary approved despite unrelated changes prose"
-assert_eq "$(verdict "Verdict: changes")" "changes" "bare Verdict: changes = changes"
-assert_eq "$(verdict "Status: changes")" "changes" "bare Status: changes = changes"
-assert_eq "$(verdict "Recommendation: approve")" "approved" "bare Recommendation: approve = approved"
-assert_eq "$(verdict "Recommendation: do not approve")" "changes" "negated Recommendation approval = changes"
-assert_eq "$(verdict "Verdict: approval not recommended")" "changes" "approval-not-recommended verdict = changes"
-assert_eq "$(verdict "Status: pending approval")" "pending" "pending approval directive stays pending"
-assert_eq "$(verdict "Status: approval required")" "pending" "approval required directive stays pending"
-assert_eq "$(verdict "Verdict: approved; no changes requested but cannot merge")" "changes" "real blocker wins over approved plus no changes requested"
-assert_eq "$(verdict "Status: not ready for approval")" "pending" "not-ready-for-approval text stays pending"
-assert_eq "$(verdict "Status: not yet approved")" "pending" "not-yet-approved text stays pending"
-assert_eq "$(verdict "Status: not ready to approve")" "pending" "not-ready-to-approve text stays pending"
-assert_eq "$(verdict "Verdict: approval denied")" "changes" "approval denied text = changes"
-assert_eq "$(verdict "Verdict: approval withheld")" "changes" "approval withheld text = changes"
-assert_eq "$(verdict "Verdict: rejected")" "changes" "rejected verdict = changes"
-assert_eq "$(verdict "Verdict: denied")" "changes" "denied verdict = changes"
-assert_eq "$(verdict "Recommendation: no approval")" "changes" "no approval text = changes"
+run_table() {
+  local title="$1" rows="$2" label body verdict got row field before=$((PASS + FAIL))
+  echo "=== $title ==="
+  while IFS= read -r row; do
+    [[ "$row" != "" ]] || continue
+    IFS='|' read -r label body verdict <<<"$row"
+    for field in "$label" "$body" "$verdict"; do
+      [[ "$field" != "" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    got="$(run "$body")"
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${GITHUB_TABLE_PROBE:-}" == 1 ]]; then
+      printf '%s => %s\n' "$label" "$got"
+      continue
+    fi
+    assert_eq "$got" "verdict=$verdict" "$label"
+  done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt "$before" ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+}
+
+run_table "compute_sticky_verdict_from_body" "\
+an empty body is pending|\\n|pending
+a checklist under a job link with no review section is pending|View job\\n- [ ] todo|pending
+a review section carrying a check mark and approved is approved|## Review\\n✅ Approved|approved
+a check-mark approval line outside any section is approved|Looks good.\\n✅ Approved|approved
+a review section carrying a warning sign is changes|## Review\\n⚠️ changes requested|changes
+mixed signals under one section are changes|## Review\\n✅ Approved with ⚠️ caveats|changes
+the review summary fixture is approved despite prose mentioning changes|@claude_review_summary_comments|approved
+a blocker sentence under a review summary heading is changes|### Review Summary\\nThis PR cannot merge until the flaky test is fixed.|changes
+a bare Verdict: changes is changes|Verdict: changes|changes
+a bare Status: changes is changes|Status: changes|changes
+a bare Recommendation: approve is approved|Recommendation: approve|approved
+a negated recommendation to approve is changes|Recommendation: do not approve|changes
+an approval-not-recommended verdict is changes|Verdict: approval not recommended|changes
+a pending-approval status stays pending|Status: pending approval|pending
+an approval-required status stays pending|Status: approval required|pending
+a pending clause outranks approval text|## Review\\n✅ Approved for merge, awaiting approval from a maintainer|pending
+a real blocker wins over approved plus no changes requested|Verdict: approved; no changes requested but cannot merge|changes
+a not-ready-for-approval status stays pending|Status: not ready for approval|pending
+a not-yet-approved status stays pending|Status: not yet approved|pending
+a not-ready-to-approve status stays pending|Status: not ready to approve|pending
+an approval-denied verdict is changes|Verdict: approval denied|changes
+an approval-withheld verdict is changes|Verdict: approval withheld|changes
+a rejected verdict is changes|Verdict: rejected|changes
+a denied verdict is changes|Verdict: denied|changes
+a no-approval recommendation is changes|Recommendation: no approval|changes
+"
 
 echo
 echo "=== select_sticky_comment_from_comments ==="
@@ -72,7 +111,5 @@ assert_eq "$selected" "" "known-bot fallback ignores a non-review bot status com
 selected=$(select_sticky_comment_from_comments "$summary_fixture" "claude[bot]" false)
 assert_eq "$(jq -r '.user.login' <<<"$selected")" "claude[bot]" "the requested bot's own review summary is selected"
 
-echo
-echo "----"
-printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/github/tests/sticky-verdict.test.sh
+++ b/skills/github/tests/sticky-verdict.test.sh
@@ -75,10 +75,10 @@ run_table() {
 
 run_table "compute_sticky_verdict_from_body" "\
 an empty body is pending|\\n|pending
-a checklist under a job link with no review section is pending|View job\\n- [ ] todo|pending
+a checklist with no review signal is pending|Checklist\\n- [ ] todo|pending
 a review section carrying a check mark and approved is approved|## Review\\n✅ Approved|approved
 a check-mark approval line outside any section is approved|Looks good.\\n✅ Approved|approved
-a review section carrying a warning sign is changes|## Review\\n⚠️ changes requested|changes
+a review section carrying a warning sign is changes|## Review\\n⚠️ Please take another look|changes
 mixed signals under one section are changes|## Review\\n✅ Approved with ⚠️ caveats|changes
 the review summary fixture is approved despite prose mentioning changes|@claude_review_summary_comments|approved
 a blocker sentence under a review summary heading is changes|### Review Summary\\nThis PR cannot merge until the flaky test is fixed.|changes


### PR DESCRIPTION
Reshapes `skills/github/tests/sticky-verdict.test.sh` (78 lines, twenty-one unrolled `assert_eq "$(verdict "…")"` lines over `compute_sticky_verdict_from_body` plus a three-assertion `select_sticky_comment_from_comments` block) to code-quality § Tests: one table of `label|body|verdict` rows; the select block is retained as written, since it already asserts the fixture is non-empty before asserting nothing was selected.

The old rows passed bash double-quoted strings, so `"## Review\n✅ Approved"` reached the reader as one line carrying a literal backslash-n; no row ever reached the section arms of the reader's line scan. The table renders `\n` through `printf '%b'` to the newline GitHub delivers. Every former body was measured both ways and every verdict is unchanged. Four rows are new: an empty-body row (the mutant printing approved at the final fallthrough reddens it), and three rows each the one-row kill of a measured survivor of the must-fail battery: a check-mark line outside any section, a blocker sentence under a review summary heading, and a pending clause beside approval text. After the reviewer round, two former rows lost a masking word so each reaches the arm its label names: the warning-sign row no longer also says "changes requested", and the checklist row no longer carries "View job", itself a review marker.

The tracked render under `.agents` is replayed with `patch` and is byte-equal.

## Folded cases, with the surviving row

| Former case | Surviving row |
|---|---|
| the twenty-one `verdict "…"` assertions (checklist, review section with ✅/⚠️/mixed, the review summary fixture, the bare directives, the negated, denied, withheld, rejected and pending directive forms, the blocker beside `no changes requested`) | rows 2 to 25 less rows 4, 8 and 16, in the old order, same verdict; every body measured identical as a literal backslash-n and as a newline |
| the untrusted fixture holds one comment; the known-bot fallback rejects it; the requested bot's own summary is selected (3) | unchanged, below the table |

## Must-fail battery

`mutate-sv.py` (in the lane's scratchpad; the records are `mutants-sv.txt`, `mutants-sv-2.txt` and `mutants-sv-3.txt`): 18 of 18 killed on the final head; 13 of 16 before the three added rows; the two reviewer mutants (the warning arm gone, the checklist branch printing changes) survived the first head and are killed after the two row corrections. m01 to m04 drop each term of the changes condition, m05 the pending branch, m06/m07 each term of the approved condition, m08/m09 a branch printing the wrong word, m10 the negated-changes strip dropping the whole line, m11 to m13 the directive, emoji and review-summary collection arms, m14 pending directives counted as denied, m15 the known-bot fallback adopting any bot, m16 the selector answering nothing. Mechanism controls: a row with an empty field exits 1 before any assertion; a table asserting no row exits 2.

## Reviewer round

reviewer-test on 07d21de89: ACCEPT WITH FIXES, both applied in the second commit (973a4e9b4 after the push rebased both commits onto main 980c99dcf; range-diff shows both `=`). All 21 former verdict assertions and the 3 select assertions map to rows or stay; the newline render measured identical per former row; 54 mutants run, the two survivors that were rows masking their own arm are the fixes above. Recorded, no ask: the five pending rows pin only that their phrase is not a denial (the fallthrough also prints pending, so dropping a row's own alternative from the pending list survives); the approval-denied row is separately not a sole pin because the bare `denied` alternative also matches its body, and the denied row already pins that alternative; the untested awk arms (`### Recommendation`, `### Inline`, the 8-line window), the `Review Complete ✅` / `**Approved**` / `ready for merge` forms and the two remaining negated-changes strips are pre-existing gaps with no former row, left as such. The three added rows are shipped shapes (the claude fixtures' heading, sticky-comment.sh's whole-body ✅ grep, a phrase the pending list names).

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
