### PR TITLE
test(KEN-1241): doctrine-routing's spec mutations as one table of rows

### DIFF
--- a/.agents/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/.agents/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -125,14 +125,8 @@ spec_table "$rows"
 # on the old id silently reaches nothing. The comparison is against the
 # frozen set, which lives in the implementation.
 spec="$(new_spec renamed-pair)"
-python3 - "$spec/SKILL.md" "$spec/schemas/renders.md" <<'PY'
-import sys
-skill, renders = sys.argv[1], sys.argv[2]
-s = open(skill).read().replace("\n### severity\n", "\n### severity-honesty\n", 1)
-open(skill, "w").write(s)
-r = open(renders).read().replace("| `severity` |", "| `severity-honesty` |", 1)
-open(renders, "w").write(r)
-PY
+spec_edit "$spec/SKILL.md" '\n### severity\n' '\n### severity-honesty\n' || exit 1
+spec_edit "$spec/schemas/renders.md" '| `severity` |' '| `severity-honesty` |' || exit 1
 expect_clause doctrine-routing "block id 'severity' is frozen and the doctrine source no longer defines it" \
   'a heading and its row renamed together, against the frozen set' \
   render --dry-run --repo "$repo" --spec "$spec"

--- a/.agents/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/.agents/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -31,7 +31,8 @@ expect_green "the running copy's own doctrine and routing agree" \
 # One spec mutation per row: `label~file~old~new~verdict`, `~`-separated
 # because the routing rows the mutations edit carry `|`. `old` and `new` are
 # literal text with `\n` for a newline; an `re:` prefix on `old` makes it a
-# regular expression and `new` its replacement (`\g<n>` groups allowed). The
+# regular expression and `new` a `re.sub` template (`\g<n>` groups, and no
+# other backslash escape). The
 # edit asserts exactly one match, so a fixture the running copy has moved
 # away from fails as a fixture rather than passing on a defect never planted.
 # `verdict` is `red:<validator>:<clause>` (exit 1, that validator alone, the
@@ -100,7 +101,10 @@ EOF
 # setext heading in `.github/copilot-instructions.md`, a forged section, and
 # an indented level-4 heading reaches the refusal rather than the section
 # parse, which a level-1 or -2 one would end.
-spec_table "$(cat <<'ROWS'
+# `read -d ''` rather than `$(cat <<'ROWS' ...)`: Bash 3.2 scans a here-document
+# inside a command substitution for quotes, and a row carrying an odd number
+# of double quotes runs its parse past the closing parenthesis.
+IFS= read -r -d '' rows <<'ROWS'
 a doctrine block with no routing row~SKILL.md~\n## Adding a repo\n~\n### unrouted\n\nA block no column carries.\n\n## Adding a repo\n~red:doctrine-routing:doctrine block 'unrouted' has no row in the routing table
 a routing row naming no doctrine heading~schemas/renders.md~| `trust-model` |~| `no-such-block` | – | – | – | – | – | – | – | – |\n| `trust-model` |~red:doctrine-routing:routing table row 'no-such-block' names no `###` heading
 a position repeated inside a column~schemas/renders.md~| `rounds` | 2 |~| `rounds` | 1 |~red:doctrine-routing:column 'AGENTS.md' repeats a position
@@ -113,7 +117,7 @@ two `## Doctrine` sections~SKILL.md~\n## Adding a repo\n~\n## Doctrine\n\n### x\
 a `---` line under text in doctrine, which forges a section~SKILL.md~### scope\n\nRaise a defect~### scope\n\nForged\n---\n\nRaise a defect~msg:heading refusal
 a heading line in doctrine text, which ends the owned region~SKILL.md~### scope\n\nRaise a defect~### scope\n\n  #### Forged\n\nRaise a defect~msg:heading refusal
 ROWS
-)"
+spec_table "$rows"
 
 # The frozen-id invariant, the one mutation that edits both files. Renaming a
 # heading and its row together leaves both sets agreeing, so a comparison of
@@ -131,6 +135,12 @@ open(renders, "w").write(r)
 PY
 expect_clause doctrine-routing "block id 'severity' is frozen and the doctrine source no longer defines it" \
   'a heading and its row renamed together, against the frozen set' \
+  render --dry-run --repo "$repo" --spec "$spec"
+# The other direction of the same comparison, on the same fixture: the new
+# id is outside the frozen set, which is what makes adding a `###` heading a
+# deliberate edit to the constant a reviewer reads.
+expect_clause doctrine-routing "block id 'severity-honesty' is not in the frozen set" \
+  'and the renamed block is not in the frozen set either' \
   render --dry-run --repo "$repo" --spec "$spec"
 
 # The other side of the heading predicate: `#` with NO whitespace after it is
@@ -307,7 +317,9 @@ fi
 # table sends there has to arrive as written. The rows are derived from the
 # spec copy rather than copied here: the column names the blocks, and each
 # block's paragraphs, joined the way the region joins a bullet, must appear
-# in the region. The `reply-contract` block's `<issue>` placeholder becomes
+# in the region, each block after the one the column routes before it, so a
+# dropped, truncated or reordered block shows in its row. The `reply-contract`
+# block's `<issue>` placeholder becomes
 # `<PREFIX>-<n>` under `[bot-instructions.repo] tracker` (`renders.md`
 # § Common rules; the canonical fixture's tracker is `FIX`), so a paragraph
 # is held with that substitution made. The floor is the column's own length:
@@ -326,20 +338,27 @@ if region is None:
 blocks = doctrine.routing["AGENTS.md"]
 if not blocks:
     sys.exit("the AGENTS.md column routes no block")
+at = 0
 for bid in blocks:
     paras = [" ".join(p.split()).replace("<issue>", "<FIX-n>")
              for p in doctrine.blocks[bid].split("\n\n") if p.strip()]
     if not paras:
         sys.exit(f"{bid}: no paragraph to hold against the region")
-    missing = [p for p in paras if p not in region]
-    print(f"{'ok' if not missing else 'missing'}\t{bid}\t{len(paras)}")
+    verdict = "ok"
+    for para in paras:
+        found = region.find(para, at)
+        if found == -1:
+            verdict = "missing-or-out-of-order"
+            break
+        at = found + len(para)
+    print(f"{verdict}\t{bid}\t{len(paras)}")
 PY
   before=$((BI_PASS + BI_FAIL))
   while IFS="$(printf '\t')" read -r verdict bid count; do
     if [ "$verdict" = ok ]; then
-      ok "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+      ok "AGENTS.md § Code Review Rules carries block $bid in its routed order ($count paragraph(s))"
     else
-      bad "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+      bad "AGENTS.md § Code Review Rules carries block $bid in its routed order ($count paragraph(s))" "$verdict"
     fi
   done < "$BI_TMP/agents-rows"
   [ "$((BI_PASS + BI_FAIL))" -gt "$before" ] || { printf 'no block row was asserted\n' >&2; exit 2; }

--- a/.agents/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/.agents/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -28,88 +28,98 @@ new_spec() {
 expect_green "the running copy's own doctrine and routing agree" \
   render --dry-run --repo "$repo"
 
-# 1. A `###` block id with no row: an unrouted block is an error, never a
-#    silent drop.
-spec="$(new_spec unrouted)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("\n## Adding a repo\n", "\n### unrouted\n\nA block no column carries.\n\n## Adding a repo\n")
-open(p, "w").write(s)
+# One spec mutation per row: `label~file~old~new~verdict`, `~`-separated
+# because the routing rows the mutations edit carry `|`. `old` and `new` are
+# literal text with `\n` for a newline; an `re:` prefix on `old` makes it a
+# regular expression and `new` its replacement (`\g<n>` groups allowed). The
+# edit asserts exactly one match, so a fixture the running copy has moved
+# away from fails as a fixture rather than passing on a defect never planted.
+# `verdict` is `red:<validator>:<clause>` (exit 1, that validator alone, the
+# finding naming the clause, since `doctrine-routing` has six clauses and a
+# fixture can trip two) or `msg:<value>` (exit 2, the message names that
+# value). A table that asserted no row exits 2 from its own counter.
+spec_edit() { # SPEC-FILE OLD NEW — one asserted replacement
+  python3 - "$1" "$2" "$3" <<'PY'
+import re, sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+if old.startswith("re:"):
+    n = len(re.findall(old[3:], s))
+    out = re.sub(old[3:], new, s, count=1)
+else:
+    old = old.replace("\\n", "\n")
+    new = new.replace("\\n", "\n")
+    n = s.count(old)
+    out = s.replace(old, new, 1)
+if n != 1:
+    sys.exit(f"{path}: expected one match of {old[:60]!r}, found {n}")
+if out == s:
+    sys.exit(f"{path}: the edit changed nothing")
+open(path, "w").write(out)
 PY
-expect_red doctrine-routing 'a doctrine block with no routing row' \
-  render --dry-run --repo "$repo" --spec "$spec"
+}
 
-# 2. A routing row naming an id the doctrine source does not define. Set
-#    equality in both directions: the one-directional half leaves the orphaned
-#    row unchecked.
-spec="$(new_spec ghost-row)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-row = "| `trust-model` |"
-ghost = "| `no-such-block` | – | – | – | – | – | – | – | – |\n"
-s = s.replace(row, ghost + row, 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a routing row naming no doctrine heading' \
-  render --dry-run --repo "$repo" --spec "$spec"
+spec_table() {
+  local rows="$1" row label file old new verdict spec field n=0 before
+  before=$((BI_PASS + BI_FAIL))
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    IFS='~' read -r label file old new verdict <<EOF
+$row
+EOF
+    for field in "$label" "$file" "$old" "$verdict"; do
+      [ -n "$field" ] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    n=$((n + 1))
+    spec="$(new_spec "row-$n")"
+    spec_edit "$spec/$file" "$old" "$new" || { printf 'fixture: %s\n' "$label" >&2; exit 1; }
+    case "$verdict" in
+      red:*:*)
+        verdict="${verdict#red:}"
+        expect_clause "${verdict%%:*}" "${verdict#*:}" "$label" render --dry-run --repo "$repo" --spec "$spec" ;;
+      msg:*) expect_message "${verdict#msg:}" "$label" render --dry-run --repo "$repo" --spec "$spec" ;;
+      *) printf 'unknown verdict: %s\n' "$verdict" >&2; exit 1 ;;
+    esac
+  done <<EOF
+$rows
+EOF
+  [ "$((BI_PASS + BI_FAIL))" -gt "$before" ] || { printf 'no row was asserted\n' >&2; exit 2; }
+}
 
