### PR TITLE
test(KEN-1241): the hook payload reader as one table of rows

### DIFF
--- a/hooks/tests/block-argv-kill.test.sh
+++ b/hooks/tests/block-argv-kill.test.sh
@@ -42,17 +42,15 @@ run_hook() { # command -> rc, stderr in ERR_FILE
   set -e
 }
 
-run_payload() { # raw-json [PATH] -> rc, stderr in ERR_FILE
+run_payload() { # raw-json -> rc, stderr in ERR_FILE
   set +e
-  if [ -n "${2:-}" ]; then
-    printf '%s' "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$2" "$BASH_BIN" "$HOOK" \
-      >/dev/null 2>"$ERR_FILE"
-  else
-    printf '%s' "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
-  fi
+  printf '%s' "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
   rc=$?
   set -e
 }
+
+# shellcheck source=lib/payload-rows.sh
+. "$TEST_DIR/lib/payload-rows.sh"
 
 echo "=== block-argv-kill: a kill by name or pattern is refused ==="
 run_hook 'pkill -f mutation-stability';        assert_eq "$rc" 2 'pkill with an argv pattern is refused'
@@ -105,43 +103,8 @@ rc=$?
 set -e
 assert_eq "$rc" 2 'a stdin that cannot be read refuses with the refusal status, not the read error'
 assert_contains "$ERR_FILE" 'could not read the hook payload' 'the read refusal names the cause'
-run_payload '{"tool_input":{"command":"pkill x"'
-assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
-assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
-run_payload '{"tool_input":{"command":123}}'
-assert_eq "$rc" 2 'a command that is not a string refuses'
-run_payload '{"tool_input":{"command":false}}'
-assert_eq "$rc" 2 'a command of false refuses, not read as an absent one'
-run_payload '{"tool_input":"pkill x"}'
-assert_eq "$rc" 2 'a tool_input that is not an object refuses'
-run_payload '{"tool_input":{"command":""}}'
-assert_eq "$rc" 0 'an empty command is read, not a read failure'
-run_payload '{"tool_name":"Bash","tool_input":{}}'
-assert_eq "$rc" 0 'a payload naming no command passes'
-run_payload '{"command":"killall x"}'
-assert_eq "$rc" 2 'a top-level command field is read like a nested one'
 
-echo "=== block-argv-kill: Copilot carries the command under toolArgs ==="
-run_payload '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"pkill -f x"}}'
-assert_eq "$rc" 2 'a Copilot toolArgs object is read'
-run_payload '{"toolName":"bash","toolArgs":"{\"command\":\"killall x\"}"}'
-assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
-run_payload '{"toolName":"bash","toolArgs":{"command":"kill 1234"}}'
-assert_eq "$rc" 0 'a PID kill under toolArgs passes, so the shape is read rather than refused'
-run_payload '{"toolName":"bash","toolArgs":"not json"}'
-assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
-
-echo "=== block-argv-kill: a missing reader refuses ==="
-NOJQ_BIN="$TMP_ROOT/nojq"
-mkdir -p "$NOJQ_BIN"
-for tool in bash cat grep sed; do
-  target="$(command -v "$tool" 2>/dev/null)" && ln -sf "$target" "$NOJQ_BIN/$tool"
-done
-run_payload '{"tool_input":{"command":"pkill x"}}' "$NOJQ_BIN"
-assert_eq "$rc" 2 'without jq the guard refuses rather than skipping'
-assert_contains "$ERR_FILE" 'required to read the hook payload' 'the refusal names what is missing'
-run_payload '{"tool_input":{"command":"kill 1"}}' "$NOJQ_BIN"
-assert_eq "$rc" 2 'without jq even a harmless command is refused: nothing was read'
+payload_table "$HOOK" 'pkill -f x' 'kill 1234'
 
 echo
 echo "block-argv-kill: $PASS passed, $FAIL failed"

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -36,10 +36,8 @@ assert_contains() {
   if grep -qF -- "$2" "$1"; then pass "$3"; else FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        wanted: %s\n        in:\n%s\n' "$3" "$2" "$(cat "$1")"; fi
 }
 
-# The command reaches the hook JSON-encoded, exactly as the harness sends it.
-# jq does the encoding rather than sed: a Bash tool call is routinely several
-# lines, and a raw newline inside a JSON string is not JSON, so a sed-built
-# fixture could not express a multi-line row at all.
+# The command reaches the hook JSON-encoded, exactly as the harness sends it,
+# with jq doing the encoding so every escape is JSON's own.
 json_for() {
   jq -nc --arg c "$1" '{tool_name:"Bash",tool_input:{command:$c}}'
 }

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -37,10 +37,11 @@ assert_contains() {
 }
 
 # The command reaches the hook JSON-encoded, exactly as the harness sends it.
+# jq does the encoding rather than sed: a Bash tool call is routinely several
+# lines, and a raw newline inside a JSON string is not JSON, so a sed-built
+# fixture could not express a multi-line row at all.
 json_for() {
-  local c
-  c=$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')
-  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$c"
+  jq -nc --arg c "$1" '{tool_name:"Bash",tool_input:{command:$c}}'
 }
 
 run_hook() { # command -> rc, stderr in ERR_FILE
@@ -50,17 +51,8 @@ run_hook() { # command -> rc, stderr in ERR_FILE
   set -e
 }
 
-run_payload() { # raw-json [PATH] -> rc, stderr in ERR_FILE
-  set +e
-  if [ -n "${2:-}" ]; then
-    printf '%s' "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$2" "$BASH_BIN" "$HOOK" \
-      >/dev/null 2>"$ERR_FILE"
-  else
-    printf '%s' "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
-  fi
-  rc=$?
-  set -e
-}
+# shellcheck source=lib/payload-rows.sh
+. "$TEST_DIR/lib/payload-rows.sh"
 
 echo "=== block-bare-cd: refused shapes ==="
 run_hook 'cd';            assert_eq "$rc" 2 'a bare cd with no argument is refused'
@@ -86,46 +78,7 @@ run_hook 'cdr --version';     assert_eq "$rc" 0 'a command whose name merely sta
 run_hook 'ls -la';            assert_eq "$rc" 0 'an unrelated command passes'
 run_hook 'git checkout main'; assert_eq "$rc" 0 'a command with no cd at all passes'
 
-echo "=== block-bare-cd: a payload it cannot read refuses ==="
-run_payload '{"tool_input":{"command":"cd /tmp"'
-assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
-assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
-run_payload '{"tool_input":{"command":123}}'
-assert_eq "$rc" 2 'a command that is not a string refuses'
-run_payload '{"tool_input":{"command":false}}'
-assert_eq "$rc" 2 'a command of false refuses, not read as an absent one'
-run_payload '{"tool_input":"cd /tmp"}'
-assert_eq "$rc" 2 'a tool_input that is not an object refuses'
-run_payload '{"tool_input":{"command":""}}'
-assert_eq "$rc" 0 'an empty command is read, not a read failure'
-run_payload '{"tool_name":"Bash","tool_input":{}}'
-assert_eq "$rc" 0 'a payload naming no command passes'
-
-echo "=== block-bare-cd: Copilot carries the command under toolArgs ==="
-run_payload '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"cd /tmp"}}'
-assert_eq "$rc" 2 'a Copilot toolArgs object is read'
-run_payload '{"toolName":"bash","toolArgs":"{\"command\":\"cd /tmp\"}"}'
-assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
-run_payload '{"toolName":"bash","toolArgs":{"command":"(cd /tmp && ls)"}}'
-assert_eq "$rc" 0 'a scoped cd under toolArgs passes, so the shape is read rather than refused'
-run_payload '{"toolName":"bash","toolArgs":"not json"}'
-assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
-
-echo "=== block-bare-cd: without the tools that read the payload ==="
-NOJQ_BIN="$TMP_ROOT/nojq"
-mkdir -p "$NOJQ_BIN"
-# type -P, not command -v: grep and friends are shell functions in some
-# interactive environments, and a function name symlinks to nothing.
-for tool in cat sed grep; do
-  real="$(type -P "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] && [ -x "$real" ] || continue
-  ln -sf "$real" "$NOJQ_BIN/$tool"
-done
-run_payload '{"tool_input":{"command":"cd /tmp"}}' "$NOJQ_BIN"
-assert_eq "$rc" 2 'no jq refuses rather than guessing at the payload'
-assert_contains "$ERR_FILE" 'required to read the hook payload' 'the refusal names what is missing'
-run_payload '{"tool_input":{"command":"cd /tmp"}}' /nonexistent
-assert_eq "$rc" 2 'no text tools at all refuses too'
+payload_table "$HOOK" 'cd /tmp' '(cd /tmp && ls)'
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/hooks/tests/block-repo-copy.test.sh
+++ b/hooks/tests/block-repo-copy.test.sh
@@ -48,18 +48,8 @@ run_hook() { # command -> rc, stderr in $err
   err="$(cat "$ERR_FILE")"
 }
 
-run_payload() { # raw-json [PATH] -> rc, stderr in $err
-  set +e
-  if [ -n "${2:-}" ]; then
-    printf '%s' "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$2" "$BASH_BIN" "$HOOK" \
-      >/dev/null 2>"$ERR_FILE"
-  else
-    printf '%s' "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
-  fi
-  rc=$?
-  set -e
-  err="$(cat "$ERR_FILE")"
-}
+# shellcheck source=lib/payload-rows.sh
+. "$TEST_DIR/lib/payload-rows.sh"
 
 REPO=/home/agent/dev/project
 
@@ -197,65 +187,7 @@ assert_contains "$err" "Read the source in place" 'the refusal offers reading in
 assert_contains "$err" "MINIMAL synthetic fixture" 'the refusal offers a minimal fixture'
 assert_contains "$err" 'mktemp -d' 'the refusal shows how to build the fixture'
 
-echo "=== block-repo-copy: a payload it cannot read refuses ==="
-run_payload "{\"tool_input\":{\"command\":\"cp -r $REPO/.git /tmp/copy"
-assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
-assert_contains "$err" 'not valid JSON' 'the parse refusal names the cause'
-run_payload '{"tool_input":{"command":123}}'
-assert_eq "$rc" 2 'a command that is not a string refuses'
-run_payload '{"tool_input":{"command":false}}'
-assert_eq "$rc" 2 'a command of false refuses, not read as an absent one'
-run_payload '{"tool_name":"Bash","tool_input":{}}'
-assert_eq "$rc" 0 'a payload naming no command passes'
-run_payload '{"tool_input":{"command":""}}'
-assert_eq "$rc" 0 'an empty command is read, not a read failure'
-# The harness sends the command under tool_input; a payload naming it at the
-# top level is read the same way, and that fallback is a branch of its own.
-run_payload "{\"command\":\"cp -r $REPO/.git /tmp/copy\"}"
-assert_eq "$rc" 2 'a top-level command field is read like a nested one'
-# Copilot carries the command under toolArgs, as an object or as one
-# JSON-encoded string.
-run_payload "{\"sessionId\":\"s\",\"timestamp\":1,\"cwd\":\"/w\",\"toolName\":\"bash\",\"toolArgs\":{\"command\":\"cp -r $REPO/.git /tmp/copy\"}}"
-assert_eq "$rc" 2 'a Copilot toolArgs object is read'
-run_payload "{\"toolName\":\"bash\",\"toolArgs\":\"{\\\"command\\\":\\\"cp -r $REPO/.git /tmp/copy\\\"}\"}"
-assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
-run_payload "{\"toolName\":\"bash\",\"toolArgs\":{\"command\":\"cp -r $REPO/src /tmp/copy\"}}"
-assert_eq "$rc" 0 'a harmless copy under toolArgs passes, so the shape is read rather than refused'
-run_payload '{"toolName":"bash","toolArgs":"not json"}'
-assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
-
-NOJQ_BIN="$TMP_ROOT/nojq"
-mkdir -p "$NOJQ_BIN"
-# type -P, not command -v: cat and friends are shell functions in some
-# interactive environments, and a function name symlinks to nothing.
-for tool in cat sed grep; do
-  real="$(type -P "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] && [ -x "$real" ] || continue
-  ln -sf "$real" "$NOJQ_BIN/$tool"
-done
-run_payload "{\"tool_input\":{\"command\":\"cp -r $REPO/.git /tmp/copy\"}}" "$NOJQ_BIN"
-assert_eq "$rc" 2 'no jq refuses rather than guessing at the payload'
-assert_contains "$err" 'required to read the hook payload' 'the refusal names what is missing'
-run_payload "{\"tool_input\":{\"command\":\"git status --short\"}}" /nonexistent
-assert_eq "$rc" 2 'no text tools at all refuses too, whatever the command'
-
-# cat is the other half of the same guard: jq reads the payload, cat is what
-# hands it over. A PATH holding jq and not cat is what tells the two apart.
-NOCAT_BIN="$TMP_ROOT/nocat"
-mkdir -p "$NOCAT_BIN"
-for tool in jq sed grep; do
-  real="$(type -P "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] && [ -x "$real" ] || continue
-  ln -sf "$real" "$NOCAT_BIN/$tool"
-done
-run_payload "{\"tool_input\":{\"command\":\"git status --short\"}}" "$NOCAT_BIN"
-assert_eq "$rc" 2 'no cat refuses rather than skipping the guard'
-assert_contains "$err" 'required to read the hook payload' 'the refusal names what is missing'
-# The control that the exact PATH is what decided: the same benign command
-# passes once cat is on it.
-ln -sf "$(type -P cat)" "$NOCAT_BIN/cat"
-run_payload "{\"tool_input\":{\"command\":\"git status --short\"}}" "$NOCAT_BIN"
-assert_eq "$rc" 0 'and the same PATH with cat added passes'
+payload_table "$HOOK" "cp -r $REPO/.git /tmp/copy" "cp -r $REPO/src /tmp/copy"
 
 echo "=== block-repo-copy: the stated limits ==="
 # Reading the command's text rather than resolving its operands costs in both

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -47,17 +47,8 @@ run_hook() { # command -> rc, stderr in ERR_FILE
   set -e
 }
 
