### PR TITLE
test(KEN-1241): the drift-check exit mapping as one table of rows

### DIFF
--- a/hooks/tests/session-drift-check.test.sh
+++ b/hooks/tests/session-drift-check.test.sh
@@ -104,9 +104,12 @@ assert_contains() {
   fi
 }
 
-# Text as one line: every newline written as `\n`.
+# Text as one line: every backslash doubled first, then every newline written
+# as `\n`, so a hook that printed the two characters `\n` instead of a line
+# break renders as `\\n` and cannot match a row.
 escape_nl() {
   local text="$1"
+  text="${text//\\/\\\\}"
   printf '%s' "${text//$'\n'/\\n}"
 }
 
@@ -120,7 +123,9 @@ calls() {
 # trailing newlines kept.
 run_row() { # fake-rc fake-out-word
   local rc=0 fake text
-  fake="$(fake_out "$2")"
+  # A word fake_out refuses must end the run, not test the empty-output arm:
+  # the substitution swallows its exit, so the status is carried out by hand.
+  fake="$(fake_out "$2")" || { printf 'the fake output word could not be mapped: %s\n' "$2" >&2; return 1; }
   : >"$ARGS_LOG"
   : >"$CWD_LOG"
   env -u CLAUDE_PROJECT_DIR -u KENDEX_DRIFT_HOOK \
@@ -135,7 +140,7 @@ run_row() { # fake-rc fake-out-word
 }
 
 run_table() {
-  local title="$1" rows="$2" label fake_rc fake_word stdout want got row field before=$((PASS + FAIL))
+  local title="$1" rows="$2" label fake_rc fake_word stdout fake_text want got row field before=$((PASS + FAIL))
   echo "=== $title ==="
   while IFS= read -r row; do
     [[ "$row" != "" ]] || continue
@@ -143,13 +148,17 @@ run_table() {
     for field in "$label" "$fake_rc" "$fake_word" "$stdout"; do
       [[ "$field" != "" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
     done
+    # The word is mapped once, here, where a refusal ends the run: inside the
+    # substitutions below its exit would be swallowed and the row would test
+    # the empty-output arm instead.
+    fake_text="$(fake_out "$fake_word")" || { printf 'a row names a fake output word fake_out refuses: %s\n' "$row" >&2; exit 1; }
     got="$(run_row "$fake_rc" "$fake_word")"
     # A rendering aid for writing rows; the run is refused after the loop.
     if [[ "${HOOKS_TABLE_PROBE:-}" == 1 ]]; then
       printf '%s => %s\n' "$label" "$got"
       continue
     fi
-    want="${stdout//\{out\}/$(escape_nl "$(fake_out "$fake_word")")}"
+    want="${stdout//\{out\}/$(escape_nl "$fake_text")}"
     assert_eq "$got" "rc=0 calls=check --quiet out=$want" "$label"
   done <<<"$rows"
   [[ "$((PASS + FAIL))" -gt "$before" ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }

--- a/hooks/tests/session-drift-check.test.sh
+++ b/hooks/tests/session-drift-check.test.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Tests for the session-drift-check hook.
 #
-# The hook is a thin adapter over `kendex check --quiet`: exit 0 → silence,
-# exit 1 → the report verbatim on stdout, exit 2 → an "incomplete" line plus
-# the report, or a "could not run" line when the output is an Error:/error:
-# line from before the check ran, anything else → a "could not run" line
-# plus the output. These cases drive it with a fake `kendex` on PATH that
-# replays a scripted exit code and output, so no real install is consulted.
+# The hook is a thin adapter over `kendex check --quiet`, and its stdout is
+# the session-start context channel, so the exact text is the contract. The
+# mapping rows drive it with a fake `kendex` on PATH that replays a scripted
+# exit code and output, so no real install is consulted.
+#
+# A row is `label|fake rc|fake out|stdout`:
+#   fake rc   the exit status the fake kendex returns
+#   fake out  the fake's output by word (fake_out maps it); `-` for none
+#   stdout    the hook's exact stdout, `\n` for a newline and `{out}` for the
+#             fake's output; `-` when empty
+# Every row also asserts the hook's exit 0 and the argv `check --quiet`.
 #
 # HOOK_UNDER_TEST overrides the script under test so the must-fail controls
 # (a no-op hook, an always-print hook) can be run against these same
@@ -38,6 +43,23 @@ fi
 exit "${FAKE_RC:-0}"
 EOF
 chmod +x "$BIN_DIR/kendex"
+
+REPORT=$'kendex drift — project scope:\n  1 outdated — run `kendex refresh` to update:\n    ! orch (skill)'
+
+# The fake's output by word.
+fake_out() {
+  case "$1" in
+    -) : ;;
+    report) printf '%s' "$REPORT" ;;
+    unevaluated) printf '%s' $'not yet evaluated:\n  33 package(s) changed upstream and are not yet re-evaluated' ;;
+    could-not-check) printf '%s' $'could not check:\n  manifest: expected a table' ;;
+    error-inside-a-line) printf '%s' $'could not check:\n  source github.com/x/y unreachable since 2026-08-01: error: cannot lock ref' ;;
+    Error-line) printf '%s' 'Error: loading lock file' ;;
+    usage-error) printf '%s' $'error: unexpected argument \'--bogus\' found\n\nUsage: kendex check --quiet' ;;
+    fatal) printf '%s' 'kendex: fatal' ;;
+    *) printf 'unknown fake output word: %s\n' "$1" >&2; exit 1 ;;
+  esac
+}
 
 # Run the hook with a SessionStart payload on stdin (source from $HOOK_SOURCE,
 # default startup). Extra VAR=value args are passed through the environment.
