### PR TITLE
test(KEN-1241): preserve notification bytes in case tables

### DIFF
--- a/pi-extensions/pi-qol/tests/notifications.test.ts
+++ b/pi-extensions/pi-qol/tests/notifications.test.ts
@@ -2,18 +2,31 @@ import { expect, test } from "bun:test";
 
 import { osc777NotificationSequence, terminalBellSequence } from "../extensions/qol/notifications.ts";
 
-test("terminalBellSequence emits BEL unless bell sound is muted", () => {
-	expect(terminalBellSequence(false)).toBe("\x07");
-	expect(terminalBellSequence(true)).toBeUndefined();
-});
+const bellRows = [
+	{ name: "audible terminal bell", muted: false, expected: "\x07" },
+	{ name: "muted terminal bell", muted: true, expected: undefined },
+];
 
-test("osc777NotificationSequence preserves BEL terminator by default", () => {
-	expect(osc777NotificationSequence("Title", "Body")).toBe("\x1b]777;notify;Title;Body\x07");
-});
+if (bellRows.length === 0) throw new Error("Terminal bell table is empty");
 
-test("osc777NotificationSequence uses ST terminator when bell sound is muted", () => {
-	const sequence = osc777NotificationSequence("Title", "Body", true);
+for (const row of bellRows) {
+	test(row.name, () => {
+		expect.hasAssertions();
+		expect(terminalBellSequence(row.muted)).toBe(row.expected);
+	});
+}
 
-	expect(sequence).toBe("\x1b]777;notify;Title;Body\x1b\\");
-	expect(sequence).not.toContain("\x07");
-});
+const oscRows = [
+	{ name: "default OSC BEL terminator", muted: undefined, expected: { sequence: "\x1b]777;notify;Title;Body\x07", containsBell: true } },
+	{ name: "muted OSC ST terminator", muted: true, expected: { sequence: "\x1b]777;notify;Title;Body\x1b\\", containsBell: false } },
+];
+
+if (oscRows.length === 0) throw new Error("OSC notification table is empty");
+
+for (const row of oscRows) {
+	test(row.name, () => {
+		expect.hasAssertions();
+		const sequence = osc777NotificationSequence("Title", "Body", row.muted);
+		expect({ sequence, containsBell: sequence.includes("\x07") }).toEqual(row.expected);
+	});
+}


### PR DESCRIPTION
Notification tests now group terminal-bell and OSC results in separate visible tables.

The rows preserve exact payload and terminator bytes, including the absence of a bell byte when muted.

Only Pi QoL test files change. These tests have no tracked renders and are excluded from the published npm package.

Part of KEN-1241. The remaining audit stays open.

## Validation

- Focused proof: 4 tests pass. Preserved old-head Pi QoL package proof: 116 tests pass.
- Saved specialist reviewer-test round: pass with no findings.
- Copied controls compile and fail at their required diagnostics. Empty-table controls apply to each table; no-op controls check the result assertions.
- Preserved old-head preflight, document limits and Pi package policy checks pass.
- This branch's OWN full guard passed at reviewed head afe8d8b77ea0f4e042a1cbc79638e2b38ecf044a. Those isolated validation receipts remain preserved.
- Current integration head aed030a0426877ae064eb98ecd0a251c9b9bba26 is based on fixture fix ddcbb65e8ed8cd9fd2a4d13da05ce16fd2a688cb (#2434). The notification test, production helper and preload retain identical bytes and modes. Both inherited fixture-helper copies match main and set `maintenance.auto=false` before committing the pristine fixture.
- The ordinary notification proof passes at the integration head: 4 tests and 4 assertions.
- The integration head's OWN full guard (`tools/guard --full`) passed at aed030a0426877ae064eb98ecd0a251c9b9bba26 with exit 0 (handle 43019). It used `TMPDIR=/var/tmp/ken-c`, cleared Git redirects, `PYTHONDONTWRITEBYTECODE=1`, and separate private paths for `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, `PI_BG_TASK_DIR`, `PI_BG_TASK_DIAGNOSTIC_LOG` and `PI_TASK_PANEL_DIAGNOSTIC_LOG`.
- The integration guard has its own output directory. Its complete launch, log, terminal and cleanup receipts are saved. The owned private root was removed after success. The worktree stayed clean at the same head. Source bytes, file modes and runner hashes are unchanged.
- Historical evidence remains preserved: the old-head guard, original failed CI run 34216749266, failed `--no-rebase` push, body rollback, old-head watcher and successful default push with its exact saved lease. The old-head guard and formal review retain their original commit bindings.

## Size

The branch adds 0 production lines, 25 test lines and 0 render-mirror lines. KEN-1241 states no line allowance.
