### PR TITLE
test(KEN-1241): isolate session JSONL test surfaces

### DIFF
--- a/pi-extensions/pi-qol/tests/session-search-jsonl.test.ts
+++ b/pi-extensions/pi-qol/tests/session-search-jsonl.test.ts
@@ -1,41 +1,19 @@
-import { afterEach, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { sessionUserMessages } from "../extensions/qol/session-search/cache.ts";
 import { forEachSessionJsonlLine } from "../extensions/qol/session-search/jsonl.ts";
 
-const root = join(process.cwd(), "tmp", "qol-session-jsonl");
-
-function resetRoot(): void {
-	rmSync(root, { recursive: true, force: true });
-	mkdirSync(root, { recursive: true });
-}
-
-afterEach(() => {
-	rmSync(root, { recursive: true, force: true });
-});
-
 test("session JSONL line reader streams across small chunks", () => {
-	resetRoot();
-	const dir = mkdtempSync(join(root, "case-"));
-	const path = join(dir, "chunks.jsonl");
-	writeFileSync(path, "one\r\ntwo\nthree");
-	const lines: string[] = [];
-	forEachSessionJsonlLine(path, (line) => lines.push(line), 3);
-	expect(lines).toEqual(["one", "two", "three"]);
-});
-
-test("session search user prompts parse without loading the whole JSONL file", () => {
-	resetRoot();
-	const dir = mkdtempSync(join(root, "case-"));
-	const path = join(dir, "session.jsonl");
-	writeFileSync(path, [
-		JSON.stringify({ type: "message", timestamp: "2026-06-04T00:00:00.000Z", message: { role: "user", content: [{ type: "text", text: "first prompt" }] } }),
-		JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "answer" }] } }),
-		JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "image" }, { type: "text", text: "second prompt" }] } }),
-	].join("\n"));
-
-	const messages = sessionUserMessages(path);
-	expect(messages.map((message) => message.text)).toEqual(["first prompt", "[image] second prompt"]);
-	expect(messages[0]?.timestamp).toBe(new Date("2026-06-04T00:00:00.000Z").getTime());
+	const root = mkdtempSync(join(tmpdir(), "pi-qol-jsonl-lines-"));
+	try {
+		expect.hasAssertions();
+		const path = join(root, "chunks.jsonl");
+		writeFileSync(path, "one\r\ntwo\nthree");
+		const lines: string[] = [];
+		forEachSessionJsonlLine(path, (line) => lines.push(line), 3);
+		expect(lines).toEqual(["one", "two", "three"]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });

--- a/pi-extensions/pi-qol/tests/session-user-messages.test.ts
+++ b/pi-extensions/pi-qol/tests/session-user-messages.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sessionUserMessages } from "../extensions/qol/session-search/cache.ts";
+
+test("session user messages retain prompt text and timestamp", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-qol-user-messages-"));
+	try {
+		expect.hasAssertions();
+		const path = join(root, "session.jsonl");
+		writeFileSync(path, [
+			JSON.stringify({ type: "message", timestamp: "2026-06-04T00:00:00.000Z", message: { role: "user", content: [{ type: "text", text: "first prompt" }] } }),
+			JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "answer" }] } }),
+			JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "image" }, { type: "text", text: "second prompt" }] } }),
+		].join("\n"));
+
+		const messages = sessionUserMessages(path);
+		expect({ texts: messages.map((message) => message.text), timestamp: messages[0]?.timestamp }).toEqual({
+			texts: ["first prompt", "[image] second prompt"],
+			timestamp: new Date("2026-06-04T00:00:00.000Z").getTime(),
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
The session JSONL tests now use unique temporary roots with cleanup in finally.

Line reading and cached user-message extraction have separate files. The assertions preserve chunked CRLF/final-line output, user text, the image marker, assistant exclusion and timestamp.

Only Pi QoL test files change. These tests have no tracked renders and are excluded from the published npm package.

Part of KEN-1241. The remaining audit stays open.

## Validation

- Focused proof: 2 tests pass. Pi QoL package: 115 tests pass.
- Saved specialist reviewer-test round: pass with no findings.
- Copied controls compile and fail at their required diagnostics. No-op controls check the result assertions. Other controls cover final-line and CRLF handling, assistant-message exclusion and timestamp preservation.
- Preflight, document limits and Pi package policy pass.
- This branch's OWN required full guard (`tools/guard --full`) passed at exact head 511fc97981d4feabc401225df0dac2e2cb13dca4 with exit 0 (handle 24325). It used `TMPDIR=/var/tmp/ken-c`, all six Git redirects cleared, `PYTHONDONTWRITEBYTECODE=1`, and separate private paths for `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, `PI_BG_TASK_DIR`, `PI_BG_TASK_DIAGNOSTIC_LOG` and `PI_TASK_PANEL_DIAGNOSTIC_LOG`.
- Complete caller, actual launch, process, log, terminal and cleanup receipts are saved. The owned private root was removed after success. The worktree stayed clean at the same head. Source bytes and modes, runner hash and historical evidence remain unchanged.

## Size

The branch adds 0 production lines, 40 test lines and 0 render-mirror lines. KEN-1241 states no line allowance.