-# 3. A position repeated inside a column.
-spec="$(new_spec repeat)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("| `rounds` | 2 |", "| `rounds` | 1 |", 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a position repeated inside a column' \
-  render --dry-run --repo "$repo" --spec "$spec"
+# An unrouted block is an error, never a silent drop. A row naming no
+# heading: set equality in both directions, since the one-directional half
+# leaves the orphaned row unchecked. Positions in a column run 1..n once
+# each. The two all-eight columns lose a block and Codex or Macroscope loses
+# it with every other validator green. A spec copy with no readable version
+# would land a doctrine change under a stamp naming doctrine it does not
+# carry; a version carrying `-->` would close the marker comment and put the
+# rest into a generated file as live reviewer instructions. Two `## Doctrine`
+# sections, or none, is an error rather than a guess. Doctrine text is under
+# the same content refusals as repo text, applied where it is read
+# (`renders.md` § Render-side second checks): a `---` under a text line is a
+# setext heading in `.github/copilot-instructions.md`, a forged section, and
+# an indented level-4 heading reaches the refusal rather than the section
+# parse, which a level-1 or -2 one would end.
+spec_table "$(cat <<'ROWS'
+a doctrine block with no routing row~SKILL.md~\n## Adding a repo\n~\n### unrouted\n\nA block no column carries.\n\n## Adding a repo\n~red:doctrine-routing:doctrine block 'unrouted' has no row in the routing table
+a routing row naming no doctrine heading~schemas/renders.md~| `trust-model` |~| `no-such-block` | – | – | – | – | – | – | – | – |\n| `trust-model` |~red:doctrine-routing:routing table row 'no-such-block' names no `###` heading
+a position repeated inside a column~schemas/renders.md~| `rounds` | 2 |~| `rounds` | 1 |~red:doctrine-routing:column 'AGENTS.md' repeats a position
+a gap in a column, whose positions must run 1..n~schemas/renders.md~| `rounds` | 2 |~| `rounds` | 9 |~red:doctrine-routing:column 'AGENTS.md' positions are [1, 3, 4, 5, 6, 7, 8, 9], not 1..n
+a block missing from the AGENTS.md column~schemas/renders.md~| `reply-contract` | 8 |~| `reply-contract` | – |~red:doctrine-routing:column 'AGENTS.md' omits 'reply-contract'
+a block missing from the macroscope doctrine.md column~schemas/renders.md~re:(\| `reply-contract` \|.*\| )8 \|\n~\g<1>– |\n~red:doctrine-routing:column 'macroscope doctrine.md' omits 'reply-contract'
+a spec copy with no readable version~SKILL.md~re:\n  version: "[^"]*"~~msg:no `version:` under metadata
+a spec version that would close its own comment~SKILL.md~re:(\n  version: ")([^"]*)(")~\g<1>\g<2> --> <!-- x\g<3>~msg:is outside [A-Za-z0-9.+-]
+two `## Doctrine` sections~SKILL.md~\n## Adding a repo\n~\n## Doctrine\n\n### x\n\ny\n\n## Adding a repo\n~msg:exactly one is required
+a `---` line under text in doctrine, which forges a section~SKILL.md~### scope\n\nRaise a defect~### scope\n\nForged\n---\n\nRaise a defect~msg:heading refusal
+a heading line in doctrine text, which ends the owned region~SKILL.md~### scope\n\nRaise a defect~### scope\n\n  #### Forged\n\nRaise a defect~msg:heading refusal
+ROWS
+)"
 