-run_payload() { # raw-json [PATH] -> rc, stderr in ERR_FILE
-  set +e
-  if [ -n "${2:-}" ]; then
-    printf '%s' "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$2" "$BASH_BIN" "$HOOK" \
-      >/dev/null 2>"$ERR_FILE"
-  else
-    printf '%s' "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
-  fi
-  rc=$?
-  set -e
-}
+# shellcheck source=lib/payload-rows.sh
+. "$TEST_DIR/lib/payload-rows.sh"
 
 echo "=== block-unsafe-rm: a variable-rooted operand is refused ==="
 run_hook 'rm -rf $CACHE/$KEY';        assert_eq "$rc" 2 'a bare $NAME root is refused'
@@ -128,72 +119,11 @@ run_hook 'ls -la';                    assert_eq "$rc" 0 'an unrelated command pa
 
 echo "=== block-unsafe-rm: the refusal names the cause and the rewrite ==="
 run_hook 'rm -rf $CACHE/$KEY'
-assert_contains "$ERR_FILE" 'possibly-empty variable path' 'the refusal names the harness prompt it prevents'
 assert_contains "$ERR_FILE" '${NAME:?}' 'the refusal names the ${NAME:?} rewrite'
 assert_contains "$ERR_FILE" '/absolute/literal/path' 'the refusal names the literal-path alternative'
 assert_contains "$ERR_FILE" 'rm -rf $CACHE/$KEY' 'the refusal quotes the command it judged'
 