@@ -82,70 +104,72 @@ assert_contains() {
   fi
 }
 
-assert_not_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" != *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected not to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
+# Text as one line: every newline written as `\n`.
+escape_nl() {
+  local text="$1"
+  printf '%s' "${text//$'\n'/\\n}"
 }
 
-echo "session-drift-check: clean install"
-capture FAKE_RC=0 FAKE_OUT=""
-assert_eq "$rc" 0 "exits 0 on a clean install"
-assert_eq "$out" "" "prints nothing on a clean install"
-assert_eq "$(cat "$ARGS_LOG")" "check --quiet" "invokes kendex check --quiet"
+calls() {
+  local text
+  text="$(paste -s -d ';' "$ARGS_LOG")"
+  [[ "$text" != "" ]] && printf '%s' "$text" || printf -- '-'
+}
 
-echo "session-drift-check: drift found"
-REPORT=$'kendex drift — project scope:\n  1 outdated — run `kendex refresh` to update:\n    ! orch (skill)'
-capture FAKE_RC=1 FAKE_OUT="$REPORT"
-assert_eq "$rc" 0 "exits 0 so drift never blocks the session"
-assert_eq "$out" "$REPORT"$'\n' "relays the report verbatim on stdout"
+# One mapping row: the hook's exit, the fake's argv and the whole stdout,
+# trailing newlines kept.
+run_row() { # fake-rc fake-out-word
+  local rc=0 fake text
+  fake="$(fake_out "$2")"
+  : >"$ARGS_LOG"
+  : >"$CWD_LOG"
+  env -u CLAUDE_PROJECT_DIR -u KENDEX_DRIFT_HOOK \
+    PATH="$BIN_DIR:$PATH" FAKE_ARGS_LOG="$ARGS_LOG" FAKE_CWD_LOG="$CWD_LOG" \
+    FAKE_RC="$1" FAKE_OUT="$fake" \
+    bash "$HOOK" <<<'{"session_id":"s","hook_event_name":"SessionStart","source":"startup"}' \
+    >"$TMP_ROOT/stdout" 2>/dev/null || rc=$?
+  text="$(cat "$TMP_ROOT/stdout"; printf x)"
+  text="${text%x}"
+  [[ "$text" != "" ]] && text="$(escape_nl "$text")" || text='-'
+  printf 'rc=%s calls=%s out=%s' "$rc" "$(calls)" "$text"
+}
 