-# 4. A gap in a column's positions, which must run 1..n.
-spec="$(new_spec gap)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("| `rounds` | 2 |", "| `rounds` | 9 |", 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a gap in a column, whose positions must run 1..n' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# 5/6. A missing block in a column that carries every block. Delete the `8`
-#    from reply-contract's AGENTS.md cell and Codex loses the reply contract
-#    with every other validator green.
-spec="$(new_spec agents-hole)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("| `reply-contract` | 8 |", "| `reply-contract` | – |", 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a block missing from the AGENTS.md column' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-spec="$(new_spec macroscope-hole)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys, re
-p = sys.argv[1]
-s = open(p).read()
-s = re.sub(r"(\| `reply-contract` \|.*\| )8 \|\n", r"\1– |\n", s, count=1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a block missing from the macroscope doctrine.md column' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# 7. The frozen-id invariant. Renaming a heading and its row together leaves
-#    both sets agreeing, so a comparison of the pair passes and a consuming
-#    repo's `[bot-instructions.doctrine.append]` on the old id silently reaches nothing. The
-#    comparison is against the frozen set, which lives in the implementation.
+# The frozen-id invariant, the one mutation that edits both files. Renaming a
+# heading and its row together leaves both sets agreeing, so a comparison of
+# the pair passes and a consuming repo's `[bot-instructions.doctrine.append]`
+# on the old id silently reaches nothing. The comparison is against the
+# frozen set, which lives in the implementation.
 spec="$(new_spec renamed-pair)"
 python3 - "$spec/SKILL.md" "$spec/schemas/renders.md" <<'PY'
 import sys
@@ -119,72 +129,8 @@ open(skill, "w").write(s)
 r = open(renders).read().replace("| `severity` |", "| `severity-honesty` |", 1)
 open(renders, "w").write(r)
 PY
-expect_red doctrine-routing 'a heading and its row renamed together, against the frozen set' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# A spec copy with no readable version: a doctrine change would otherwise land
-# under a stamp naming doctrine it does not carry.
-spec="$(new_spec no-version)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys, re
-p = sys.argv[1]
-s = re.sub(r'\n  version: "[^"]*"', "", open(p).read(), count=1)
-open(p, "w").write(s)
-PY
-expect_message "no \`version:\` under metadata" 'a spec copy with no readable version' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# The version is interpolated into a comment. One carrying `-->` or a newline
-# would end that comment and put the rest into a generated file as live
-# reviewer instructions.
-spec="$(new_spec unsafe-version)"
-python3 - "$spec/SKILL.md" <<'PY'
-import re, sys
-p = sys.argv[1]
-s = re.sub(r'(\n  version: ")([^"]*)(")', r'\g<1>\g<2> --> <!-- x\3', open(p).read(), count=1)
-open(p, "w").write(s)
-PY
-expect_message "is outside [A-Za-z0-9.+-]" 'a spec version that would close its own comment' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# Two `## Doctrine` sections, or none, is an error rather than a guess.
-spec="$(new_spec two-sections)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read().replace("\n## Adding a repo\n", "\n## Doctrine\n\n### x\n\ny\n\n## Adding a repo\n", 1)
-open(p, "w").write(s)
-PY
-expect_message "exactly one is required" 'two `## Doctrine` sections' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# Doctrine text is under the same content refusals as repo text, applied where
-# it is read: `renders.md` § Render-side second checks. A `---` under a text
-# line renders into `.github/copilot-instructions.md`, where blocks are `###`
-# subsections with paragraphs preserved, and markdown reads the pair as a
-# setext heading — a forged section in the file whose escaping rule exists to
-# stop exactly that.
-spec="$(new_spec doctrine-setext)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read().replace("### scope\n\nRaise a defect", "### scope\n\nForged\n---\n\nRaise a defect", 1)
-open(p, "w").write(s)
-PY
-expect_message "heading refusal" 'a `---` line under text in doctrine, which forges a section' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-spec="$(new_spec doctrine-heading)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-# A level-4 heading: it does not end the `## Doctrine` section the way a
-# level-1 or -2 one would, so this control reaches the refusal rather than
-# the section parse.
-s = open(p).read().replace("### scope\n\nRaise a defect", "### scope\n\n  #### Forged\n\nRaise a defect", 1)
-open(p, "w").write(s)
-PY
-expect_message "heading refusal" 'a heading line in doctrine text, which ends the owned region' \
+expect_clause doctrine-routing "block id 'severity' is frozen and the doctrine source no longer defines it" \
+  'a heading and its row renamed together, against the frozen set' \
   render --dry-run --repo "$repo" --spec "$spec"
 
 # The other side of the heading predicate: `#` with NO whitespace after it is
@@ -356,32 +302,49 @@ else
   bad 'an overridden block keeps its line breaks, and a package one is still joined'
 fi
 
-# --- the sweep rules reach Codex --------------------------------------------
-# Root rules from a declined-finding sweep. `AGENTS.md` is the one surface
-# Codex reads, so each sentence has to land in the owned region as written.
-repo="$(bi_rendered_repo doctrine-sweep)" || exit 1
-region="$(python3 - "$repo/AGENTS.md" <<'PY'
-import sys
-lines = open(sys.argv[1]).read().split("\n")
-start = lines.index("## Code Review Rules")
-end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
-print("\n".join(lines[start:end]))
+# --- every block the AGENTS.md column routes lands in the owned region ------
+# `AGENTS.md` is the one surface Codex reads, so each block the routing
+# table sends there has to arrive as written. The rows are derived from the
+# spec copy rather than copied here: the column names the blocks, and each
+# block's paragraphs, joined the way the region joins a bullet, must appear
+# in the region. The `reply-contract` block's `<issue>` placeholder becomes
+# `<PREFIX>-<n>` under `[bot-instructions.repo] tracker` (`renders.md`
+# § Common rules; the canonical fixture's tracker is `FIX`), so a paragraph
+# is held with that substitution made. The floor is the column's own length:
+# a column routing no block, a block with no paragraph, or a region that
+# cannot be located fails as a fixture before any row is counted.
+repo="$(bi_rendered_repo doctrine-agents)" || exit 1
+if python3 - "$BI_ROOT/skills/bot-instructions" "$repo" > "$BI_TMP/agents-rows" <<'PY'; then
+import os, sys
+PKG, repo = sys.argv[1], sys.argv[2]
+sys.path.insert(0, os.path.join(PKG, "scripts"))
+from lib import render, spec as spec_mod, tree
+doctrine = spec_mod.load(tree.Worktree(PKG), "SKILL.md", "schemas/renders.md")
+region = render.region_of(open(os.path.join(repo, "AGENTS.md")).read())
+if region is None:
+    sys.exit("the rendered AGENTS.md has no owned region")
+blocks = doctrine.routing["AGENTS.md"]
+if not blocks:
+    sys.exit("the AGENTS.md column routes no block")
+for bid in blocks:
+    paras = [" ".join(p.split()).replace("<issue>", "<FIX-n>")
+             for p in doctrine.blocks[bid].split("\n\n") if p.strip()]
+    if not paras:
+        sys.exit(f"{bid}: no paragraph to hold against the region")
+    missing = [p for p in paras if p not in region]
+    print(f"{'ok' if not missing else 'missing'}\t{bid}\t{len(paras)}")
 PY
-)"
-while IFS= read -r sentence; do
-  if printf '%s\n' "$region" | grep -qF -- "$sentence"; then
-    ok "AGENTS.md § Code Review Rules carries: $sentence"
-  else
-    bad "AGENTS.md § Code Review Rules carries: $sentence"
-  fi
-done <<'EOF'
-Report an input only after establishing that a shipped producer emits it in normal use; a full disk or a value past 2^53 is not one.
-Name the user-visible consequence in every finding.
-Report a gap only after establishing that nothing already covers it: a required CI context, a shipped hook, the file's own stated contract, or the platform's documentation.
-Request a tighter assertion only when the row's named claim can regress without it reddening; an incidental finding the fixture also produces, or a state pin restating a refusal the exit status carries, is not a gap.
-Do not ask a script to copy a verb another file owns, such as an ancestor walk or a parser; name the owner and ask for a call to it or an escalation, since a second copy is a twin.
-Before reporting an output as missing or hard-coded, read the full line and the lines it prints; a value already emitted there answers the finding.
-Before reporting coverage or a reference as missing on a branch, check main and the sibling PRs the body names; a series lands its halves in separate PRs and a branch cut from an earlier main lacks the sibling's files by construction.
-EOF
+  before=$((BI_PASS + BI_FAIL))
+  while IFS="$(printf '\t')" read -r verdict bid count; do
+    if [ "$verdict" = ok ]; then
+      ok "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+    else
+      bad "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+    fi
+  done < "$BI_TMP/agents-rows"
+  [ "$((BI_PASS + BI_FAIL))" -gt "$before" ] || { printf 'no block row was asserted\n' >&2; exit 2; }
+else
+  bad 'the AGENTS.md block rows could be derived from the spec copy' "$(cat "$BI_TMP/agents-rows")"
+fi
 
 bi_summary

--- a/.agents/skills/bot-instructions/tests/globs.test.sh
+++ b/.agents/skills/bot-instructions/tests/globs.test.sh
@@ -86,7 +86,13 @@ PY
 export BI_ROOT
 
 # Every shape the dialect permits, each with the selection it makes over the
-# tree above: `pattern|selection`.
+# tree above: `pattern|selection`. A list an edit emptied would let the
+# assertions below supply the suite's success, so each loop here floors on
+# its own count.
+floor() { # BEFORE LABEL — at least one assertion since BEFORE
+  [ "$((BI_PASS + BI_FAIL))" -gt "$1" ] || { printf '%s asserted no row\n' "$2" >&2; exit 2; }
+}
+before=$((BI_PASS + BI_FAIL))
 for row in 'a/**|a/b/g a/f' 'a/*|a/f' '**|a/b/g a/f ab/h docs/x.md solo top.md' \
            '*|solo top.md' '*.md|top.md' '**/*.md|docs/x.md top.md' '**/g|a/b/g' \
            'a/**/g|a/b/g' 'a/*/g|a/b/g' 'a/b/**|a/b/g' 'a?f|-' 'a**|a/b/g a/f ab/h' \
@@ -94,6 +100,7 @@ for row in 'a/**|a/b/g a/f' 'a/*|a/f' '**|a/b/g a/f ab/h docs/x.md solo top.md' 
            'docs|docs/x.md' 'doc?|-'; do
   vector "${row%%|*}" agree "${row#*|}"
 done
+floor "$before" 'the agree table'
 
 # The harness's own control, on inputs the dialect refuses. An empty component
 # is the sharpest: git normalizes `a//f` to `a/f` and selects a file, and this
@@ -111,6 +118,7 @@ vector '../a/f' refused
 # sequences, and this is the difference: a ban list closes the shapes someone
 # thought of, and every byte below is outside the class whether or not anyone
 # named it.
+before=$((BI_PASS + BI_FAIL))
 for bad_pattern in '{a,ab}/**' '@(a|ab)/**' 'a,b' 'a#b' 'a!b' 'a"b'; do
   if python3 -c "
 import sys, os
@@ -128,6 +136,7 @@ raise SystemExit(1)
     bad "the dialect refuses: $bad_pattern"
   fi
 done
+floor "$before" 'the refused-pattern table'
 
 # `**/` translates to `(?:[^/]*/)*`, and nesting those is exponential in the
 # number of `**`: rejecting a deep path took seconds at a dozen, inside the
@@ -140,11 +149,17 @@ sys.path.insert(0, os.path.join(sys.argv[1], "scripts"))
 from lib import globs
 
 paths = ["a", "a/b", "a/x/b", "b", "a/x/y/b", "a/b/c", "x/b", "a/x/y/z/b"]
+compared = 0
 for n in range(1, 6):
     many = "a/" + "**/" * n + "b"
     for p in paths:
         if bool(globs.matching(many, [p])) != bool(globs.matching("a/**/b", [p])):
             sys.exit(f"{many!r} and 'a/**/b' disagree on {p!r}")
+        compared += 1
+# The equivalence half floors on its own count: an emptied path list would
+# leave the cost probe below to supply this assertion's success.
+if not compared:
+    sys.exit("the collapse matrix compared no path")
 # In a child with a hard deadline: uncollapsed, twenty `**` against a
 # twenty-deep path does not return in any time a CI lane will wait, and a
 # control that waits with it reports a timeout rather than a failure.