-echo "=== block-unsafe-rm: a payload it cannot read refuses ==="
-run_payload '{"tool_input":{"command":"rm -rf $X"'
-assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
-assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
-run_payload '{"tool_input":{"command":123}}'
-assert_eq "$rc" 2 'a command that is not a string refuses'
-run_payload '{"tool_input":{"command":false}}'
-assert_eq "$rc" 2 'a command of false refuses, not read as an absent one'
-run_payload '{"tool_name":"Bash","tool_input":{}}'
-assert_eq "$rc" 0 'a payload naming no command passes'
-run_payload '{"tool_input":{"command":""}}'
-assert_eq "$rc" 0 'an empty command is read, not a read failure'
-# The harness sends the command under tool_input; a payload naming it at the
-# top level is read the same way, and that fallback is a branch of its own.
-run_payload '{"command":"rm -rf $X"}'
-assert_eq "$rc" 2 'a top-level command field is read like a nested one'
-run_payload '{"command":false}'
-assert_eq "$rc" 2 'and a top-level false is refused, not read as an absent one'
-# Copilot carries the command under toolArgs, as an object or as one
-# JSON-encoded string.
-run_payload '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"rm -rf $X/sub"}}'
-assert_eq "$rc" 2 'a Copilot toolArgs object is read'
-run_payload '{"toolName":"bash","toolArgs":"{\"command\":\"rm -rf $X/sub\"}"}'
-assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
-run_payload '{"toolName":"bash","toolArgs":{"command":"rm -rf -- \"${X:?}/sub\""}}'
-assert_eq "$rc" 0 'the accepted rewrite under toolArgs passes, so the shape is read rather than refused'
-run_payload '{"toolName":"bash","toolArgs":"not json"}'
-assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
-
-NOJQ_BIN="$TMP_ROOT/nojq"
-mkdir -p "$NOJQ_BIN"
-# type -P, not command -v: cat and friends are shell functions in some
-# interactive environments, and a function name symlinks to nothing.
-for tool in cat sed grep; do
-  real="$(type -P "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] && [ -x "$real" ] || continue
-  ln -sf "$real" "$NOJQ_BIN/$tool"
-done
-run_payload '{"tool_input":{"command":"rm -rf $X"}}' "$NOJQ_BIN"
-assert_eq "$rc" 2 'no jq refuses rather than guessing at the payload'
-assert_contains "$ERR_FILE" 'required to read the hook payload' 'the refusal names what is missing'
-run_payload '{"tool_input":{"command":"ls -la"}}' /nonexistent
-assert_eq "$rc" 2 'no text tools at all refuses too, whatever the command'
-
-# cat is the other half of the same guard: jq reads the payload, cat is what
-# hands it over. A PATH holding jq and not cat is what tells the two apart.
-NOCAT_BIN="$TMP_ROOT/nocat"
-mkdir -p "$NOCAT_BIN"
-for tool in jq sed grep; do
-  real="$(type -P "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] && [ -x "$real" ] || continue
-  ln -sf "$real" "$NOCAT_BIN/$tool"
-done
-run_payload '{"tool_input":{"command":"ls -la"}}' "$NOCAT_BIN"
-assert_eq "$rc" 2 'no cat refuses rather than skipping the guard'
-assert_contains "$ERR_FILE" 'required to read the hook payload' 'the refusal names what is missing'
-# The control that the exact PATH is what decided: the same benign command
-# passes once cat is on it.
-ln -sf "$(type -P cat)" "$NOCAT_BIN/cat"
-run_payload '{"tool_input":{"command":"ls -la"}}' "$NOCAT_BIN"
-assert_eq "$rc" 0 'and the same PATH with cat added passes'
+payload_table "$HOOK" 'rm -rf $X/sub' 'rm -rf -- "${X:?}/sub"'
 
 echo "=== block-unsafe-rm: the stated limit ==="
 # A flag the shell would assemble is not seen here. The harness prompt still

