### PR TITLE
test(KEN-1241): verify live process identity transitions

### DIFF
--- a/pi-extensions/pi-background-tasks/tests/fixtures/identity-child.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/identity-child.ts
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+// Both shells use builtins until exec. The child never creates descendants.
+const script = `
+printf 'bash-ready\\n'
+IFS= read -r release || exit 64
+case "$release" in
+  exec) exec /bin/sh -c 'printf "exec-ready\\n"; IFS= read -r release; test "$release" = exit' ;;
+  exit) exit 0 ;;
+  *) exit 64 ;;
+esac
+`;
+
+async function beforeDeadline<T>(operation: Promise<T>, label: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(`identity child did not report ${label}`)), 3_000);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** Owns a shell that waits for an explicit exec or exit release. */
+export function identityChild() {
+	const child = spawn("/bin/bash", ["--noprofile", "--norc", "-c", script], {
+		stdio: ["pipe", "pipe", "pipe"],
+		env: { PATH: "/usr/bin:/bin", LC_ALL: "C" },
+	});
+	let spawnError: Error | undefined;
+	child.on("error", (error) => { spawnError = error; });
+	child.stdin.on("error", (error) => { spawnError = error; });
+	const completed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+		child.once("close", (code, signal) => resolve({ code, signal }));
+	});
+	const reader = createInterface({ input: child.stdout });
+	const lines = reader[Symbol.asyncIterator]();
+	return {
+		child,
+		async ready(expected: string) {
+			const line = await beforeDeadline(Promise.race([
+				lines.next(),
+				completed.then(({ code, signal }) => {
+					throw spawnError ?? new Error(`identity child closed before ${expected}: ${code ?? signal}`);
+				}),
+			]), expected);
+			if (line.done || line.value !== expected) {
+				throw spawnError ?? new Error(`identity child expected ${expected}, received ${line.value ?? "EOF"}`);
+			}
+		},
+		async exited() {
+			const { code, signal } = await beforeDeadline(completed, "exit");
+			if (spawnError) throw spawnError;
+			if (code !== 0 || signal !== null) throw new Error(`identity child exit failed: ${code ?? signal}`);
+		},
+		async dispose() {
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			await completed;
+			reader.close();
+			child.stdin.destroy();
+			child.stdout.destroy();
+			child.stderr.destroy();
+			if (spawnError) throw spawnError;
+		},
+	};
+}