--- a/.agents/skills/bot-instructions/tests/globs.test.sh
+++ b/.agents/skills/bot-instructions/tests/globs.test.sh
@@ -40,11 +40,16 @@ git -C "$work" init -q .
 for f in a/f a/b/g ab/h top.md docs/x.md solo; do printf 'x\n' > "$work/$f"; done
 git -C "$work" add -A >/dev/null 2>&1
 
-# One vector: git's selection for the pattern against this package's.
+# One vector: git's selection for the pattern against this package's. An
+# `agree` row names the selection both must make (`-` for none), so a row on
+# which both select nothing is visibly that and never an agreement on a
+# fixture the pattern does not reach.
 vector() {
-  local pattern want_agree theirs mine
+  local pattern want_agree theirs mine want
   pattern="$1"
   want_agree="$2"
+  want="${3:-}"
+  [ "$want" != - ] || want=""
   local refused=0
   theirs="$(git -C "$work" ls-files -- ":(glob)$pattern" 2>/dev/null | LC_ALL=C sort | tr '\n' ' ' | sed 's/  *$//')" || refused=1
   git -C "$work" ls-files -- ":(glob)$pattern" >/dev/null 2>&1 || refused=1
@@ -61,10 +66,10 @@ PY
   mine="$(printf '%s' "$mine" | sed 's/  *$//')"
   case "$want_agree" in
     agree)
-      if [ "$refused" -eq 0 ] && [ "$theirs" = "$mine" ]; then
-        ok "agrees with git's wildmatch: $pattern"
+      if [ "$refused" -eq 0 ] && [ "$theirs" = "$want" ] && [ "$mine" = "$want" ]; then
+        ok "agrees with git's wildmatch: $pattern selects [$want]"
       else
-        bad "agrees with git's wildmatch: $pattern" "git [$theirs] refused=$refused vs this package [$mine]"
+        bad "agrees with git's wildmatch: $pattern selects [$want]" "git [$theirs] refused=$refused vs this package [$mine]"
       fi ;;
     disagree)
       if [ "$theirs" != "$mine" ]; then ok "the harness reports a disagreement: $pattern"
@@ -80,10 +85,14 @@ PY
 
 export BI_ROOT
 
-# Every shape the dialect permits.
-for p in 'a/**' 'a/*' '**' '*' '*.md' '**/*.md' '**/g' 'a/**/g' 'a/*/g' 'a/b/**' \
-         'a?f' 'a**' '[a]b/h' 'docs/**' 'top.md' 'solo/**' 'docs' 'doc?'; do
-  vector "$p" agree
+# Every shape the dialect permits, each with the selection it makes over the
+# tree above: `pattern|selection`.
+for row in 'a/**|a/b/g a/f' 'a/*|a/f' '**|a/b/g a/f ab/h docs/x.md solo top.md' \
+           '*|solo top.md' '*.md|top.md' '**/*.md|docs/x.md top.md' '**/g|a/b/g' \
+           'a/**/g|a/b/g' 'a/*/g|a/b/g' 'a/b/**|a/b/g' 'a?f|-' 'a**|a/b/g a/f ab/h' \
+           '[a]b/h|ab/h' 'docs/**|docs/x.md' 'top.md|top.md' 'solo/**|-' \
+           'docs|docs/x.md' 'doc?|-'; do
+  vector "${row%%|*}" agree "${row#*|}"
 done
 
 # The harness's own control, on inputs the dialect refuses. An empty component

--- a/.agents/skills/bot-instructions/tests/lib/harness.sh
+++ b/.agents/skills/bot-instructions/tests/lib/harness.sh
@@ -205,6 +205,26 @@ expect_message() {
   else bad "$label" "expected '$want'; got: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"; fi
 }
 
+# The red control for one clause of a validator that has several: exit 1,
+# that validator alone, and the finding naming the clause (the fragment only
+# that clause's message carries), so a fixture that also trips a neighbouring
+# clause of the same validator cannot pass on the neighbour.
+expect_clause() {
+  local validator clause label fired
+  validator="$1"; clause="$2"; label="$3"; shift 3
+  bi_run "$@"
+  fired="$(bi_fired)"
+  if [ "$bi_status" -ne 1 ]; then
+    bad "$label" "expected exit 1 with $validator; exited $bi_status: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"
+  elif [ "$fired" != "$validator " ]; then
+    bad "$label" "expected exactly [$validator ]; fired: [$fired]"
+  elif ! bi_carries "$clause"; then
+    bad "$label" "expected the finding to name '$clause'; got: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"
+  else
+    ok "$label"
+  fi
+}
+
 # The validator names in `$bi_out`, sorted, space-separated, one trailing
 # space: the set `expect_red` and a table row compare against.
 bi_fired() {

--- a/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -125,14 +125,8 @@ spec_table "$rows"
 # on the old id silently reaches nothing. The comparison is against the
 # frozen set, which lives in the implementation.
 spec="$(new_spec renamed-pair)"
-python3 - "$spec/SKILL.md" "$spec/schemas/renders.md" <<'PY'
-import sys
-skill, renders = sys.argv[1], sys.argv[2]
-s = open(skill).read().replace("\n### severity\n", "\n### severity-honesty\n", 1)
-open(skill, "w").write(s)
-r = open(renders).read().replace("| `severity` |", "| `severity-honesty` |", 1)
-open(renders, "w").write(r)
-PY
+spec_edit "$spec/SKILL.md" '\n### severity\n' '\n### severity-honesty\n' || exit 1
+spec_edit "$spec/schemas/renders.md" '| `severity` |' '| `severity-honesty` |' || exit 1
 expect_clause doctrine-routing "block id 'severity' is frozen and the doctrine source no longer defines it" \
   'a heading and its row renamed together, against the frozen set' \
   render --dry-run --repo "$repo" --spec "$spec"

--- a/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -31,7 +31,8 @@ expect_green "the running copy's own doctrine and routing agree" \
 # One spec mutation per row: `label~file~old~new~verdict`, `~`-separated
 # because the routing rows the mutations edit carry `|`. `old` and `new` are
 # literal text with `\n` for a newline; an `re:` prefix on `old` makes it a
-# regular expression and `new` its replacement (`\g<n>` groups allowed). The
+# regular expression and `new` a `re.sub` template (`\g<n>` groups, and no
+# other backslash escape). The
 # edit asserts exactly one match, so a fixture the running copy has moved
 # away from fails as a fixture rather than passing on a defect never planted.
 # `verdict` is `red:<validator>:<clause>` (exit 1, that validator alone, the
@@ -100,7 +101,10 @@ EOF
 # setext heading in `.github/copilot-instructions.md`, a forged section, and
 # an indented level-4 heading reaches the refusal rather than the section
 # parse, which a level-1 or -2 one would end.
-spec_table "$(cat <<'ROWS'
+# `read -d ''` rather than `$(cat <<'ROWS' ...)`: Bash 3.2 scans a here-document
+# inside a command substitution for quotes, and a row carrying an odd number
+# of double quotes runs its parse past the closing parenthesis.
+IFS= read -r -d '' rows <<'ROWS'
 a doctrine block with no routing row~SKILL.md~\n## Adding a repo\n~\n### unrouted\n\nA block no column carries.\n\n## Adding a repo\n~red:doctrine-routing:doctrine block 'unrouted' has no row in the routing table
 a routing row naming no doctrine heading~schemas/renders.md~| `trust-model` |~| `no-such-block` | – | – | – | – | – | – | – | – |\n| `trust-model` |~red:doctrine-routing:routing table row 'no-such-block' names no `###` heading
 a position repeated inside a column~schemas/renders.md~| `rounds` | 2 |~| `rounds` | 1 |~red:doctrine-routing:column 'AGENTS.md' repeats a position
@@ -113,7 +117,7 @@ two `## Doctrine` sections~SKILL.md~\n## Adding a repo\n~\n## Doctrine\n\n### x\
 a `---` line under text in doctrine, which forges a section~SKILL.md~### scope\n\nRaise a defect~### scope\n\nForged\n---\n\nRaise a defect~msg:heading refusal
 a heading line in doctrine text, which ends the owned region~SKILL.md~### scope\n\nRaise a defect~### scope\n\n  #### Forged\n\nRaise a defect~msg:heading refusal
 ROWS
-)"
+spec_table "$rows"
 
 # The frozen-id invariant, the one mutation that edits both files. Renaming a
 # heading and its row together leaves both sets agreeing, so a comparison of
@@ -131,6 +135,12 @@ open(renders, "w").write(r)
 PY
 expect_clause doctrine-routing "block id 'severity' is frozen and the doctrine source no longer defines it" \
   'a heading and its row renamed together, against the frozen set' \