--- a/hooks/tests/block-worktree-refresh.test.sh
+++ b/hooks/tests/block-worktree-refresh.test.sh
@@ -87,6 +87,9 @@ run_payload() { # raw-json [PATH] -> rc, stderr in ERR_FILE, run in the worktree
   set -e
 }
 
+# shellcheck source=lib/payload-rows.sh
+. "$TEST_DIR/lib/payload-rows.sh"
+
 echo "=== block-worktree-refresh: a project-scope write from a linked worktree is refused ==="
 for verb in refresh apply 'add orch' 'remove orch' update-pi 'pin orch' 'fork orch' adopt drift-hook 'source add x' 'source remove x' 'source enable x' 'source disable x' 'marketplace subscribe x' 'marketplace unsubscribe x'; do
   run_in "$WT" "kendex $verb"; assert_eq "$rc" 2 "kendex $verb from the worktree is refused"
@@ -175,34 +178,12 @@ set +e
 rc=$?
 set -e
 assert_eq "$rc" 2 'a stdin that cannot be read refuses with the refusal status, not the read error'
-run_payload '{"tool_input":{"command":"kendex refresh"'
-assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
-run_payload '{"tool_input":{"command":123}}'
-assert_eq "$rc" 2 'a command that is not a string refuses'
 run_payload '{"tool_input":{"command":"kendex refresh"},"cwd":5}'
 assert_eq "$rc" 2 'a cwd that is not a string refuses'
-run_payload '{"tool_input":{"command":""}}'
-assert_eq "$rc" 0 'an empty command is read, not a read failure'
-run_payload '{"tool_name":"Bash","tool_input":{}}'
-assert_eq "$rc" 0 'a payload naming no command passes'
-run_payload '{"command":"kendex apply"}'
-assert_eq "$rc" 2 'a top-level command field is read like a nested one'
-run_payload '{"sessionId":"s","timestamp":1,"cwd":"'"$WT"'","toolName":"bash","toolArgs":{"command":"kendex refresh"}}'
-assert_eq "$rc" 2 'a Copilot toolArgs object is read'
-run_payload '{"toolName":"bash","toolArgs":"{\"command\":\"kendex refresh\"}"}'
-assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
-run_payload '{"toolName":"bash","toolArgs":{"command":"kendex verify"}}'
-assert_eq "$rc" 0 'a read under toolArgs passes, so the shape is read rather than refused'
 
-echo "=== block-worktree-refresh: a missing reader refuses ==="
-NOJQ_BIN="$TMP_ROOT/nojq"
-mkdir -p "$NOJQ_BIN"
-for tool in bash cat git; do
-  target="$(command -v "$tool" 2>/dev/null)" && ln -sf "$target" "$NOJQ_BIN/$tool"
-done
-run_payload '{"tool_input":{"command":"kendex refresh"}}' "$NOJQ_BIN"
-assert_eq "$rc" 2 'without jq the guard refuses rather than skipping'
-assert_contains "$ERR_FILE" 'required to read the hook payload' 'the refusal names what is missing'
+payload_table "$HOOK" 'kendex refresh' 'kendex verify' "$WT"
+
+echo "=== block-worktree-refresh: a missing git refuses ==="
 NOGIT_BIN="$TMP_ROOT/nogit"
 mkdir -p "$NOGIT_BIN"
 for tool in bash cat jq; do

