### PR TITLE
test(KEN-1241): require compaction stop-reason assertions

### DIFF
--- a/pi-extensions/pi-qol/tests/compaction-length-stop.test.ts
+++ b/pi-extensions/pi-qol/tests/compaction-length-stop.test.ts
@@ -62,8 +62,11 @@ const rows: Array<{ stopReason: string; accepted: boolean }> = [
 	{ accepted: true, stopReason: "stop" },
 ];
 
+if (rows.length === 0) throw new Error("Compaction stop-reason table is empty");
+
 for (const row of rows) {
 	test(`generateQolSummary ${row.accepted ? "accepts" : "rejects"} a summary with stopReason ${row.stopReason}`, async () => {
+		expect.hasAssertions();
 		stubComplete(row.stopReason);
 		const run = generateQolSummary(makeCtx(), { conversationText: "user: hello", purpose: "compaction" });
 		if (row.accepted) {


### PR DESCRIPTION
The compaction stop-reason suite now rejects an empty table or a row that executes without an assertion.

The existing accepted-summary and token-cap rejection assertions remain unchanged.

Only Pi QoL test files change. These tests have no tracked renders and are excluded from the published npm package.

Part of KEN-1241. The remaining audit stays open.

## Validation

- Stop-reason proof: 2 tests pass. Root's combined proof passes 3 cases, including the retained model-resolution case. Pi QoL package: 115 tests pass.
- Saved specialist reviewer-test round: pass with no findings.
- Copied controls compile and fail at their required diagnostics. Empty-table controls apply to each table; no-op controls check the result assertions.
- Preflight, document limits and Pi package policy pass.
- Required full guard passed at c811854d5ca221386ca8ea80bbadbecd1fac7880 with external temporary storage, cleared Git redirects and private Pi/task/diagnostic roots.

## Size

The branch adds 0 production lines, 3 test lines and 0 render-mirror lines. KEN-1241 states no line allowance.