-echo "session-drift-check: packages not yet evaluated"
-UNEVALUATED=$'not yet evaluated:\n  33 package(s) changed upstream and are not yet re-evaluated'
-capture FAKE_RC=1 FAKE_OUT="$UNEVALUATED"
-assert_eq "$out" "$UNEVALUATED"$'\n' "relays a not-yet-evaluated report verbatim, never as a failure"
+run_table() {
+  local title="$1" rows="$2" label fake_rc fake_word stdout want got row field before=$((PASS + FAIL))
+  echo "=== $title ==="
+  while IFS= read -r row; do
+    [[ "$row" != "" ]] || continue
+    IFS='|' read -r label fake_rc fake_word stdout <<<"$row"
+    for field in "$label" "$fake_rc" "$fake_word" "$stdout"; do
+      [[ "$field" != "" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    got="$(run_row "$fake_rc" "$fake_word")"
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [[ "${HOOKS_TABLE_PROBE:-}" == 1 ]]; then
+      printf '%s => %s\n' "$label" "$got"
+      continue
+    fi
+    want="${stdout//\{out\}/$(escape_nl "$(fake_out "$fake_word")")}"
+    assert_eq "$got" "rc=0 calls=check --quiet out=$want" "$label"
+  done <<<"$rows"
+  [[ "$((PASS + FAIL))" -gt "$before" ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+}
 
-echo "session-drift-check: could not check"
-capture FAKE_RC=2 FAKE_OUT=$'could not check:\n  manifest: expected a table'
-assert_eq "$rc" 0 "exits 0 when part of the check could not be made"
-assert_contains "$out" "kendex check incomplete (exit 2)" "names the incomplete check and exit code"
-assert_contains "$out" "manifest: expected a table" "carries the check's own diagnostic"
-assert_not_contains "$out" "could not run" "a completed run is never called a crash"
-capture FAKE_RC=2 FAKE_OUT=$'could not check:\n  source github.com/x/y unreachable since 2026-08-01: error: cannot lock ref'
-assert_contains "$out" "kendex check incomplete (exit 2)" "an error: inside a report line is still a completed report"
-assert_contains "$out" "error: cannot lock ref" "carries the fetch error the line quotes"
-assert_not_contains "$out" "could not run" "only an error: at the start of the output is the pre-check shape"
-
-echo "session-drift-check: failed before the check ran"
-capture FAKE_RC=2 FAKE_OUT=""
-assert_eq "$rc" 0 "exits 0 when the check fails saying nothing"
-assert_eq "$out" $'kendex check could not run (exit 2); drift status unknown\n' "exit 2 with no output is a failure to run, not an empty partial report"
-capture FAKE_RC=2 FAKE_OUT="Error: loading lock file"
-assert_eq "$rc" 0 "exits 0 when the check fails before reading anything"
-assert_contains "$out" "kendex check could not run (exit 2)" "an Error: line at exit 2 is a failure to run"
-assert_contains "$out" "Error: loading lock file" "carries kendex's own diagnostic"
-assert_not_contains "$out" "incomplete" "nothing checked is never called partial"
-capture FAKE_RC=2 FAKE_OUT=$'error: unexpected argument \'--bogus\' found\n\nUsage: kendex check --quiet'
-assert_contains "$out" "kendex check could not run (exit 2)" "a usage error: at exit 2 is a failure to run"
-assert_not_contains "$out" "incomplete" "a usage error is never called partial"
-
-echo "session-drift-check: check failed"
-capture FAKE_RC=3 FAKE_OUT="kendex: fatal"
-assert_eq "$rc" 0 "exits 0 when the check itself fails"
-assert_contains "$out" "kendex check could not run (exit 3)" "names the failure and exit code"
-assert_contains "$out" "kendex: fatal" "carries the failure's own output"
-# A signal or a timeout kills the check before it says anything. The
-# empty-output arm belongs to exit 2 alone, so this keeps the colon over a
-# blank line — the same text the embedded and Pi hooks print.
-capture FAKE_RC=3 FAKE_OUT=""
-assert_eq "$rc" 0 "exits 0 when the check dies saying nothing"
-assert_eq "$out" $'kendex check could not run (exit 3); drift status unknown:\n\n' \
-  "exit 3 with no output keeps the shape every rendering prints"
+# The empty-output arm belongs to exit 2 alone: a signal or a timeout kills
+# the check before it says anything, and the exit 3 row keeps the colon over
+# a blank line, the same text the embedded and Pi hooks print.
+run_table "the kendex check exit to stdout mapping" "\
+a clean install prints nothing|0|-|-
+drift found: the report verbatim|1|report|{out}\n
+not yet evaluated: the report verbatim, never as a failure|1|unevaluated|{out}\n
+could not check: incomplete, carrying the check's own diagnostic|2|could-not-check|kendex check incomplete (exit 2); some drift status unknown:\n{out}\n
+an error: inside a report line is still a completed report|2|error-inside-a-line|kendex check incomplete (exit 2); some drift status unknown:\n{out}\n
+exit 2 with no output is a failure to run, not an empty partial report|2|-|kendex check could not run (exit 2); drift status unknown\n
+an Error: line at exit 2 is a failure to run, carrying kendex's own diagnostic|2|Error-line|kendex check could not run (exit 2); drift status unknown:\n{out}\n
+a usage error: at exit 2 is a failure to run, never partial|2|usage-error|kendex check could not run (exit 2); drift status unknown:\n{out}\n
+exit 3 names the failure and exit code and carries the output|3|fatal|kendex check could not run (exit 3); drift status unknown:\n{out}\n
+exit 3 with no output keeps the shape every rendering prints|3|-|kendex check could not run (exit 3); drift status unknown:\n\n
+"
 
 echo "session-drift-check: unreadable stdin"
 # Strict mode must not let a failed payload read abort the session start.
@@ -307,5 +331,5 @@ assert_eq "$rc" 0 "exits 0 without a kendex binary"
 assert_eq "$out" "kendex drift check skipped: kendex is not on PATH" "says why it skipped without a kendex binary"
 
 echo
-echo "passed: $PASS  failed: $FAIL"
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes the `kendex check --quiet` exit-to-stdout mapping in `hooks/tests/session-drift-check.test.sh` (old lines 96–148, 26 assertions across `assert_eq`, `assert_contains` and `assert_not_contains`) to code-quality § Tests: one table of ten `label|fake rc|fake out|stdout` rows, `stdout` the hook's exact stdout with `\n` for a newline and `{out}` for the fake's mapped output, trailing newlines kept; every row's rendering is `rc=<hook exit> calls=<fake argv> out=<stdout>`, so the hook's exit 0, the `check --quiet` argv and the call count are pinned on each row. stdout is the session-start context channel, so exact text is the contract; the sixteen containment checks become ten equalities. Everything from old line 150 on is unchanged; the unused `assert_not_contains` helper is gone.

`hooks/tests/*` renders nowhere; `hooks/session-drift-check.sh` is unchanged and advisory.

## Assertion and disposition map

Every one of the 26 former assertions lands on a row (the implementer's line-by-line map is in the lane's scratchpad; the reviewer verified it and confirmed the kept region byte-identical apart from the tally line). The four `assert_not_contains` pins survive as consequences of exact equality, each measured to redden on its own arm. No row added, no named loss.

## Must-fail battery

`mutate-sdc.py` (in the lane's scratchpad; the record is `mutants.txt`): 24 of 24 killed, each exit arm of the mapping swapped or removed, each rendering line dropped, the passthrough dropped, the start-reason gate inverted and dropped, the PATH guard dropped, `--quiet` dropped. The reviewer added nine (rendering lines swapped in each arm, the trailing blank line dropped, the report doubled inside and outside the rendering, `--quiet` dropped on one call only, the check invoked twice, the check's exit returned): 33 of 33 killed, and the two rows the implementer reported without a sole killer each have one (an output carrying `kendex drift` read as clean; the incomplete arm demanding an `error:` token). Mechanism controls: a blank field exits 1 naming the row; an empty row list exits 2; a want shortened by one `\n` reddens its row; the probe aid renders then exits 2. All of that evidence stands unchanged: the implementer's 24 mutants, the reviewer's 33, and the two old-pass/new-fail controls behind the bot fixes, one for the escape encoding and one for the swallowed word-lookup status.

## Validation

`tools/guard --full` passed on this exact head, `c63a58ba271e8e7275a494c384718336eb214b28`: exit 0 with no `guard:` line, run once. It ran in this worktree alone: the run's own log records, before the guard started, the granted head, the external `TMPDIR` and the five Pi coding-agent, session, background-task and diagnostic-log paths, each pointing into a root the run created for itself, and it records that root's removal afterwards. Two further conditions come from the launch record rather than that log, which does not print them: the git redirect variables were read and cleared in the calling shell before the runner and its bindings, and Python bytecode writing was turned off there. The verdict was read from the run's own exit file and terminal line rather than from the launching shell.

## Reviewer round

reviewer-test on e80d0ee26: ACCEPT, no blocker (the first push rebased the commit onto main 8cf58920e as 41b730c79 and the second onto e588d7f82 as 191aad36a; the hooks/ diff is byte-identical each time, cmp). Green three times, under jq 1.7.1, under de_DE.UTF-8 and C, four concurrent runs; no git in the suite, so no redirect clearing is owed; `bash32-lint` clean. One suggestion declined: folding the row runner into the file's existing `capture` helper would drop eleven lines but read stdout through a parameter expansion where the row runner reads it from a file with a trailing-newline guard, the stricter form for an exact-text contract.

## Bot pass

Copilot and Codex, five threads, all resolved. Fixed in c63a58ba2: the one-line rendering wrote a real newline and the two characters backslash-n the same way, so a hook regressing to escape sequences matched every row; backslashes are now doubled before newlines are encoded (a hook printing backslash-n in its could-not-run rendering survives the previous head and reddens both exit-3 rows). Also fixed there: a fake-output word the mapper refuses exited only inside a command substitution, so a misspelled row silently tested the empty-output arm; the word is mapped once in the table loop, where a refusal ends the run with exit 1 (a misspelled row passes on the previous head and exits 1 on this one). Declined: the `-` empty marker aliasing a bare `-` output, a shape no hook arm produces (every rendering ends in a newline and would render as `-\n`), and the marker every merged table suite uses.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