--- a/hooks/tests/lib/payload-rows.sh
+++ b/hooks/tests/lib/payload-rows.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# The payload reader the Bash hooks share, as one table each hook's suite runs
+# against its own hook. Every hook inlines the same reader, so the rows are
+# the same rows, and a copy that drifts reds in the suite of the hook it
+# drifted in.
+#
+# Usage, from a suite:
+#
+#   . "$TEST_DIR/lib/payload-rows.sh"
+#   payload_table "$HOOK" 'pkill -f x' 'kill 1234'        # [DIR]
+#
+# HOOK is the script under test, then a command that hook refuses and one it
+# passes; DIR is the directory the hook runs in, the caller's working
+# directory when absent. The suite defines `assert_eq GOT WANT LABEL`, counts
+# PASS and FAIL, and holds TMP_ROOT, a directory it removes at exit; the
+# table asserts through them.
+#
+# A row is `label|payload|command|world|rc|err`:
+#   payload  the shape the command is carried in. `harness` is
+#            {tool_input:{command}}, what Claude Code, Codex, Gemini CLI and
+#            the Pi carrier send; `truncated` is that shape cut before its
+#            closing braces; `number` and `false` name a command that is not
+#            a string; `input-string` a tool_input that is not an object;
+#            `no-command` a tool_input naming none; `top-level` a bare
+#            `command` beside no tool_input, and `top-level-false` that
+#            field as false; `copilot-object` and `copilot-string` are
+#            Copilot's toolArgs, an object or one JSON-encoded string;
+#            `copilot-text` a toolArgs string that is not JSON
+#   command  what the shape carries: `refusing`, `passing`, `empty`; `-`
+#            where the shape carries none
+#   world    the PATH the hook runs under. `tools` holds every tool a hook
+#            sourcing this table reads (jq, cat, grep, sed, git) and nothing
+#            else; `no-jq` and `no-cat` are that set less the one tool;
+#            `none` is a directory that does not exist
+#   rc       the exit status
+#   err      stderr reduced to the arm that wrote it: `parse` is the reader's
+#            refusal of a payload it could not read, `tools` its refusal of a
+#            PATH that cannot read one, `refusal` the hook's own refusal of a
+#            command it read, `-` silence
+#
+# Every row runs the hook under `env -i` with HOME, PWD and the world's PATH
+# and nothing else, so a passing row proves the hook read the payload with
+# those tools alone. `tools` is `no-cat` plus cat and `no-jq` plus jq, so the
+# passing harness row is the control that the PATH alone decided the tool
+# rows. The Copilot shapes carry DIR as their cwd, as Copilot carries the
+# directory the command runs in.
+#
+# HOOKS_TABLE_PROBE=1 renders `label => got` for every row instead of
+# asserting; the run is then refused after the loop.
+
+payload_json() { # shape command dir -> the payload text
+  local shape="$1" c="$2" d="$3" whole
+  case "$shape" in
+    harness) jq -nc --arg c "$c" '{tool_name:"Bash",tool_input:{command:$c}}' ;;
+    truncated)
+      whole=$(jq -nc --arg c "$c" '{tool_name:"Bash",tool_input:{command:$c}}')
+      printf '%s' "${whole%\}\}}"
+      ;;
+    number) printf '%s' '{"tool_input":{"command":123}}' ;;
+    false) printf '%s' '{"tool_input":{"command":false}}' ;;
+    input-string) jq -nc --arg c "$c" '{tool_input:$c}' ;;
+    no-command) printf '%s' '{"tool_name":"Bash","tool_input":{}}' ;;
+    top-level) jq -nc --arg c "$c" '{command:$c}' ;;
+    top-level-false) printf '%s' '{"command":false}' ;;
+    copilot-object)
+      jq -nc --arg c "$c" --arg d "$d" '{sessionId:"s",timestamp:1,cwd:$d,toolName:"bash",toolArgs:{command:$c}}'
+      ;;
+    copilot-string)
+      jq -nc --arg c "$c" --arg d "$d" '{sessionId:"s",timestamp:1,cwd:$d,toolName:"bash",toolArgs:({command:$c}|tojson)}'
+      ;;
+    copilot-text) printf '%s' '{"toolName":"bash","toolArgs":"not json"}' ;;
+    *)
+      printf 'payload-rows: no payload shape named %s\n' "$shape" >&2
+      exit 1
+      ;;
+  esac
+}
+
+payload_world() { # name tool... -> a directory holding those tools and nothing else
+  local dir="$PAYLOAD_ROOT/$1" tool real
+  shift
+  mkdir -p "$dir"
+  for tool in "$@"; do
+    # type -P, not command -v: cat and friends are shell functions in some
+    # interactive environments, and a function name symlinks to nothing.
+    if ! real="$(type -P "$tool")"; then
+      printf 'payload-rows: %s is not on PATH, so the tool worlds cannot be built\n' "$tool" >&2
+      exit 1
+    fi
+    ln -s "$real" "$dir/$tool"
+  done
+}
+
+payload_err_kind() { # -> the arm that wrote stderr
+  local text
+  text="$(cat "$PAYLOAD_ROOT/stderr")"
+  case "$text" in
+    "") printf -- '-' ;;
+    *"not valid JSON"*) printf 'parse' ;;
+    *"required to read the hook payload"*) printf 'tools' ;;
+    *) printf 'refusal' ;;
+  esac
+}
+
+payload_run() { # hook dir path payload -> "rc=N err=KIND"
+  local hook="$1" dir="$2" path="$3" payload="$4" rc=0
+  printf '%s' "$payload" | (
+    cd "$dir" && env -i HOME="$HOME" PWD="$dir" PATH="$path" "$PAYLOAD_BASH" "$hook" \
+      >/dev/null 2>"$PAYLOAD_ROOT/stderr"
+  ) || rc=$?
+  printf 'rc=%s err=%s' "$rc" "$(payload_err_kind)"
+}
+
+PAYLOAD_ROWS="\
+the refusing command under the harness shape is refused, so the shape is read|harness|refusing|tools|2|refusal
+the passing command under the harness shape passes|harness|passing|tools|0|-
+a truncated payload is refused unread rather than skipping the guard|truncated|refusing|tools|2|parse
+a command that is not a string is refused unread|number|-|tools|2|parse
+a command of false is refused unread, not read as an absent one|false|-|tools|2|parse
+a tool_input that is not an object is refused unread|input-string|refusing|tools|2|parse
+an empty command is read and passes, not a read failure|harness|empty|tools|0|-
+a payload naming no command passes|no-command|-|tools|0|-
+a top-level command field is read like a nested one|top-level|refusing|tools|2|refusal
+a top-level false is refused unread, not read as an absent one|top-level-false|-|tools|2|parse
+a Copilot toolArgs object is read|copilot-object|refusing|tools|2|refusal
+a Copilot toolArgs JSON string is read|copilot-string|refusing|tools|2|refusal
+the passing command under toolArgs passes, so the shape is read rather than refused|copilot-object|passing|tools|0|-
+a toolArgs string that is not JSON is refused unread rather than skipping the guard|copilot-text|-|tools|2|parse
+without jq the refusing command is refused unread rather than guessed at|harness|refusing|no-jq|2|tools
+without jq even the passing command is refused: nothing was read|harness|passing|no-jq|2|tools
+without cat the passing command is refused unread rather than dying at the read|harness|passing|no-cat|2|tools
+with no tools at all the passing command is refused unread|harness|passing|none|2|tools
+"
+
+payload_table() { # hook refusing passing [dir]
+  local hook="$1" refusing="$2" passing="$3" dir="${4:-$PWD}"
+  local label shape command world rc err row field text path got before=$((PASS + FAIL))
+  PAYLOAD_BASH="$(command -v bash)"
+  PAYLOAD_ROOT="$TMP_ROOT/payload-rows"
+  rm -rf "$PAYLOAD_ROOT"
+  mkdir -p "$PAYLOAD_ROOT"
+  # cat is the other half of the reader: jq reads the payload, cat is what
+  # hands it over, and a hook that reaches `INPUT=$(cat)` without it dies
+  # with a status that is not 2, which the harness runs the command past.
+  payload_world tools jq cat grep sed git
+  payload_world no-jq cat grep sed git
+  payload_world no-cat jq grep sed git
+  echo "=== $(basename "$hook" .sh): the payload reader ==="
+  while IFS= read -r row; do
+    [ "$row" != "" ] || continue
+    IFS='|' read -r label shape command world rc err <<<"$row"
+    for field in "$label" "$shape" "$command" "$world" "$rc" "$err"; do
+      [ "$field" != "" ] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    case "$command" in
+      refusing) text="$refusing" ;;
+      passing) text="$passing" ;;
+      empty | -) text="" ;;
+      *)
+        printf 'payload-rows: no command named %s: %s\n' "$command" "$row" >&2
+        exit 1
+        ;;
+    esac
+    case "$world" in
+      tools | no-jq | no-cat) path="$PAYLOAD_ROOT/$world" ;;
+      none) path="$PAYLOAD_ROOT/none" ;;
+      *)
+        printf 'payload-rows: no world named %s: %s\n' "$world" "$row" >&2
+        exit 1
+        ;;
+    esac
+    got="$(payload_run "$hook" "$dir" "$path" "$(payload_json "$shape" "$text" "$dir")")"
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [ "${HOOKS_TABLE_PROBE:-}" = 1 ]; then
+      printf '%s => %s\n' "$label" "$got"
+      continue
+    fi
+    assert_eq "$got" "rc=$rc err=$err" "$label"
+  done <<<"$PAYLOAD_ROWS"
+  [ "$((PASS + FAIL))" -gt "$before" ] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+}