+  render --dry-run --repo "$repo" --spec "$spec"
+# The other direction of the same comparison, on the same fixture: the new
+# id is outside the frozen set, which is what makes adding a `###` heading a
+# deliberate edit to the constant a reviewer reads.
+expect_clause doctrine-routing "block id 'severity-honesty' is not in the frozen set" \
+  'and the renamed block is not in the frozen set either' \
   render --dry-run --repo "$repo" --spec "$spec"
 
 # The other side of the heading predicate: `#` with NO whitespace after it is
@@ -307,7 +317,9 @@ fi
 # table sends there has to arrive as written. The rows are derived from the
 # spec copy rather than copied here: the column names the blocks, and each
 # block's paragraphs, joined the way the region joins a bullet, must appear
-# in the region. The `reply-contract` block's `<issue>` placeholder becomes
+# in the region, each block after the one the column routes before it, so a
+# dropped, truncated or reordered block shows in its row. The `reply-contract`
+# block's `<issue>` placeholder becomes
 # `<PREFIX>-<n>` under `[bot-instructions.repo] tracker` (`renders.md`
 # § Common rules; the canonical fixture's tracker is `FIX`), so a paragraph
 # is held with that substitution made. The floor is the column's own length:
@@ -326,20 +338,27 @@ if region is None:
 blocks = doctrine.routing["AGENTS.md"]
 if not blocks:
     sys.exit("the AGENTS.md column routes no block")
+at = 0
 for bid in blocks:
     paras = [" ".join(p.split()).replace("<issue>", "<FIX-n>")
              for p in doctrine.blocks[bid].split("\n\n") if p.strip()]
     if not paras:
         sys.exit(f"{bid}: no paragraph to hold against the region")
-    missing = [p for p in paras if p not in region]
-    print(f"{'ok' if not missing else 'missing'}\t{bid}\t{len(paras)}")
+    verdict = "ok"
+    for para in paras:
+        found = region.find(para, at)
+        if found == -1:
+            verdict = "missing-or-out-of-order"
+            break
+        at = found + len(para)
+    print(f"{verdict}\t{bid}\t{len(paras)}")
 PY
   before=$((BI_PASS + BI_FAIL))
   while IFS="$(printf '\t')" read -r verdict bid count; do
     if [ "$verdict" = ok ]; then
-      ok "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+      ok "AGENTS.md § Code Review Rules carries block $bid in its routed order ($count paragraph(s))"
     else
-      bad "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+      bad "AGENTS.md § Code Review Rules carries block $bid in its routed order ($count paragraph(s))" "$verdict"
     fi
   done < "$BI_TMP/agents-rows"
   [ "$((BI_PASS + BI_FAIL))" -gt "$before" ] || { printf 'no block row was asserted\n' >&2; exit 2; }

--- a/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -28,88 +28,98 @@ new_spec() {
 expect_green "the running copy's own doctrine and routing agree" \
   render --dry-run --repo "$repo"
 
-# 1. A `###` block id with no row: an unrouted block is an error, never a
-#    silent drop.
-spec="$(new_spec unrouted)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("\n## Adding a repo\n", "\n### unrouted\n\nA block no column carries.\n\n## Adding a repo\n")
-open(p, "w").write(s)
+# One spec mutation per row: `label~file~old~new~verdict`, `~`-separated
+# because the routing rows the mutations edit carry `|`. `old` and `new` are
+# literal text with `\n` for a newline; an `re:` prefix on `old` makes it a
+# regular expression and `new` its replacement (`\g<n>` groups allowed). The
+# edit asserts exactly one match, so a fixture the running copy has moved
+# away from fails as a fixture rather than passing on a defect never planted.
+# `verdict` is `red:<validator>:<clause>` (exit 1, that validator alone, the
+# finding naming the clause, since `doctrine-routing` has six clauses and a
+# fixture can trip two) or `msg:<value>` (exit 2, the message names that
+# value). A table that asserted no row exits 2 from its own counter.
+spec_edit() { # SPEC-FILE OLD NEW — one asserted replacement
+  python3 - "$1" "$2" "$3" <<'PY'
+import re, sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+if old.startswith("re:"):
+    n = len(re.findall(old[3:], s))
+    out = re.sub(old[3:], new, s, count=1)
+else:
+    old = old.replace("\\n", "\n")
+    new = new.replace("\\n", "\n")
+    n = s.count(old)
+    out = s.replace(old, new, 1)
+if n != 1:
+    sys.exit(f"{path}: expected one match of {old[:60]!r}, found {n}")
+if out == s:
+    sys.exit(f"{path}: the edit changed nothing")
+open(path, "w").write(out)
 PY
-expect_red doctrine-routing 'a doctrine block with no routing row' \
-  render --dry-run --repo "$repo" --spec "$spec"
+}
 
-# 2. A routing row naming an id the doctrine source does not define. Set
-#    equality in both directions: the one-directional half leaves the orphaned
-#    row unchecked.
-spec="$(new_spec ghost-row)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-row = "| `trust-model` |"
-ghost = "| `no-such-block` | – | – | – | – | – | – | – | – |\n"
-s = s.replace(row, ghost + row, 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a routing row naming no doctrine heading' \
-  render --dry-run --repo "$repo" --spec "$spec"
+spec_table() {
+  local rows="$1" row label file old new verdict spec field n=0 before
+  before=$((BI_PASS + BI_FAIL))
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    IFS='~' read -r label file old new verdict <<EOF
+$row
+EOF
+    for field in "$label" "$file" "$old" "$verdict"; do
+      [ -n "$field" ] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    n=$((n + 1))
+    spec="$(new_spec "row-$n")"
+    spec_edit "$spec/$file" "$old" "$new" || { printf 'fixture: %s\n' "$label" >&2; exit 1; }
+    case "$verdict" in
+      red:*:*)
+        verdict="${verdict#red:}"
+        expect_clause "${verdict%%:*}" "${verdict#*:}" "$label" render --dry-run --repo "$repo" --spec "$spec" ;;
+      msg:*) expect_message "${verdict#msg:}" "$label" render --dry-run --repo "$repo" --spec "$spec" ;;
+      *) printf 'unknown verdict: %s\n' "$verdict" >&2; exit 1 ;;
+    esac
+  done <<EOF
+$rows
+EOF
+  [ "$((BI_PASS + BI_FAIL))" -gt "$before" ] || { printf 'no row was asserted\n' >&2; exit 2; }
+}
 
-# 3. A position repeated inside a column.
-spec="$(new_spec repeat)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("| `rounds` | 2 |", "| `rounds` | 1 |", 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a position repeated inside a column' \
-  render --dry-run --repo "$repo" --spec "$spec"
+# An unrouted block is an error, never a silent drop. A row naming no
+# heading: set equality in both directions, since the one-directional half
+# leaves the orphaned row unchecked. Positions in a column run 1..n once
+# each. The two all-eight columns lose a block and Codex or Macroscope loses
+# it with every other validator green. A spec copy with no readable version
+# would land a doctrine change under a stamp naming doctrine it does not
+# carry; a version carrying `-->` would close the marker comment and put the
+# rest into a generated file as live reviewer instructions. Two `## Doctrine`
+# sections, or none, is an error rather than a guess. Doctrine text is under
+# the same content refusals as repo text, applied where it is read
+# (`renders.md` § Render-side second checks): a `---` under a text line is a
+# setext heading in `.github/copilot-instructions.md`, a forged section, and
+# an indented level-4 heading reaches the refusal rather than the section
+# parse, which a level-1 or -2 one would end.
+spec_table "$(cat <<'ROWS'
+a doctrine block with no routing row~SKILL.md~\n## Adding a repo\n~\n### unrouted\n\nA block no column carries.\n\n## Adding a repo\n~red:doctrine-routing:doctrine block 'unrouted' has no row in the routing table
+a routing row naming no doctrine heading~schemas/renders.md~| `trust-model` |~| `no-such-block` | – | – | – | – | – | – | – | – |\n| `trust-model` |~red:doctrine-routing:routing table row 'no-such-block' names no `###` heading
+a position repeated inside a column~schemas/renders.md~| `rounds` | 2 |~| `rounds` | 1 |~red:doctrine-routing:column 'AGENTS.md' repeats a position
+a gap in a column, whose positions must run 1..n~schemas/renders.md~| `rounds` | 2 |~| `rounds` | 9 |~red:doctrine-routing:column 'AGENTS.md' positions are [1, 3, 4, 5, 6, 7, 8, 9], not 1..n
+a block missing from the AGENTS.md column~schemas/renders.md~| `reply-contract` | 8 |~| `reply-contract` | – |~red:doctrine-routing:column 'AGENTS.md' omits 'reply-contract'
+a block missing from the macroscope doctrine.md column~schemas/renders.md~re:(\| `reply-contract` \|.*\| )8 \|\n~\g<1>– |\n~red:doctrine-routing:column 'macroscope doctrine.md' omits 'reply-contract'
+a spec copy with no readable version~SKILL.md~re:\n  version: "[^"]*"~~msg:no `version:` under metadata
+a spec version that would close its own comment~SKILL.md~re:(\n  version: ")([^"]*)(")~\g<1>\g<2> --> <!-- x\g<3>~msg:is outside [A-Za-z0-9.+-]
+two `## Doctrine` sections~SKILL.md~\n## Adding a repo\n~\n## Doctrine\n\n### x\n\ny\n\n## Adding a repo\n~msg:exactly one is required
+a `---` line under text in doctrine, which forges a section~SKILL.md~### scope\n\nRaise a defect~### scope\n\nForged\n---\n\nRaise a defect~msg:heading refusal
+a heading line in doctrine text, which ends the owned region~SKILL.md~### scope\n\nRaise a defect~### scope\n\n  #### Forged\n\nRaise a defect~msg:heading refusal
+ROWS
+)"
 
