### PR TITLE
test(KEN-1241): the setup suite pins setup's own clauses

### DIFF
--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -8,6 +8,11 @@
 # runs first in every pair.
 set -euo pipefail
 
+# A suite running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which take precedence over `git -C` and
+# would point the fixtures' git at the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS="$(cd "$TEST_DIR/.." && pwd)"
 REPO="$(cd "$TOOLS/.." && pwd)"

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Pins what tools/setup arms: the commit-guards installer writes both shims,
-# nothing is spliced in beside them, and the clone then commits through the
-# armed hooks in both directions — one package verdict has to be reachable
-# from a real commit, or the chain is wired to nothing. The refusing direction
+# and the clone then commits through the armed hooks in both directions — one
+# package verdict has to be reachable from a real commit, or the chain is
+# wired to nothing. Every refusal is setup's own report (exit status, the
+# `hooks armed` line withheld, the remedy it names); what the installer says
+# about each hook is the installer's suite to pin. The refusing direction
 # runs first in every pair.
 set -euo pipefail
 
@@ -18,9 +20,11 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 
+# Fixture validity: the changelog refusal below is reachable only through a
+# path this repo obliges.
 [ -n "$REQUIRED_PATHS" ] \
-  && ok "kendex.settings.toml names the paths that oblige a changelog entry" \
-  || bad "kendex.settings.toml names the paths that oblige a changelog entry" "COMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS is empty"
+  && ok "precondition: COMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS is set" \
+  || bad "precondition: COMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS is set" "the value read from kendex.settings.toml is empty"
 
 new_fixture() { # NAME — a clone-shaped repo carrying the package and these tools
   R="$TMP/$1"
@@ -59,30 +63,17 @@ OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
 { [ -x "$HOOKS/commit-msg" ] && grep -qF "$SENTINEL" "$HOOKS/commit-msg"; } \
   && ok "commit-msg carries the installer's line and is executable" \
   || bad "commit-msg carries the installer's line and is executable" "$(cat "$HOOKS/commit-msg" 2>&1)"
-grep -qF "tools/commit-msg" "$HOOKS/commit-msg" \
-  && bad "no repo-local lane is spliced in beside it" "$(cat "$HOOKS/commit-msg")" \
-  || ok "no repo-local lane is spliced in beside it"
 
 echo "=== the chain runs at commit time, local lane last ==="
+# A lane spliced in beside the package's commit-msg line would die here on
+# `No such file or directory`, so this one passing commit is also the proof
+# that nothing was.
 git -C "$R" add -A
 RC=0
 OUT="$(git -C "$R" commit -m "chore: fixture" 2>&1)" || RC=$?
 [ "$RC" -eq 0 ] && case "$OUT" in *"repo-local lane ran"*) true ;; *) false ;; esac \
   && ok "the first commit passes and reaches tools/guard last" \
   || bad "the first commit passes and reaches tools/guard last" "rc=$RC out=$OUT"
-
-echo "=== the package judges the header ==="
-printf 'x\n' >>"$R/README.md"
-git -C "$R" add -A
-RC=0
-OUT="$(git -C "$R" commit -m "not conventional at all" 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"non-conventional header"*) true ;; *) false ;; esac \
-  && ok "a non-conventional subject is refused by the package's check" \
-  || bad "a non-conventional subject is refused by the package's check" "rc=$RC out=$OUT"
-RC=0
-OUT="$(git -C "$R" commit -m "docs: a conventional subject" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "a conventional subject passes" \
-  || bad "a conventional subject passes" "rc=$RC out=$OUT"
 
 echo "=== the installed hook still obliges the changelog this repo's paths ask for ==="
 # One arm, and it is here for the render, not for the rule. commit-msg.test.sh
@@ -97,11 +88,11 @@ OUT="$(git -C "$R" commit -m "feat: a crate change" 2>&1)" || RC=$?
   && ok "a crates/ change with no changelog entry is refused by the installed hook" \
   || bad "a crates/ change with no changelog entry is refused by the installed hook" "rc=$RC out=$OUT"
 
-echo "=== hooks the installer will not vouch for are each named ==="
-# It refuses an interpreter it cannot verify rather than rewriting somebody
-# else's hook. setup's remedy points back at that report rather than naming a
-# cause of its own, so the report has to name every hook in the way and why —
-# the first one it tripped over is not the whole answer.
+echo "=== hooks the installer will not vouch for stop setup short of armed ==="
+# The installer refuses an interpreter it cannot verify rather than rewriting
+# somebody else's hook, and names each hook it refused; that report is the
+# installer's to pin. setup's own report of that world is the exit status,
+# the `hooks armed` line withheld, and the remedy it names.
 new_fixture foreign
 for hook in pre-commit commit-msg; do
   printf '#!/usr/bin/env bash\necho "%s ran"\n' "$hook" >"$HOOKS/$hook"
@@ -109,17 +100,9 @@ for hook in pre-commit commit-msg; do
 done
 RC=0
 OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && ok "setup stops instead of reporting the clone armed" \
-  || bad "setup stops instead of reporting the clone armed" "rc=$RC out=$OUT"
-# Cause and remedy are asserted apart: the remedy prints for every refusal, so
-# matching it alone would pass on a message naming the wrong cause.
-for hook in pre-commit commit-msg; do
-  case "$OUT" in
-    *"hooks/$hook runs under an interpreter that cannot be verified"*)
-      ok "the report names $hook and why it was refused" ;;
-    *) bad "the report names $hook and why it was refused" "out=$OUT" ;;
-  esac
-done
+[ "$RC" -ne 0 ] && case "$OUT" in *"hooks armed"*) false ;; *"--uninstall"*) true ;; *) false ;; esac \
+  && ok "setup stops with its remedy instead of reporting the clone armed" \
+  || bad "setup stops with its remedy instead of reporting the clone armed" "rc=$RC out=$OUT"
 
 echo "=== following the printed remedy through arms the clone ==="
 # The remedy is keyed on what a hook still HOLDS, not on who wrote it, and