--- a/hooks/tests/lib/payload-rows.sh
+++ b/hooks/tests/lib/payload-rows.sh
@@ -136,8 +136,8 @@ payload_table() { # hook refusing passing [dir]
   local hook="$1" refusing="$2" passing="$3" dir="${4:-$PWD}"
   local label shape command world rc err row field text path got before=$((PASS + FAIL))
   PAYLOAD_BASH="$(command -v bash)"
-  PAYLOAD_ROOT="$TMP_ROOT/payload-rows"
-  rm -rf "$PAYLOAD_ROOT"
+  PAYLOAD_ROOT="${TMP_ROOT:?}/payload-rows"
+  rm -rf -- "${TMP_ROOT:?}/payload-rows"
   mkdir -p "$PAYLOAD_ROOT"
   # cat is the other half of the reader: jq reads the payload, cat is what
   # hands it over, and a hook that reaches `INPUT=$(cat)` without it dies

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -19,6 +19,10 @@
 # must-fail control checks that these assertions can go red.
 set -euo pipefail
 
+# The fixture's own git calls must build the fixture, not whatever repository
+# a wrapper's redirection variables name.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOK="${HOOK_UNDER_TEST:-$HOOKS_DIR/pre-commit-check.sh}"
 
@@ -220,6 +224,11 @@ done
 
 echo
 payload_table "$HOOK" "git commit $NV -m x" 'git commit -m x' "$ARMED"
+# The table's refusal column says the hook read the command and refused it;
+# which arm refused is this suite's pin, and the armed bypass arm is the one
+# that must be reached through the Copilot shape.
+run_hook "$ARMED" "$(jq -nc --arg c "git commit $NV -m x" '{toolName:"bash",toolArgs:{command:$c}}')"
+assert_contains "$err" "would skip this repository's armed git hooks" "the bypass under toolArgs is named"
 
 run_hook "$UNARMED" '{"note":"about to commit with git"}'
 assert_eq "$rc" "0" "a payload with no command field is left alone"

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -49,14 +49,16 @@ done
 
 run_hook() {
   local dir="$1" payload="$2"
-  shift 2
   set +e
-  (cd "$dir" && env PATH="$NO_KENDEX_BIN" "$@" bash "$HOOK" <<<"$payload") >/dev/null 2>"$ERR_FILE"
+  (cd "$dir" && env PATH="$NO_KENDEX_BIN" bash "$HOOK" <<<"$payload") >/dev/null 2>"$ERR_FILE"
   rc=$?
   set -e
   err="$(cat "$ERR_FILE")"
   log="$(cat "$RAN_LOG" 2>/dev/null || true)"
 }
+
+# shellcheck source=lib/payload-rows.sh
+. "$HOOKS_DIR/tests/lib/payload-rows.sh"
 
 payload() { printf '{"tool_input":{"command":"%s"}}' "$1"; }
 
@@ -126,21 +128,6 @@ mkdir -p "$TMP_ROOT/custom-hooks"
 cp "$ARMED_BY_PATH/.git/hooks/pre-commit" "$ARMED_BY_PATH/.git/hooks/commit-msg" "$TMP_ROOT/custom-hooks/"
 git -C "$ARMED_BY_PATH" config core.hooksPath "$TMP_ROOT/custom-hooks"
 NOT_A_REPO="$TMP_ROOT/plain"; mkdir -p "$NOT_A_REPO"
-# Everything the hook needs except one tool, so each missing-tool lane is
-# measured rather than asserted from an unreachable interpreter. Dropping cat
-# is not the same failure as dropping jq: without the guard the hook dies at
-# `INPUT=$(cat)` with 127, and a PreToolUse status that is not 2 is a
-# non-blocking error the harness runs the command past.
-NO_JQ_BIN="$TMP_ROOT/no-jq-bin"
-mkdir -p "$NO_JQ_BIN"
-for tool in git grep bash cat env printf; do
-  target="$(command -v "$tool" 2>/dev/null)" && ln -sf "$target" "$NO_JQ_BIN/$tool"
-done
-NO_CAT_BIN="$TMP_ROOT/no-cat-bin"
-mkdir -p "$NO_CAT_BIN"
-for tool in git grep jq bash env printf; do
-  target="$(command -v "$tool" 2>/dev/null)" && ln -sf "$target" "$NO_CAT_BIN/$tool"
-done
 
 echo "a git word with a later commit word is the commit"
 
@@ -232,47 +219,10 @@ for form in 'cd sub && git commit -m x' 'GIT_DIR=/e/.git git commit -m x' 'GIT_W
 done
 
 echo
-echo "an unreadable payload is refused, never skipped"
-
-run_hook "$UNARMED" '{"tool_input":{"command":123}}'
-assert_eq "$rc" "2" "a command that is not a string is refused"
-assert_contains "$err" "not valid JSON, or names a command that is not a string" "the refusal names the payload"
-assert_eq "$log" "" "nothing ran for the unreadable payload"
-
-echo
-echo "Copilot carries the command under toolArgs, as an object or as one JSON-encoded string"
-
-run_hook "$ARMED" '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"git commit '"$NV"' -m x"}}'
-assert_eq "$rc" "2" "a Copilot toolArgs object is read"
-assert_contains "$err" "would skip this repository's armed git hooks" "the bypass under toolArgs is named"
-run_hook "$ARMED" '{"toolName":"bash","toolArgs":"{\"command\":\"git commit '"$NV"' -m x\"}"}'
-assert_eq "$rc" "2" "a Copilot toolArgs JSON string is read"
-run_hook "$ARMED" '{"toolName":"bash","toolArgs":{"command":"git commit -m x"}}'
-assert_eq "$rc" "0" "a plain commit under toolArgs passes, so the shape is read rather than refused"
-run_hook "$ARMED" '{"toolName":"bash","toolArgs":"not json"}'
-assert_eq "$rc" "2" "a toolArgs string that is not JSON refuses rather than skipping the guard"
-
-run_hook "$UNARMED" '{"tool_input":{"command":"git commit -m x'
-assert_eq "$rc" "2" "a command string that never ends is refused"
-
-run_hook "$UNARMED" "$(payload 'git commit -m x')" PATH="$NO_JQ_BIN"
-assert_eq "$rc" "2" "a PATH without jq refuses rather than skipping the guard"
-assert_contains "$err" "jq, cat and grep are required" "and says which tools are missing"
-
-run_hook "$UNARMED" "$(payload 'git commit -m x')" PATH="$NO_CAT_BIN"
-assert_eq "$rc" "2" "a PATH without cat refuses rather than dying unread"
-assert_contains "$err" "jq, cat and grep are required" "and says which tools are missing"
-
-# The harness sends the command under tool_input; a payload naming it at the
-# top level is read the same way, and that fallback is a line of its own.
-run_hook "$UNARMED" '{"command":"git commit -m x"}'
-assert_eq "$rc" "2" "a top-level command field is read like a nested one"
-assert_contains "$err" "not armed by kendex" "and reaches the ordinary refusal"
+payload_table "$HOOK" "git commit $NV -m x" 'git commit -m x' "$ARMED"
 
 run_hook "$UNARMED" '{"note":"about to commit with git"}'
 assert_eq "$rc" "0" "a payload with no command field is left alone"
-run_hook "$UNARMED" '{"tool_input":{"command":""}}'
-assert_eq "$rc" "0" "an empty command string is left alone"
 # A command that splits into no words at all. On bash before 4.4 expanding a
 # zero-element array under `set -u` aborts, so the clean exit is pinned rather
 # than assumed; this suite is run against bash 3.2 as well as the host's.


### PR DESCRIPTION
Six catalog hooks (`block-argv-kill`, `block-bare-cd`, `block-unsafe-rm`, `block-repo-copy`, `block-worktree-refresh`, `pre-commit-check`) inline the same jq payload reader, and their six suites under `hooks/tests` each re-derived the same payload rows and the same no-jq / no-cat PATH blocks, some with a sed-built JSON helper that could not express what jq can. This adds `hooks/tests/lib/payload-rows.sh`, one table `label|payload|command|world|rc|err` of eighteen rows run once per suite as `payload_table HOOK REFUSING PASSING [DIR]`, each suite supplying its own refusing and passing command; the rows are the union of what the six suites asserted, every row having a former assertion in at least one sibling (the reader is one copied block, so the union is the same claim per hook). Payload shapes are built with `jq -nc --arg`; worlds are PATH directories (`tools` = jq cat grep sed git and nothing else, `no-jq`, `no-cat`, `none`); every row runs the hook under `env -i HOME PWD PATH`, which is every variable the six hooks read; `err` reduces stderr to the arm that wrote it (`parse`, `tools`, `refusal`, `-`), both reader clauses proven load-bearing. Each suite keeps the rows that are its own (empty and unreadable payload where the hook has them, `cwd`, `note`, no-git). Root ruling in force: no hook is edited, and no empty-payload or unreadable-stdin row is added where a hook lacks one.

`hooks/tests/*` renders nowhere.

## Assertion and disposition map

Every removed payload or PATH assertion in the six suites lands on one of the eighteen rows (the implementer's per-suite map is in the lane's scratchpad). Named losses: `block-unsafe-rm`'s `possibly-empty variable path`, the harness prompt's wording, with the remedy values beside it kept; `pre-commit-check`'s `$log == ""` on the unreadable payload, a fixture property the arming section still asserts once per fixture. `pre-commit-check`'s payload rows moved from the unarmed to the armed fixture; the one assertion pinning the unarmed arm is still pinned by `both` and the arming loop. After the reviewer round: the Copilot-object row on `pre-commit-check` had lost its shape-specific `would skip this repository's armed git hooks` pin behind the `refusal` bucket; it is restored as one assertion after the table (a mutant silencing that clause for the toolArgs shape now reddens it); the lib's scratch root takes the `${TMP_ROOT:?}` form with `--`; an overstated comment in `block-bare-cd` is trimmed; and `pre-commit-check.test.sh` gains the `unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE` line its siblings carry, its fixture setup having failed under inherited redirects on main (measured before and after on a private scratch repository). Declined: a pin separating the linked-worktree arm from the could-not-say arm on `block-worktree-refresh`'s payload rows, which no former assertion made and whose mutant the suite's own rows already redden.

## Must-fail battery

`mutate-payload.py` (in the lane's scratchpad; the records are `mutants.txt` and `mutants-c2.txt`): 37 of 37 killed, six mutants per hook (a non-string command read as text, the Copilot arm gone, the top-level arm gone, the missing-tools refusal passing, the parse refusal passing, an absent command an error) plus the silenced bypass clause on `pre-commit-check`, each killed by its own hook's rows and nothing else. Mechanism controls: a blank field exits 1 naming the row; an empty row list exits 2; the probe aid renders the rows then exits 2.

## Validation

`tools/guard --full` passed twice on this exact head, `52b3a51da3326a66a687ddb6ba69db7b747d1830`. The first run (exit 0, zero `guard:` lines) set only an external `TMPDIR` and cleared the four git redirect variables; it did not export the Pi coding-agent, session, background-task or diagnostic-log roots, which were unset in its environment, and that pass is preserved separately rather than restated. The second run repeated the guard on the same head through a runner that exports all five of those paths to roots it creates under the external `TMPDIR`, records every path value and the live-versus-granted head in its log before starting, and removes only those roots afterwards: exit 0, zero `guard:` lines, with the cleanup confirmed and nothing outside its own roots touched.

## Reviewer round

reviewer-test on 01c27f54f: ACCEPT, no blocker (the push rebased both commits onto main 0b4f5003f as f026604d9 and 52b3a51da; the hooks/ diff is byte-identical, cmp). Every removed assertion mapped; no row is a claim no sibling made; both reader clauses proven able to redden; the `tools` world confirmed exact against every external command the six hooks call; `env -i HOME PWD PATH` confirmed sufficient against every variable they read; the lib never runs as a suite (the workflow glob does not descend and its lint loop excludes `tests/lib`, `tools/guard`'s glob likewise); green three times per suite, under jq 1.7.1, under de_DE.UTF-8, and under inherited git redirects for five suites with the sixth's pre-existing failure now fixed. Two reviewer survivors (a bare JSON-string payload; a top-level command read before the nested one) are shapes no harness emits and take no row. Its four suggestions are the second commit above, one declined.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