-# 4. A gap in a column's positions, which must run 1..n.
-spec="$(new_spec gap)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("| `rounds` | 2 |", "| `rounds` | 9 |", 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a gap in a column, whose positions must run 1..n' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# 5/6. A missing block in a column that carries every block. Delete the `8`
-#    from reply-contract's AGENTS.md cell and Codex loses the reply contract
-#    with every other validator green.
-spec="$(new_spec agents-hole)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace("| `reply-contract` | 8 |", "| `reply-contract` | – |", 1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a block missing from the AGENTS.md column' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-spec="$(new_spec macroscope-hole)"
-python3 - "$spec/schemas/renders.md" <<'PY'
-import sys, re
-p = sys.argv[1]
-s = open(p).read()
-s = re.sub(r"(\| `reply-contract` \|.*\| )8 \|\n", r"\1– |\n", s, count=1)
-open(p, "w").write(s)
-PY
-expect_red doctrine-routing 'a block missing from the macroscope doctrine.md column' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# 7. The frozen-id invariant. Renaming a heading and its row together leaves
-#    both sets agreeing, so a comparison of the pair passes and a consuming
-#    repo's `[bot-instructions.doctrine.append]` on the old id silently reaches nothing. The
-#    comparison is against the frozen set, which lives in the implementation.
+# The frozen-id invariant, the one mutation that edits both files. Renaming a
+# heading and its row together leaves both sets agreeing, so a comparison of
+# the pair passes and a consuming repo's `[bot-instructions.doctrine.append]`
+# on the old id silently reaches nothing. The comparison is against the
+# frozen set, which lives in the implementation.
 spec="$(new_spec renamed-pair)"
 python3 - "$spec/SKILL.md" "$spec/schemas/renders.md" <<'PY'
 import sys
@@ -119,72 +129,8 @@ open(skill, "w").write(s)
 r = open(renders).read().replace("| `severity` |", "| `severity-honesty` |", 1)
 open(renders, "w").write(r)
 PY
-expect_red doctrine-routing 'a heading and its row renamed together, against the frozen set' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# A spec copy with no readable version: a doctrine change would otherwise land
-# under a stamp naming doctrine it does not carry.
-spec="$(new_spec no-version)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys, re
-p = sys.argv[1]
-s = re.sub(r'\n  version: "[^"]*"', "", open(p).read(), count=1)
-open(p, "w").write(s)
-PY
-expect_message "no \`version:\` under metadata" 'a spec copy with no readable version' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# The version is interpolated into a comment. One carrying `-->` or a newline
-# would end that comment and put the rest into a generated file as live
-# reviewer instructions.
-spec="$(new_spec unsafe-version)"
-python3 - "$spec/SKILL.md" <<'PY'
-import re, sys
-p = sys.argv[1]
-s = re.sub(r'(\n  version: ")([^"]*)(")', r'\g<1>\g<2> --> <!-- x\3', open(p).read(), count=1)
-open(p, "w").write(s)
-PY
-expect_message "is outside [A-Za-z0-9.+-]" 'a spec version that would close its own comment' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# Two `## Doctrine` sections, or none, is an error rather than a guess.
-spec="$(new_spec two-sections)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read().replace("\n## Adding a repo\n", "\n## Doctrine\n\n### x\n\ny\n\n## Adding a repo\n", 1)
-open(p, "w").write(s)
-PY
-expect_message "exactly one is required" 'two `## Doctrine` sections' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-# Doctrine text is under the same content refusals as repo text, applied where
-# it is read: `renders.md` § Render-side second checks. A `---` under a text
-# line renders into `.github/copilot-instructions.md`, where blocks are `###`
-# subsections with paragraphs preserved, and markdown reads the pair as a
-# setext heading — a forged section in the file whose escaping rule exists to
-# stop exactly that.
-spec="$(new_spec doctrine-setext)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-s = open(p).read().replace("### scope\n\nRaise a defect", "### scope\n\nForged\n---\n\nRaise a defect", 1)
-open(p, "w").write(s)
-PY
-expect_message "heading refusal" 'a `---` line under text in doctrine, which forges a section' \
-  render --dry-run --repo "$repo" --spec "$spec"
-
-spec="$(new_spec doctrine-heading)"
-python3 - "$spec/SKILL.md" <<'PY'
-import sys
-p = sys.argv[1]
-# A level-4 heading: it does not end the `## Doctrine` section the way a
-# level-1 or -2 one would, so this control reaches the refusal rather than
-# the section parse.
-s = open(p).read().replace("### scope\n\nRaise a defect", "### scope\n\n  #### Forged\n\nRaise a defect", 1)
-open(p, "w").write(s)
-PY
-expect_message "heading refusal" 'a heading line in doctrine text, which ends the owned region' \
+expect_clause doctrine-routing "block id 'severity' is frozen and the doctrine source no longer defines it" \
+  'a heading and its row renamed together, against the frozen set' \
   render --dry-run --repo "$repo" --spec "$spec"
 
 # The other side of the heading predicate: `#` with NO whitespace after it is
@@ -356,32 +302,49 @@ else
   bad 'an overridden block keeps its line breaks, and a package one is still joined'
 fi
 
-# --- the sweep rules reach Codex --------------------------------------------
-# Root rules from a declined-finding sweep. `AGENTS.md` is the one surface
-# Codex reads, so each sentence has to land in the owned region as written.
-repo="$(bi_rendered_repo doctrine-sweep)" || exit 1
-region="$(python3 - "$repo/AGENTS.md" <<'PY'
-import sys
-lines = open(sys.argv[1]).read().split("\n")
-start = lines.index("## Code Review Rules")
-end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
-print("\n".join(lines[start:end]))
+# --- every block the AGENTS.md column routes lands in the owned region ------
+# `AGENTS.md` is the one surface Codex reads, so each block the routing
+# table sends there has to arrive as written. The rows are derived from the
+# spec copy rather than copied here: the column names the blocks, and each
+# block's paragraphs, joined the way the region joins a bullet, must appear
+# in the region. The `reply-contract` block's `<issue>` placeholder becomes
+# `<PREFIX>-<n>` under `[bot-instructions.repo] tracker` (`renders.md`
+# § Common rules; the canonical fixture's tracker is `FIX`), so a paragraph
+# is held with that substitution made. The floor is the column's own length:
+# a column routing no block, a block with no paragraph, or a region that
+# cannot be located fails as a fixture before any row is counted.
+repo="$(bi_rendered_repo doctrine-agents)" || exit 1
+if python3 - "$BI_ROOT/skills/bot-instructions" "$repo" > "$BI_TMP/agents-rows" <<'PY'; then
+import os, sys
+PKG, repo = sys.argv[1], sys.argv[2]
+sys.path.insert(0, os.path.join(PKG, "scripts"))
+from lib import render, spec as spec_mod, tree
+doctrine = spec_mod.load(tree.Worktree(PKG), "SKILL.md", "schemas/renders.md")
+region = render.region_of(open(os.path.join(repo, "AGENTS.md")).read())
+if region is None:
+    sys.exit("the rendered AGENTS.md has no owned region")
+blocks = doctrine.routing["AGENTS.md"]
+if not blocks:
+    sys.exit("the AGENTS.md column routes no block")
+for bid in blocks:
+    paras = [" ".join(p.split()).replace("<issue>", "<FIX-n>")
+             for p in doctrine.blocks[bid].split("\n\n") if p.strip()]
+    if not paras:
+        sys.exit(f"{bid}: no paragraph to hold against the region")
+    missing = [p for p in paras if p not in region]
+    print(f"{'ok' if not missing else 'missing'}\t{bid}\t{len(paras)}")
 PY
