### PR TITLE
test(KEN-1241): separate provider-header refusal cases

### DIFF
--- a/pi-extensions/pi-qol/tests/provider-headers.test.ts
+++ b/pi-extensions/pi-qol/tests/provider-headers.test.ts
@@ -3,16 +3,20 @@ import { headerRecord } from "../extensions/qol/session-rename.ts";
 
 // Pi resolves provider headers as `ProviderHeaders` (`Record<string, string | null>`).
 // `null` is a header-deletion marker pi-ai acts on, so forwarding must not drop it.
-test("headerRecord preserves null header-deletion markers", () => {
-	expect(headerRecord({ "x-keep": "value", "x-delete": null })).toEqual({ "x-keep": "value", "x-delete": null });
-});
+const headerRows = [
+	{ name: "null deletion marker", input: { "x-keep": "value", "x-delete": null }, expected: { "x-keep": "value", "x-delete": null } },
+	{ name: "empty header value", input: { "x-empty": "", "x-keep": "value" }, expected: { "x-keep": "value" } },
+	{ name: "numeric header value", input: { "x-number": 7, "x-keep": "value" }, expected: { "x-keep": "value" } },
+	{ name: "absent headers", input: undefined, expected: undefined },
+	{ name: "array headers", input: ["x-keep", "value"], expected: undefined },
+	{ name: "empty header record", input: {}, expected: undefined },
+];
 
-test("headerRecord still drops empty and non-string header values", () => {
-	expect(headerRecord({ "x-empty": "", "x-number": 7, "x-keep": "value" })).toEqual({ "x-keep": "value" });
-});
+if (headerRows.length === 0) throw new Error("Provider header table is empty");
 
-test("headerRecord returns undefined for absent or non-object headers", () => {
-	expect(headerRecord(undefined)).toBeUndefined();
-	expect(headerRecord(["x-keep", "value"])).toBeUndefined();
-	expect(headerRecord({})).toBeUndefined();
-});
+for (const row of headerRows) {
+	test(row.name, () => {
+		expect.hasAssertions();
+		expect(headerRecord(row.input)).toEqual(row.expected);
+	});
+}


### PR DESCRIPTION
Provider-header tests now give empty and numeric values separate asserted rows.

The table preserves exact kept values, null deletion markers, and undefined results for absent, array and empty-record inputs.

Only Pi QoL test files change. These tests have no tracked renders and are excluded from the published npm package.

Part of KEN-1241. The remaining audit stays open.

## Validation

- Focused proof: 6 tests pass. Pi QoL package: 118 tests pass.
- Saved specialist reviewer-test round: pass with no findings.
- Copied controls compile and fail at their required diagnostics. Empty-table controls apply to each table; no-op controls check the result assertions.
- Preflight, document limits and Pi package policy pass.
- This branch's required full guard passed at exact head ee95f39ca562cc3fdfe09b4c3d1051052a05a594 with external temporary storage, cleared Git redirects and private Pi/task/diagnostic roots.

## Size

The branch adds 0 production lines, 15 test lines and 0 render-mirror lines. KEN-1241 states no line allowance.
