### PR TITLE
test(KEN-1241): pin the reviewer hook suites on values, not sentences

### DIFF
--- a/hooks/tests/reviewer-read-only.test.sh
+++ b/hooks/tests/reviewer-read-only.test.sh
@@ -41,23 +41,14 @@ fgit -C "$REPO" commit -q -m init
 SCRATCH="$TMP_ROOT/scratch"
 mkdir -p "$SCRATCH"
 
-# A JSON string, escaped the way the harness sends it.
-json_str() {
-  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
-}
-
 # run AGENT_TYPE TOOL FIELD VALUE -> rc, stderr in $err. An empty AGENT_TYPE
-# omits the field, as the main session's payload does.
+# omits the field, as the main session's payload does. jq encodes the value
+# the way the harness does, so a path or command holding a quote, a
+# backslash or a newline reaches the hook as JSON.
 run_tool() {
-  local agent="$1" tool="$2" field="$3" value="$4" payload
-  if [ -n "$agent" ]; then
-    payload=$(printf '{"agent_type":"%s","tool_name":"%s","tool_input":{"%s":"%s"}}' \
-      "$agent" "$tool" "$field" "$(json_str "$value")")
-  else
-    payload=$(printf '{"tool_name":"%s","tool_input":{"%s":"%s"}}' \
-      "$tool" "$field" "$(json_str "$value")")
-  fi
-  run_payload "$payload"
+  local agent="$1" tool="$2" field="$3" value="$4"
+  run_payload "$(jq -nc --arg a "$agent" --arg t "$tool" --arg f "$field" --arg v "$value" \
+    '(if $a == "" then {} else {agent_type: $a} end) + {tool_name: $t, tool_input: {($f): $v}}')"
 }
 
 run_payload() { # raw-json [PATH] -> rc, stderr in $err
@@ -95,17 +86,6 @@ assert_contains() {
   fi
 }
 
-assert_not_contains() {
-  local got="$1" needle="$2" name="$3"
-  if [[ "$got" != *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected not to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
-  fi
-}
-
 ARTIFACT="$REPO/tmp/review-reviewer-test-20260903-101010.json"
 
 echo "reviewer-read-only: agents that are not reviewers pass"
@@ -126,9 +106,7 @@ for tool in Edit MultiEdit NotebookEdit; do
   assert_eq "$rc" 2 "a reviewer's $tool is refused"
 done
 run_tool reviewer-correctness Edit file_path "$REPO/src/lib.rs"
-assert_contains "$err" "a reviewer edits nothing" "the refusal names the rule"
 assert_contains "$err" "tmp/review-reviewer-correctness-" "the refusal names the one path a reviewer writes"
-assert_not_contains "$err" "bypass" "never suggests bypassing"
 run_tool reviewer-correctness Edit file_path "$SCRATCH/note.txt"
 assert_eq "$rc" 2 "an Edit outside any repository is refused too: a reviewer never edits"
 
@@ -168,8 +146,6 @@ for cmd in 'git commit -m x' 'git push' 'git push origin HEAD' "git -C $REPO com
   run_tool reviewer-security Bash command "$cmd"
   assert_eq "$rc" 2 "refused: $cmd"
 done
-run_tool reviewer-security Bash command 'git commit -m x'
-assert_contains "$err" "commits and pushes nothing" "the refusal names the rule"
 for cmd in 'git log --oneline -5' "git -C $REPO diff origin/main...HEAD" 'git cat-file commit HEAD' \
   'git commit-tree HEAD^{tree}' 'git status --porcelain' 'git show HEAD --stat' 'git log --grep=commit' \
   'echo committed' 'grep -rn "git push" docs/' 'git rev-list --count HEAD' 'git worktree list'; do

--- a/hooks/tests/reviewer-read-only.test.sh
+++ b/hooks/tests/reviewer-read-only.test.sh
@@ -17,6 +17,11 @@
 # assertions.
 set -euo pipefail
 
+# A suite running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which take precedence over `git -C` and
+# would point the fixtures' git at the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/reviewer-read-only.sh}"
 

--- a/hooks/tests/reviewer-stop-check.test.sh
+++ b/hooks/tests/reviewer-stop-check.test.sh
@@ -18,6 +18,11 @@
 # assertions.
 set -euo pipefail
 
+# A suite running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which take precedence over `git -C` and
+# would point the fixtures' git at the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/reviewer-stop-check.sh}"
 

--- a/hooks/tests/reviewer-stop-check.test.sh
+++ b/hooks/tests/reviewer-stop-check.test.sh
@@ -146,9 +146,6 @@ run_hook "$T" reviewer-test a1
 assert_eq "$rc" 2 "blocks on an untracked file"
 assert_contains "$err" "?? probe.sh" "names the untracked file"
 assert_contains "$err" "$REPO" "names the reviewed worktree"
-assert_contains "$err" "Delete every file you created" "says what to do"
-assert_contains "$err" "report any change that was there before you" "and what not to do"
-assert_not_contains "$err" "bypass" "never suggests bypassing"
 [ -e "$REPO/.git/kendex/reviewer-stop/a1" ] && marker=yes || marker=no
 assert_eq "$marker" yes "the block records the agent under the reviewed repository's git common dir"
 run_hook "$T" reviewer-test a1


### PR DESCRIPTION
Cuts the two reviewer-gate suites, `hooks/tests/reviewer-read-only.test.sh` and `hooks/tests/reviewer-stop-check.test.sh`, to value pins per code-quality § Tests; both are at the bar in shape. Gone: `a reviewer edits nothing`, `commits and pushes nothing` (with its feeding run), `Delete every file you created`, `report any change that was there before you`, and the two `bypass` negative scans, each the wording of a rule or remedy sentence no consumer parses. Kept verbatim: the artifact path value, the refused path, `mktemp -d`, the git stderr passthrough, every arm clause, every porcelain line, the marker checks, `names no review artifact path`, both `rev-parse … failed` clauses, every exit row. The sed-built JSON helper in read-only becomes the `jq -nc --arg` builder its siblings use (every payload the rows use measured byte-identical between the two builders; an empty agent still omits `agent_type`). The Write-pair fold the classification suggested was measured at no line saving and skipped. Both suites clear the four git redirect variables after the preamble (second commit): their fixture git calls override HOME but not the redirects, so the measured run with Git redirects exported at a private repository wrote into the inherited index.

`hooks/tests/*` renders nowhere; both hooks are unchanged.

## Assertion and disposition map

Six named losses, listed above, each measured as wording alone: rewording mutants were killed on the old suites only by the cut pins and survive the new ones. Every other assertion is kept with its name. No row added. Named gap, no assertion owed: the regex head of read-only's git-write rule reduced to `git(` survives both suites (fail-closed on `mygit commit`, input no producer emits).

## Must-fail battery

`mutate-revhooks.py` (in the lane's scratchpad; the record is `mutants.txt`), every mutant run against the new and the old suite: read-only 19 of 20 killed on both with the same behaviour-control verdicts (the agent gate inverted, a refused tool allowed, the artifact exemption widened, the inside-work-tree check dropped, each regex arm, the git-failure pass, the ancestor walk, the payload edges, the kept value pins); stop-check 20 of 20 on both with the same behaviour-control verdicts (the agent gate, the `stop_hook_active` gate, the no-artifact transcript, oldest-mention-wins, the dirt check, untracked directories collapsed, the marker never written or never read, git-dir versus common-dir, the three git-failure arms, the payload edges, the kept value pins). The reviewer added six behaviour mutants and three wording mutants per hook with the same result.

## Validation

`tools/guard --full` passed on this exact head, `ba40a9020a606c50d02b80905f274270b7c0bed4`: exit 0 with no `guard:` line, run once, in these two suites' worktree alone. Two kinds of evidence back that, kept apart. From the run's own log, written before the guard started: the granted head, the external `TMPDIR`, and the five Pi coding-agent, session, background-task and diagnostic-log paths, each pointing into a root the run created for itself, with that root's removal recorded afterwards. From the launch record, which the log does not print: all six git redirect variables read and cleared in the calling shell before the runner and its bindings, the two the runner itself does not clear included, and Python bytecode writing turned off there. The verdict was read from the run's own exit file and terminal line rather than from the launching shell, and the worktree, its source and its file modes were unchanged afterwards.

## Reviewer round

reviewer-test on 91d7b05: ACCEPT, no blocker (the push rebased both commits onto main e588d7f82 as 2947574f6 and ba40a9020; the hooks/ diff is byte-identical, cmp). Both builders diffed over all 38 row tuples; the wording mutants confirmed killed on old only by the cut pins; the fold re-measured at +0 and the decision upheld; green three times each, under jq 1.7.1 and de_DE.UTF-8; `bash32-lint` clean. Suggestions: the redirect clearing, applied as the second commit (the reviewer measured the old file and the trim head both writing into an inherited index under the four redirects exported at a scratch repository; the lane's receipt `controls-revhooks-gitenv.txt` shows the trim head 2947574f6 exiting 1 for both suites and the corrected head ba40a9020 passing 55/55 and 48/48 under the same exported redirects with the scratch repository's porcelain unchanged), and two refusal values no row has ever pinned, not owed.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