@@ -191,7 +174,7 @@ git -C "$E" init -q
 git -C "$E" config core.hooksPath "$E/other-hooks"
 RC=0
 OUT="$(cd "$E" && ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"not armed"*) true ;; *) false ;; esac \
+[ "$RC" -ne 0 ] && case "$OUT" in *"hooks armed"*) false ;; *"not armed"*) true ;; *) false ;; esac \
   && ok "a configured hooks path stops setup instead of wiring a hook git ignores" \
   || bad "a configured hooks path stops setup instead of wiring a hook git ignores" "rc=$RC out=$OUT"
 [ ! -e "$E/.git/hooks/pre-commit" ] && [ ! -e "$E/.git/hooks/commit-msg" ] \


### PR DESCRIPTION
Trims `tools/tests/setup.test.sh` (214 lines, 23 assertions over six clone-shaped worlds) to setup's own claims per code-quality § Tests: the file stays scenario-shaped by necessity, each world a distinct hook state the next step mutates in place, so no table is owed. What goes: the twinned package verdicts (a non-conventional header refused by the commit-guards message gate and its conventional-pass partner, subsumed by the first fixture commit through the same armed hook; the changelog refusal stays as the proof the commit-msg hook is wired), the per-hook "runs under an interpreter that cannot be verified" pin (the installer's report, which setup has no observable for), and the `tools/commit-msg` text pin on the generated hook (the first-commit row already dies if a lane were spliced in). What tightens: the foreign-world row asserts `hooks armed` absent beside a nonzero exit and the `--uninstall` remedy value, and the hooks-path row asserts `hooks armed` absent beside a nonzero exit and the `not armed` clause; that absence is the correction a mutant printing `hooks armed` before the installers ran measured (it survives the old suite, 23/0, and is killed on the new one). The settings read is labelled `precondition:` above the fixture. The suite clears the four git redirect variables after the preamble, as its siblings do (second commit).

`tools/tests/*` renders nowhere; `tools/setup` is unchanged.

## Assertion and disposition map

The implementer's old-line map is in the lane's scratchpad; the reviewer verified it against the old file with no unnamed loss. Named losses: the header refusal and the conventional pass (package verdicts), the two per-hook installer clauses, the generated-file text pin. Every other assertion is unchanged, including the must-fail controls at the remedy walk (step one alone does not clear the refusal; deleting pre-commit alone is not enough; no shim written where git reads elsewhere; not `hooks armed` outside a work tree). No row added. Named gap, no assertion owed: a setup that never enters the repository root passes every world (no world runs it from a subdirectory).

## Must-fail battery

`mutate-setup.py` (in the lane's scratchpad; the record is `mutants.txt`): new suite 7 of 8 killed (the `not armed` message dropped, `hooks armed` printed early, the not-a-work-tree refusal exiting 0, `--uninstall` dropped from the remedy, an installer call dropped, the `--check` call dropped, `not_armed` exiting 0), the old suite 6 of 8 against the same mutants. The reviewer ran thirteen (12/13 on the new suite, 10/13 on the old): the early `hooks armed` mutant and its in-`not_armed` variant survive the old suite and are killed by the new absence pins. Both records stand unchanged: the implementer's 7 of 8, with m08, a setup that never enters the repository root, recorded as a named gap no old assertion covered, and the git-environment control that fails on the trim head and passes on the corrected one.

## Validation

`tools/guard --full` passed on this exact head, `ff0a33855682e2b0fa99f3763b9b9946c42bdd59`: exit 0 with no `guard:` line, run once, in this worktree alone. Two kinds of evidence back that, kept apart. From the run's own log, written before the guard started: the granted head, the external `TMPDIR`, and the five Pi coding-agent, session, background-task and diagnostic-log paths, each pointing into a root the run created for itself, with that root's removal recorded afterwards. From the launch record, which the log does not print: all six git redirect variables read and cleared in the calling shell before the runner and its bindings, the two the runner itself does not clear included, and Python bytecode writing turned off there. The verdict was read from the run's own exit file and terminal line rather than from the launching shell, and the worktree, its source and its file modes were unchanged afterwards.

## Reviewer round

reviewer-test on d76e5bb26: ACCEPT, no blocker (the push rebased both commits onto main e588d7f82 as d2e0378d8 and ff0a33855; the tools/ diff is byte-identical, cmp). Every loss confirmed as another package's clause or a generated-file pin; nothing setup emits was dropped; the conventional-pass subsumption measured; the precondition placed above the fixture; green three times, under de_DE.UTF-8, `shellcheck -S warning` clean. Two suggestions: the git-redirect clearing, applied as the second commit (the reviewer measured the old file and the trim head both failing under the four redirects exported at a private scratch repository, 7 and 5 reds, and committing into it; the lane's receipt `controls-setup-gitenv.txt` shows the trim head d2e0378d8 exiting 1 with the setup, pre-commit and commit-msg rows red and the corrected head ff0a33855 passing 18/18 under the same exported redirects with the scratch repository's porcelain unchanged), and an old unchecked setup run in the remedy world that fails closed and is left as is.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