-)"
-while IFS= read -r sentence; do
-  if printf '%s\n' "$region" | grep -qF -- "$sentence"; then
-    ok "AGENTS.md § Code Review Rules carries: $sentence"
-  else
-    bad "AGENTS.md § Code Review Rules carries: $sentence"
-  fi
-done <<'EOF'
-Report an input only after establishing that a shipped producer emits it in normal use; a full disk or a value past 2^53 is not one.
-Name the user-visible consequence in every finding.
-Report a gap only after establishing that nothing already covers it: a required CI context, a shipped hook, the file's own stated contract, or the platform's documentation.
-Request a tighter assertion only when the row's named claim can regress without it reddening; an incidental finding the fixture also produces, or a state pin restating a refusal the exit status carries, is not a gap.
-Do not ask a script to copy a verb another file owns, such as an ancestor walk or a parser; name the owner and ask for a call to it or an escalation, since a second copy is a twin.
-Before reporting an output as missing or hard-coded, read the full line and the lines it prints; a value already emitted there answers the finding.
-Before reporting coverage or a reference as missing on a branch, check main and the sibling PRs the body names; a series lands its halves in separate PRs and a branch cut from an earlier main lacks the sibling's files by construction.
-EOF
+  before=$((BI_PASS + BI_FAIL))
+  while IFS="$(printf '\t')" read -r verdict bid count; do
+    if [ "$verdict" = ok ]; then
+      ok "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+    else
+      bad "AGENTS.md § Code Review Rules carries block $bid ($count paragraph(s))"
+    fi
+  done < "$BI_TMP/agents-rows"
+  [ "$((BI_PASS + BI_FAIL))" -gt "$before" ] || { printf 'no block row was asserted\n' >&2; exit 2; }
+else
+  bad 'the AGENTS.md block rows could be derived from the spec copy' "$(cat "$BI_TMP/agents-rows")"
+fi
 
 bi_summary

--- a/skills/bot-instructions/tests/globs.test.sh
+++ b/skills/bot-instructions/tests/globs.test.sh
@@ -86,7 +86,13 @@ PY
 export BI_ROOT
 
 # Every shape the dialect permits, each with the selection it makes over the
-# tree above: `pattern|selection`.
+# tree above: `pattern|selection`. A list an edit emptied would let the
+# assertions below supply the suite's success, so each loop here floors on
+# its own count.
+floor() { # BEFORE LABEL — at least one assertion since BEFORE
+  [ "$((BI_PASS + BI_FAIL))" -gt "$1" ] || { printf '%s asserted no row\n' "$2" >&2; exit 2; }
+}
+before=$((BI_PASS + BI_FAIL))
 for row in 'a/**|a/b/g a/f' 'a/*|a/f' '**|a/b/g a/f ab/h docs/x.md solo top.md' \
            '*|solo top.md' '*.md|top.md' '**/*.md|docs/x.md top.md' '**/g|a/b/g' \
            'a/**/g|a/b/g' 'a/*/g|a/b/g' 'a/b/**|a/b/g' 'a?f|-' 'a**|a/b/g a/f ab/h' \
@@ -94,6 +100,7 @@ for row in 'a/**|a/b/g a/f' 'a/*|a/f' '**|a/b/g a/f ab/h docs/x.md solo top.md' 
            'docs|docs/x.md' 'doc?|-'; do
   vector "${row%%|*}" agree "${row#*|}"
 done
+floor "$before" 'the agree table'
 
 # The harness's own control, on inputs the dialect refuses. An empty component
 # is the sharpest: git normalizes `a//f` to `a/f` and selects a file, and this
@@ -111,6 +118,7 @@ vector '../a/f' refused
 # sequences, and this is the difference: a ban list closes the shapes someone
 # thought of, and every byte below is outside the class whether or not anyone
 # named it.
+before=$((BI_PASS + BI_FAIL))
 for bad_pattern in '{a,ab}/**' '@(a|ab)/**' 'a,b' 'a#b' 'a!b' 'a"b'; do
   if python3 -c "
 import sys, os
@@ -128,6 +136,7 @@ raise SystemExit(1)
     bad "the dialect refuses: $bad_pattern"
   fi
 done
+floor "$before" 'the refused-pattern table'
 
 # `**/` translates to `(?:[^/]*/)*`, and nesting those is exponential in the
 # number of `**`: rejecting a deep path took seconds at a dozen, inside the
@@ -140,11 +149,17 @@ sys.path.insert(0, os.path.join(sys.argv[1], "scripts"))
 from lib import globs
 
 paths = ["a", "a/b", "a/x/b", "b", "a/x/y/b", "a/b/c", "x/b", "a/x/y/z/b"]
+compared = 0
 for n in range(1, 6):
     many = "a/" + "**/" * n + "b"
     for p in paths:
         if bool(globs.matching(many, [p])) != bool(globs.matching("a/**/b", [p])):
             sys.exit(f"{many!r} and 'a/**/b' disagree on {p!r}")
+        compared += 1
+# The equivalence half floors on its own count: an emptied path list would
+# leave the cost probe below to supply this assertion's success.
+if not compared:
+    sys.exit("the collapse matrix compared no path")
 # In a child with a hard deadline: uncollapsed, twenty `**` against a
 # twenty-deep path does not return in any time a CI lane will wait, and a
 # control that waits with it reports a timeout rather than a failure.

--- a/skills/bot-instructions/tests/globs.test.sh
+++ b/skills/bot-instructions/tests/globs.test.sh
@@ -40,11 +40,16 @@ git -C "$work" init -q .
 for f in a/f a/b/g ab/h top.md docs/x.md solo; do printf 'x\n' > "$work/$f"; done
 git -C "$work" add -A >/dev/null 2>&1
 
-# One vector: git's selection for the pattern against this package's.
+# One vector: git's selection for the pattern against this package's. An
+# `agree` row names the selection both must make (`-` for none), so a row on
+# which both select nothing is visibly that and never an agreement on a
+# fixture the pattern does not reach.
 vector() {
-  local pattern want_agree theirs mine
+  local pattern want_agree theirs mine want
   pattern="$1"
   want_agree="$2"
+  want="${3:-}"
+  [ "$want" != - ] || want=""
   local refused=0
   theirs="$(git -C "$work" ls-files -- ":(glob)$pattern" 2>/dev/null | LC_ALL=C sort | tr '\n' ' ' | sed 's/  *$//')" || refused=1
   git -C "$work" ls-files -- ":(glob)$pattern" >/dev/null 2>&1 || refused=1
@@ -61,10 +66,10 @@ PY
   mine="$(printf '%s' "$mine" | sed 's/  *$//')"
   case "$want_agree" in
     agree)
-      if [ "$refused" -eq 0 ] && [ "$theirs" = "$mine" ]; then
-        ok "agrees with git's wildmatch: $pattern"
+      if [ "$refused" -eq 0 ] && [ "$theirs" = "$want" ] && [ "$mine" = "$want" ]; then
+        ok "agrees with git's wildmatch: $pattern selects [$want]"
       else
-        bad "agrees with git's wildmatch: $pattern" "git [$theirs] refused=$refused vs this package [$mine]"
+        bad "agrees with git's wildmatch: $pattern selects [$want]" "git [$theirs] refused=$refused vs this package [$mine]"
       fi ;;
     disagree)
       if [ "$theirs" != "$mine" ]; then ok "the harness reports a disagreement: $pattern"
@@ -80,10 +85,14 @@ PY
 
 export BI_ROOT
 
-# Every shape the dialect permits.
-for p in 'a/**' 'a/*' '**' '*' '*.md' '**/*.md' '**/g' 'a/**/g' 'a/*/g' 'a/b/**' \
-         'a?f' 'a**' '[a]b/h' 'docs/**' 'top.md' 'solo/**' 'docs' 'doc?'; do
-  vector "$p" agree
+# Every shape the dialect permits, each with the selection it makes over the
+# tree above: `pattern|selection`.
+for row in 'a/**|a/b/g a/f' 'a/*|a/f' '**|a/b/g a/f ab/h docs/x.md solo top.md' \
+           '*|solo top.md' '*.md|top.md' '**/*.md|docs/x.md top.md' '**/g|a/b/g' \
+           'a/**/g|a/b/g' 'a/*/g|a/b/g' 'a/b/**|a/b/g' 'a?f|-' 'a**|a/b/g a/f ab/h' \
+           '[a]b/h|ab/h' 'docs/**|docs/x.md' 'top.md|top.md' 'solo/**|-' \
+           'docs|docs/x.md' 'doc?|-'; do
+  vector "${row%%|*}" agree "${row#*|}"
 done
 
 # The harness's own control, on inputs the dialect refuses. An empty component

--- a/skills/bot-instructions/tests/lib/harness.sh
+++ b/skills/bot-instructions/tests/lib/harness.sh
@@ -205,6 +205,26 @@ expect_message() {
   else bad "$label" "expected '$want'; got: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"; fi
 }
 
