### PR TITLE
test(KEN-1241): fail closed on missing Iced guidance sources

### DIFF
--- a/.agents/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
+++ b/.agents/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
@@ -21,11 +21,23 @@ SOURCES=("$SKILL_DIR/SKILL.md" "$SKILL_DIR/references")
 
 # 1. No `mouse_area(...).on_press_maybe(...)` construct anywhere in the guidance.
 #    Matches a `mouse_area` occurrence followed on the same line by `.on_press_maybe`.
-if grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" >/dev/null 2>&1; then
-    fail "found forbidden mouse_area(...).on_press_maybe(...) construct:"
-    grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" >&2 || true
+if [ "${#SOURCES[@]}" -eq 0 ]; then
+    fail "guidance source table is empty"
 else
-    pass "no mouse_area(...).on_press_maybe(...) construct in guidance sources"
+    pass "guidance source table is not empty"
+
+    if forbidden_matches="$(grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" 2>&1)"; then
+        fail "found forbidden mouse_area(...).on_press_maybe(...) construct:"
+        printf '%s\n' "$forbidden_matches" >&2
+    else
+        forbidden_status=$?
+        if [ "$forbidden_status" -eq 1 ]; then
+            pass "no mouse_area(...).on_press_maybe(...) construct in guidance sources"
+        else
+            fail "could not search guidance sources for mouse_area(...).on_press_maybe(...):"
+            printf '%s\n' "$forbidden_matches" >&2
+        fi
+    fi
 fi
 
 # 2. The correct conditional pattern (gate the on_press call, keep wrapper) is present.

--- a/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
+++ b/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
@@ -21,11 +21,23 @@ SOURCES=("$SKILL_DIR/SKILL.md" "$SKILL_DIR/references")
 
 # 1. No `mouse_area(...).on_press_maybe(...)` construct anywhere in the guidance.
 #    Matches a `mouse_area` occurrence followed on the same line by `.on_press_maybe`.
-if grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" >/dev/null 2>&1; then
-    fail "found forbidden mouse_area(...).on_press_maybe(...) construct:"
-    grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" >&2 || true
+if [ "${#SOURCES[@]}" -eq 0 ]; then
+    fail "guidance source table is empty"
 else
-    pass "no mouse_area(...).on_press_maybe(...) construct in guidance sources"
+    pass "guidance source table is not empty"
+
+    if forbidden_matches="$(grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" 2>&1)"; then
+        fail "found forbidden mouse_area(...).on_press_maybe(...) construct:"
+        printf '%s\n' "$forbidden_matches" >&2
+    else
+        forbidden_status=$?
+        if [ "$forbidden_status" -eq 1 ]; then
+            pass "no mouse_area(...).on_press_maybe(...) construct in guidance sources"
+        else
+            fail "could not search guidance sources for mouse_area(...).on_press_maybe(...):"
+            printf '%s\n' "$forbidden_matches" >&2
+        fi
+    fi
 fi
 
 # 2. The correct conditional pattern (gate the on_press call, keep wrapper) is present.


### PR DESCRIPTION
KEN-1241 tests audit, lane F2: The Iced-rs guidance test now fails closed when its source table is empty or unreadable.

## What changed

- Added a named assertion that rejects an empty guidance-source table.
- Distinguished a true forbidden-pattern absence from a source read error.
- Preserved the existing union check for a valid MouseArea handler assignment.
- Preserved the existing Button optional-handler signature check and accumulated suite failure status.
- Replayed the source test change into its exact tracked render.

## Must-fail controls

An empty source table passes the old suite from an empty working directory and fails the corrected suite before later rows can hide it. A missing source also passes the old suite and fails the corrected suite with the read error intact.

## Size

- Production lines added: 0.
- Test lines added: 16.
- Render-mirror lines added: 16.
- KEN-1241 states no expected-delta allowance.

## Test plan

- Root proof passed 4/4 and confirmed source/render byte equality, executable mode equality, and the reviewed diff SHA-256.
- One specialist reviewer-test round passed with no findings. Its controls killed both mutants and stayed stable for every recorded run.
- `tools/guard --full` exited 0 under `TMPDIR=/var/tmp/ken-c` with inherited Git directory and index overrides cleared.
- The pushed diff SHA-256 remains `118ccdf465e7ae8556f76b1d602760c368dbc7026cd8a818e324d8949d9dd821` after the automatic rebase.

KEN-1241
