### PR TITLE
test(KEN-1241): vendored-settings-libs derives its expected set

### DIFF
--- a/tools/tests/vendored-settings-libs.test.sh
+++ b/tools/tests/vendored-settings-libs.test.sh
@@ -9,11 +9,12 @@ compare_copies() { # ROOT
   local root="$1" source render canonical="$1/skills/orch/scripts/lib/kendex-env.sh" has_canonical=0
   local -a sources=("$root"/skills/*/scripts/lib/kendex-env.sh)
   # The expected set is the glob's own, never a count kept here: a skill
-  # vendoring the lib joins the scan by existing. Under-inclusion is closed by
-  # the floor (an unmatched glob is its own pattern, one entry) and by the one
-  # required member, the copy every other is compared against; either failing
-  # is a broken scan, not a sparse tree. Over-inclusion stays open: an extra
-  # match is compared like the rest.
+  # vendoring the lib joins the scan by existing. The floor (an unmatched glob
+  # is its own pattern, one entry) and the one required member, the copy every
+  # other is compared against, close a broken extractor only; either failing
+  # is a broken scan, not a sparse tree. Two directions stay open: a copy
+  # deleted from the tree leaves the scan green, and an extra match is
+  # compared like the rest.
   for source in "${sources[@]}"; do
     [[ $source != "$canonical" ]] || has_canonical=1
   done

--- a/tools/tests/vendored-settings-libs.test.sh
+++ b/tools/tests/vendored-settings-libs.test.sh
@@ -51,4 +51,36 @@ if compare_copies "$SCRATCH" >/dev/null 2>&1; then
   echo "vendored-settings-libs: planted divergence passed" >&2
   exit 1
 fi
+# Each extractor guard has its own plant, asserting the diagnosis only that
+# guard prints: on these worlds the comparison against a missing canonical
+# would red as well, so the verdict alone would not prove the guard.
+mkdir -p "$SCRATCH/unmatched/skills/none"
+if diag="$(compare_copies "$SCRATCH/unmatched" 2>&1)" || [[ $diag != *"matched 1 entry: the glob is broken"* ]]; then
+  echo "vendored-settings-libs: an unmatched glob was not named as broken: $diag" >&2
+  exit 1
+fi
+mkdir -p "$SCRATCH/no-orch"
+cp -R "$SCRATCH/skills" "$SCRATCH/.agents" "$SCRATCH/no-orch/"
+rm -f "$SCRATCH/no-orch/skills/orch/scripts/lib/kendex-env.sh" "$SCRATCH/no-orch/.agents/skills/orch/scripts/lib/kendex-env.sh"
+if diag="$(compare_copies "$SCRATCH/no-orch" 2>&1)" || [[ $diag != *"missed skills/orch/scripts/lib/kendex-env.sh: the glob is broken"* ]]; then
+  echo "vendored-settings-libs: a missing canonical copy was not named as broken: $diag" >&2
+  exit 1
+fi
+# The derived set is what this scan buys over a kept count: an eighth skill
+# vendoring the lib joins by existing. The plant plays that skill, and a scan
+# restricted to the seven present today reds here.
+mkdir -p "$SCRATCH/eighth"
+for source in "$ROOT"/skills/*/scripts/lib/kendex-env.sh; do
+  rel="${source#"$ROOT/"}"
+  mkdir -p "$SCRATCH/eighth/${rel%/*}" "$SCRATCH/eighth/.agents/${rel%/*}"
+  cp "$source" "$SCRATCH/eighth/$rel"
+  cp "$ROOT/.agents/$rel" "$SCRATCH/eighth/.agents/$rel"
+done
+mkdir -p "$SCRATCH/eighth/skills/newcomer/scripts/lib" "$SCRATCH/eighth/.agents/skills/newcomer/scripts/lib"
+cp "$ROOT/skills/orch/scripts/lib/kendex-env.sh" "$SCRATCH/eighth/skills/newcomer/scripts/lib/kendex-env.sh"
+cp "$ROOT/skills/orch/scripts/lib/kendex-env.sh" "$SCRATCH/eighth/.agents/skills/newcomer/scripts/lib/kendex-env.sh"
+if ! diag="$(compare_copies "$SCRATCH/eighth" 2>&1)"; then
+  echo "vendored-settings-libs: a skill vendoring an eighth copy was refused: $diag" >&2
+  exit 1
+fi
 echo "vendored-settings-libs: every copy and its render match"

--- a/tools/tests/vendored-settings-libs.test.sh
+++ b/tools/tests/vendored-settings-libs.test.sh
@@ -6,9 +6,26 @@ SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
 compare_copies() { # ROOT
-  local root="$1" source render canonical="$1/skills/orch/scripts/lib/kendex-env.sh" count=0
-  for source in "$root"/skills/*/scripts/lib/kendex-env.sh; do
-    count=$((count + 1))
+  local root="$1" source render canonical="$1/skills/orch/scripts/lib/kendex-env.sh" has_canonical=0
+  local -a sources=("$root"/skills/*/scripts/lib/kendex-env.sh)
+  # The expected set is the glob's own, never a count kept here: a skill
+  # vendoring the lib joins the scan by existing. Under-inclusion is closed by
+  # the floor (an unmatched glob is its own pattern, one entry) and by the one
+  # required member, the copy every other is compared against; either failing
+  # is a broken scan, not a sparse tree. Over-inclusion stays open: an extra
+  # match is compared like the rest.
+  for source in "${sources[@]}"; do
+    [[ $source != "$canonical" ]] || has_canonical=1
+  done
+  [[ ${#sources[@]} -ge 2 ]] || {
+    echo "skills/*/scripts/lib/kendex-env.sh matched ${#sources[@]} entry: the glob is broken" >&2
+    return 1
+  }
+  [[ $has_canonical -eq 1 ]] || {
+    echo "skills/*/scripts/lib/kendex-env.sh missed skills/orch/scripts/lib/kendex-env.sh: the glob is broken" >&2
+    return 1
+  }
+  for source in "${sources[@]}"; do
     cmp -s "$canonical" "$source" || {
       echo "${source#"$root/"} differs from skills/orch/scripts/lib/kendex-env.sh" >&2
       return 1
@@ -19,7 +36,6 @@ compare_copies() { # ROOT
       return 1
     }
   done
-  [[ $count -eq 7 ]] || { echo "expected seven kendex-env.sh copies, found $count" >&2; return 1; }
 }
 
 compare_copies "$ROOT"
@@ -34,4 +50,4 @@ if compare_copies "$SCRATCH" >/dev/null 2>&1; then
   echo "vendored-settings-libs: planted divergence passed" >&2
   exit 1
 fi
-echo "vendored-settings-libs: seven copies and renders match"
+echo "vendored-settings-libs: every copy and its render match"


### PR DESCRIPTION
Corrects the expected set in `tools/tests/vendored-settings-libs.test.sh` per code-quality § Prove Your Guards: the hand-kept `[[ $count -eq 7 ]]`, a second list that reddened on any eighth skill vendoring the lib with no defect, becomes a `sources` array derived from the glob the loop scans, with a floor (`-ge 2`, since an unmatched glob is its own single entry) and orch's own copy as a required member, both diagnostics naming the glob as broken rather than the tree as sparse. The planted-divergence control is unchanged, and the pass line drops its numeral. The second commit rewords the comment after the reviewer measured what the floor and member close: a broken extractor only; a copy deleted from the tree leaves the scan green, as an extra match does, and the comment now says so.

`tools/tests/*` renders nowhere; no vendored copy changes.

## Assertion and disposition map

Every copy identical to orch's and every render matching its source: unchanged, over the derived array. The hand-kept count: replaced by the floor plus the required member. Named open direction: a copy deleted from the tree (main's count caught it; nothing else under `tools/` covers an orphaned render). Recorded and not built: a derived set from the `source … kendex-env.sh` lines the skills' scripts carry would restore that claim without a numeral.

## Must-fail battery

`impl-controls/vendored-libs/mutants.txt` in the lane's scratchpad: the glob matching nothing and orch's copy missing each reddened with the new diagnosis before any comparison; the reviewer confirmed the two guards own the diagnosis, never the verdict (with either removed the pre-existing comparison still reddens those worlds), and measured the deleted-copy worlds green on this head and red on main's count.

## Bot pass

Copilot and Codex, two threads, both resolved and both the same class: the change's three new claims had no committed world. Fixed in a87487b49 with three plants in the suite's own scratch tree, each asserting the diagnosis only its guard prints: an unmatched glob (`matched 1 entry: the glob is broken`), a tree without the canonical copy (`missed skills/orch/...: the glob is broken`), and a skill vendoring an eighth copy with its render, which the scan must accept. Controls in `controls-vl-2.txt`: both guards removed, the floor alone removed and the member alone removed each redden the plant that guard owns; a seven-copy ceiling reddens exactly the eighth-copy plant, and a reinstated `-eq 7` reddens too.

## Reviewer round

reviewer-test on 0c8aae123: ACCEPT WITH FIXES, the comment fix applied in the second commit (the pushes rebased the branch onto the moving main; the reviewed and comment commits are 01af55958 and cb6025cbe on this head, and the tools/ diff was byte-identical at each rebase, cmp). One list confirmed (the fixture builder's re-glob builds the scratch tree, not the expected set); green three times and under de_DE.UTF-8; `shellcheck -x` clean; `bash32-lint` reports only the pre-existing hit.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