+# The red control for one clause of a validator that has several: exit 1,
+# that validator alone, and the finding naming the clause (the fragment only
+# that clause's message carries), so a fixture that also trips a neighbouring
+# clause of the same validator cannot pass on the neighbour.
+expect_clause() {
+  local validator clause label fired
+  validator="$1"; clause="$2"; label="$3"; shift 3
+  bi_run "$@"
+  fired="$(bi_fired)"
+  if [ "$bi_status" -ne 1 ]; then
+    bad "$label" "expected exit 1 with $validator; exited $bi_status: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"
+  elif [ "$fired" != "$validator " ]; then
+    bad "$label" "expected exactly [$validator ]; fired: [$fired]"
+  elif ! bi_carries "$clause"; then
+    bad "$label" "expected the finding to name '$clause'; got: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"
+  else
+    ok "$label"
+  fi
+}
+
 # The validator names in `$bi_out`, sorted, space-separated, one trailing
 # space: the set `expect_red` and a table row compare against.
 bi_fired() {


### PR DESCRIPTION
Reshapes `skills/bot-instructions/tests/doctrine-routing.test.sh` and `globs.test.sh` to code-quality § Tests, with one harness helper.

`doctrine-routing.test.sh` planted its twelve spec-copy mutations as twelve python heredocs whose `replace` never asserted a match, and every red row asserted only that `doctrine-routing` fired: a validator with six clauses, so a fixture tripping a neighbouring clause passed as coverage (an unrouted block is also a block outside the frozen set; a repeated position is also a run that is not 1..n; the first battery run recorded those mutants surviving). Eleven mutations are one table `label~file~old~new~verdict` (`~`-separated because the routing rows carry `|`; `\n` for a newline; `re:` for a regular expression), whose edit asserts exactly one match and whose red verdict names the clause through the new harness `expect_clause`: exit 1, that validator alone, the finding naming the clause. The frozen-set case, the one mutation editing both files, pins its clause the same way. The seven verbatim sweep sentences pinned doctrine prose; they are eight rows derived from the routing table's AGENTS.md column: each routed block's paragraphs, joined as the region joins a bullet and with the `reply-contract` placeholder substituted as `renders.md` § Common rules states for the fixture's tracker, must appear in the owned region, with the column's own length as the floor. The two readback cases, the fenced/wrapped-spec case and the running-copy control are unchanged.

`globs.test.sh`'s agree rows compared two computed selections with no expected value, so a pattern selecting nothing on both sides agreed on an empty set; each row names git's selection now (`pattern|selection`), and three (`a?f`, `solo/**`, `doc?`) are visibly empty.

The tracked renders under `.agents` are replayed with `patch` and are byte-identical to the source.

## Former assertions, with the surviving row

| Former case | Surviving row |
|---|---|
| the running copy's own doctrine and routing agree | unchanged |
| 1 unrouted block, 2 ghost row, 3 repeated position, 4 gap, 5 AGENTS.md hole, 6 macroscope hole | table rows 1 to 6, each pinning its clause |
| 7 renamed pair against the frozen set | its own case, pinning the frozen-set clause |
| no readable version; an unsafe version; two Doctrine sections; a setext forge; a heading in doctrine text | table rows 7 to 11 (`msg:` verdicts, exit 2) |
| a `#<digits>` line renders, and the block keeps it; `##` before a no-break space renders, and the block keeps it | unchanged |
| an overridden block keeps its line breaks, and a package one is still joined | unchanged |
| AGENTS.md § Code Review Rules carries: seven sentences (in `scope`, `severity`, `no-preferences`, `declined`) | the derived block rows for those four blocks, plus `rounds`, `reply-contract`, `render-out-of-scope`, `trust-model` |
| globs: 18 agree rows, 1 disagree, 2 refused, 6 dialect refusals, the collapse probe | the same rows; each agree row names its selection |

## Must-fail battery

`mutate-bi.py pr2` (in the lane's scratchpad; the record is `mutants-bi2-2.txt`): 21 of 21 killed. m01 an unrouted block not reported, m02 a ghost row not reported, m03 the frozen set not compared, m04 a repeated position accepted, m05 a gap accepted, m06 the all-eight columns not checked, m07 a missing version invented, m08 an unsafe version accepted, m09 two Doctrine sections taking the first, m10 the doctrine heading refusal skipped, m11 the AGENTS render dropping a block, m12 truncating one, m13 `*` crossing a slash, m14 `?` crossing a slash, m15 a literal pattern not covering its tree, m16 a wildcard pattern covering its tree, m17 `**` stopping at a slash, m18 a character class taken literally, m19 `**/` matching one level only, m20 a new heading outside the frozen set accepted, m21 the AGENTS render reversing the block order. m01, m03 and m04 survived the rows before the clause pins; m20 and m21 survived before the review's two rows.

## Reviewer round

reviewer-test on a6e09f183: action_required, two blockers and three suggestions; both blockers and two suggestions applied in the second commit da1044503, one suggestion kept as written. Its map: doctrine-routing 25 old assertions to 26 rows and globs 28 to 28, no named assertion lost; 19 delivered mutants reproduced from its own archive copy plus 6 of its own (two survived, both now killed) and 9 planted suite-defect controls, each failing loudly; 33/33 suite runs green on Linux, green under `LC_ALL=C` and `de_DE.UTF-8`. Blocker 1: the row table was a here-document inside `$(cat ...)`, which Bash 3.2 scans for quotes, so rows 7 and 8 (an odd number of double quotes each) ran the parse past the closing parenthesis and the macOS leg would have skipped the suite; the rows are read with `read -d ''` and the file parses under real 3.2.57. Blocker 2: the frozen-set comparison's other direction (a new heading outside the frozen set) was a masked union with the frozen-side clause on the renamed-pair fixture; it has its own pinned row, and its deletion mutant reddens that row alone. Applied suggestions: the derived AGENTS.md rows require each block after the one the column routes before it (a reversed render survived; it reddens every row now), and the `re:` rows' replacement is named as a re.sub template. Kept as written: the gap row pins the full printed position list, which is the value the validator prints. Battery rerun 21/21 (`mutants-bi2-2.txt`), m20 the frozen-set's other direction and m21 the reversed render added.

## Validation

`tools/guard --full` (DEV_VALIDATE_CMD) on `ad8c25bb2` in the branch worktree under the full-guard slot, with the Git redirect variables cleared and `TMPDIR=/var/tmp/ken-c`: exit 0, no `guard:` line (log `guard-bi2.log` in the lane's scratchpad: every cargo lane ok, UI 159 files / 1286 tests). The push then restacked the three commits onto main `8cf58920e` as `14f2b37ac`, `2b5bb9dbb` and `a0e4ed543`: `git range-diff` reports all three `=`, and the `-U0` source-plus-render diff `69ec4e5a5..ad8c25bb2` is byte-identical to `8cf58920e..a0e4ed543`. All eleven suites green at the head; `tools/bash32-lint` clean; the reshaped suites parse under Bash 3.2.57.

## Root read, the one same-class gap

Root's PR 2 read found that `globs.test.sh` had no independent floor for its agree-row loop, its refused-pattern loop, or the collapse probe's path matrix, so any of the three lists could be emptied while later assertions supplied the suite's success. Proved on a private copy before the change (each list emptied: exit 0 at 10, 22 and 28 passed) and after (exit 2 `the agree table asserted no row`, exit 2 `the refused-pattern table asserted no row`, and the probe's own `the collapse matrix compared no path` reddening its row): `globs-floor-controls.sh`, `-before.txt`, `-after.txt` in the lane's scratchpad. The third commit adds the smallest guard per list: a `floor` on the assertion count around each shell loop, and a comparison count in the probe before its cost half. The 21 behaviour controls and the reviewer round are unchanged.

## Bot pass

Copilot, one thread: the renamed-pair fixture's two `replace` calls never asserted a match. Measured on private copies before and after, in both directions (the routing-row rename missed; the heading rename missed): the OLD fixture already fails closed, exit 1 at 25 passed / 2 failed, both frozen-set rows red as `expected exit 1 with doctrine-routing; exited 2: Traceback` (a `KeyError` in `model.blocks_for`), so there was no silent pass to close; the CORRECTED fixture (`a664aff87`, both renames through the existing `spec_edit`) refuses before any run at its own cause, `expected one match of ..., found 0`. The change is kept as a fixture-integrity assertion for direct diagnosis, the same asserted-match rule the table rows and `bounds` carry, not as a fail-open fix. The `KeyError` on a routing row whose heading the doctrine source lacks is an existing refusal of malformed authoring input (exit 2, no fail-open, data loss or security consequence): accepted as it stands under KEN-1241 per the owner, no production change and no new issue. Every other scripted edit in this PR's files asserts its match. Exact failure text and outputs are kept in the lane's scratch artifacts (`missed-edit-control-both.txt`, `missed-edit-outputs/`).

KEN-1241

https://claude.ai/code/session_01SvJgBMmZb5cX6YrV9MyB3x