--- a/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
@@ -1,105 +1,44 @@
-// Live integration test for defaultReadProcessIdentity.
-//
-// Spawn `/bin/bash -c "exec sleep 5"`: bash execve(2)s the sleep binary
-// in place with no fork, so pid + starttime stay identical across the
-// exec while the process image changes underneath them. The identity
-// check MUST treat before and after as the same process — otherwise the
-// orphan watcher false-finalizes a live task on every restore.
-//
-// Enforced on Linux only. There, a null from the probe against a pid
-// still present in /proc is a defect in the reader this suite gates, and
-// the case throws. Elsewhere a null logs a skip line and returns: the
-// portable `ps -o lstart=,comm= -p <pid>` path returns null for reader
-// defects too, and nothing here separates those from a host that cannot
-// probe at all, so this suite makes no promise off Linux.
-
-import { afterAll, describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
 import { defaultReadProcessIdentity, identityMatches } from "../extensions/snapshot.js";
+import { identityChild } from "./fixtures/identity-child.js";
 
-const children: number[] = [];
-afterAll(() => {
-	for (const pid of children) {
-		try { process.kill(pid, "SIGKILL"); } catch { /* */ }
-	}
-});
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((res) => setTimeout(res, ms));
-}
-
-describe("defaultReadProcessIdentity live (bash exec drift)", () => {
-	test("bash -c 'exec sleep N': pid + startToken stable across the exec, identityMatches stays true whether or not comm rotated", async () => {
-		// `exec sleep N` replaces the bash process image in place
-		// (execve(2) with no fork), so the kernel reports the same pid
-		// and start time but a different /proc/<pid>/comm. identityMatches must
-		// not treat this post-exec state as PID reuse.
-		const child = spawn("/bin/bash", ["-c", "exec sleep 5"], { stdio: "ignore", detached: true });
-		const pid = child.pid;
-		if (typeof pid !== "number" || pid <= 0) {
-			throw new Error("could not spawn bash");
-		}
-		children.push(pid);
-
-		const spawnIdentity = defaultReadProcessIdentity(pid);
-		if (spawnIdentity === null) {
-			// A null is "the probe failed", not "this host cannot probe":
-			// defaultReadProcessIdentity also returns null on a malformed
-			// /proc/<pid>/stat, an absent starttime field, or a non-zero `ps`
-			// exit, which indicates a defect in the reader. On
-			// Linux with the process still in /proc, the probe path is there,
-			// so a null is that defect and must fail rather than pass quietly.
-			if (process.platform === "linux" && existsSync(`/proc/${pid}`)) {
-				throw new Error(
-					`defaultReadProcessIdentity returned null for live pid ${pid} with /proc/${pid} present — the probe is broken, not the host`,
-				);
+describe.skipIf(process.platform !== "linux")("Linux process identity across exec and exit", () => {
+	test("observes each owned process transition", async () => {
+		const rows = [
+			{ name: "exec changes the executable but retains the process identity", release: "exec", matches: true },
+			{ name: "reaped process no longer matches its recorded identity", release: "exit", matches: false },
+		] as const;
+		expect.assertions(rows.length + 1);
+		expect(rows.length, "process identity table must contain cases").toBeGreaterThan(0);
+		for (const row of rows) {
+			const owned = identityChild();
+			try {
+				await owned.ready("bash-ready");
+				const pid = owned.child.pid;
+				if (pid === undefined) throw new Error(`${row.name}: Bash has no process ID`);
+				const initial = defaultReadProcessIdentity(pid);
+				if (initial === null) throw new Error(`${row.name}: initial live identity is null`);
+				owned.child.stdin.write(`${row.release}\n`);
+				if (row.release === "exec") await owned.ready("exec-ready");
+				else await owned.exited();
+				const current = defaultReadProcessIdentity(pid);
+				if (row.release === "exec" && current === null) {
+					throw new Error(`${row.name}: post-exec live identity is null`);
+				}
+				expect({ initial, current, matches: identityMatches(initial, current) }, row.name).toStrictEqual({
+					initial: { pid, startToken: expect.stringMatching(/^\d+$/), comm: "bash" },
+					current: row.release === "exec"
+						? { pid, startToken: initial.startToken, comm: "sh" }
+						: current === null ? null : expect.not.objectContaining({ startToken: initial.startToken }),
+					matches: row.matches,
+				});
+				if (row.release === "exec") {
+					owned.child.stdin.write("exit\n");
+					await owned.exited();
+				}
+			} finally {
+				await owned.dispose();
 			}
-			// No /proc and no working `ps`: nothing to observe. Say so, so a
-			// suite that has stopped exercising the reproducer is visible in
-			// the log instead of reading like a run that proved the fix.
-			console.log(`skip: no process-identity probe on ${process.platform} — the exec-drift reproducer did not run`);
-			return;
 		}
-
-		// Give bash time to call execve. On Linux this typically
-		// takes <10ms; 250ms is generous.
-		await sleep(250);
-
-		const drifted = defaultReadProcessIdentity(pid);
-		expect(drifted).not.toBeNull();
-		// pid + startToken MUST stay identical across the exec.
-		expect(drifted?.pid).toBe(spawnIdentity.pid);
-		expect(drifted?.startToken).toBe(spawnIdentity.startToken);
-		// identityMatches MUST treat them as the same process, even if
-		// comm rotated bash -> sleep. comm is diagnostic-only.
-		expect(identityMatches(spawnIdentity, drifted)).toBe(true);
-		// comm may or may not have rotated by the time of the second
-		// read — the kernel does not promise when. Either way the
-		// identity check above is what gates the bug, so nothing here
-		// depends on observing the rotation.
-	});
-
-	test("identityMatches is false after the process actually exits", async () => {
-		const child = spawn("/bin/true", [], { stdio: "ignore" });
-		const pid = child.pid;
-		if (typeof pid !== "number" || pid <= 0) throw new Error("could not spawn /bin/true");
-		// Capture identity before /bin/true reaps.
-		const ident = defaultReadProcessIdentity(pid);
-		// Wait for the child to be reaped. /bin/true exits immediately.
-		await new Promise<void>((res) => child.on("exit", () => res()));
-		await sleep(50);
-		const dead = defaultReadProcessIdentity(pid);
-		// After exit + reap, identity reads as null (or the pid is
-		// reused; either way identityMatches against the original
-		// must NOT return true with a null current).
-		if (dead === null) {
-			expect(identityMatches(ident ?? undefined, null)).toBe(false);
-		} else {
-			// Unlikely but possible: a different process raced into
-			// this pid by the time we re-read. The kernel-stable
-			// startToken still differs from the original.
-			expect(dead.startToken).not.toBe(ident?.startToken ?? "missing");
-		}
-	});
+	}, 15_000);
 });


### PR DESCRIPTION
The process-identity test could miss an executable change or read a child only after it had exited. It now waits for explicit child readiness before each live identity read and observes child completion before the exit check.

- Check the executable change, stable process ID and start token, and refusal after exit in named rows.
- Compare the generated observation exactly. Retain the existing start-token comparison for a reused process ID.
- Own child handles and await cleanup after each row, including assertion failures and missing readiness.
- Declare Linux support and detect empty tables, omitted row assertions, and empty registration.

This change covers the identity test and its private child fixture. Production behavior is unchanged. Part of KEN-1241; the wider audit remains open.

## Validation

- Clean compiled test: 1 pass and 3 assertions.
- All 15 compiled controls failed with the intended diagnostics. The clean baseline was reused.
- Owned child cleanup passed for every control invocation.
- The single reviewer-test round passed on 1da723c573fb2dec013d9f2b9ba848df353c944f with no findings. It reused the completed control evidence.
- The required full guard passed at the same head with external temporary roots and private Pi/task/diagnostic directories. The coordinator reported that another lane's small #2420 correction controls overlapped the run despite its hold; this passing result does not claim complete battery exclusivity. The bot pass remains pending.

## Size

- Added lines: 0 production, 111 test, 0 render mirror. KEN-1241 states no size allowance.
