### PR TITLE
test(KEN-1241): audit Pi log result tables

### DIFF
--- a/pi-extensions/pi-background-tasks/tests/background-ack.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/background-ack.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { bashBackgroundAckText } from "../extensions/auto-background.js";
+import { WAKE_MANIFEST_FIELD_MAX_CHARS as cap } from "../extensions/wake-events.js";
+import { fakeSnapshot } from "./fixtures/lifecycle.js";
+
+const rows = [
+	{ name: "huge acknowledgement fields retain bounded prefixes", huge: true },
+	{ name: "small acknowledgement fields are unchanged", huge: false },
+];
+
+test("background acknowledgement rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "acknowledgement table must contain cases").toBeGreaterThan(0);
+	for (const row of rows) {
+		const task = fakeSnapshot({
+			id: "bg-log-1", pid: 4242, command: row.huge ? "C".repeat(200_000) : "echo log",
+			cwd: row.huge ? "/path/" + "P".repeat(5_000) : "/path/work",
+			logFile: row.huge ? "/tmp/" + "L".repeat(5_000) : "/tmp/log",
+			notifyOnOutput: true, notifyPattern: row.huge ? "R".repeat(5_000) : "ready",
+			dedupeKey: row.huge ? "D".repeat(5_000) : "monitor",
+		});
+		const text = bashBackgroundAckText(task, { forced: false, notifyOnExit: true, notifyOnOutput: true, reason: "test", title: "test" });
+		const expected = [
+			"Started bg-log-1 (pid 4242) in the background.", "Reason: test.",
+			`Command: ${row.huge ? "C".repeat(cap - 1) + "…" : "echo log"}`,
+			`Cwd: ${row.huge ? "/path/" + "P".repeat(cap - 7) + "…" : "/path/work"}`,
+			`Log: ${row.huge ? "/tmp/" + "L".repeat(cap - 6) + "…" : "/tmp/log"}`,
+			`Wakeups: exit=yes, output=${row.huge ? "R".repeat(cap - 1) + "…" : "ready"}, mode=always, dedupeKey=${row.huge ? "D".repeat(cap - 1) + "…" : "monitor"}`,
+			"Continue the turn without waiting. Use bg_task list/log/stop to inspect or terminate this task.",
+		].join("\n");
+		expect({ text, bounded: Buffer.byteLength(text, "utf8") < 4_096, excluded: ["C", "P", "L", "R", "D"].filter((char) => text.includes(char.repeat(cap + 1))) }, row.name).toStrictEqual({ text: expected, bounded: true, excluded: [] });
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/compact-log-snapshot.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/compact-log-snapshot.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import { compactBackgroundTaskSnapshot, WAKE_MANIFEST_FIELD_MAX_CHARS as cap } from "../extensions/wake-events.js";
+import { fakeSnapshot } from "./fixtures/lifecycle.js";
+
+const rows = [
+	{ name: "huge command retains its bounded prefix", field: "command", input: "C".repeat(200_000), expected: "C".repeat(cap - 1) + "…" },
+	{ name: "huge title retains its bounded prefix", field: "title", input: "T".repeat(2_000), expected: "T".repeat(cap - 1) + "…" },
+	{ name: "huge cwd retains its bounded prefix", field: "cwd", input: "/path/" + "P".repeat(5_000), expected: "/path/" + "P".repeat(cap - 7) + "…" },
+	{ name: "huge logFile retains its bounded prefix", field: "logFile", input: "/tmp/" + "L".repeat(5_000), expected: "/tmp/" + "L".repeat(cap - 6) + "…" },
+	{ name: "small command is unchanged", field: "command", input: "echo log", expected: "echo log" },
+] as const;
+
+test("compact log snapshot field rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "compact snapshot table must contain cases").toBeGreaterThan(0);
+	for (const row of rows) {
+		const compact = compactBackgroundTaskSnapshot(fakeSnapshot({ [row.field]: row.input }));
+		expect({ value: compact[row.field], bounded: compact[row.field].length <= cap }, row.name).toStrictEqual({ value: row.expected, bounded: true });
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/fixtures/log-settings.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/log-settings.ts
@@ -1,0 +1,30 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// The .pi boundary stops ancestor settings discovery in this private cwd.
+export function privateLogRoot() {
+	const scratch = resolve(import.meta.dir, "../../../..", "tmp");
+	mkdirSync(scratch, { recursive: true });
+	const root = realpathSync(mkdtempSync(join(scratch, "pi-log-results-")));
+	try {
+		mkdirSync(join(root, ".pi"));
+		mkdirSync(join(root, "agent"));
+		return root;
+	} catch (error) {
+		rmSync(root, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+export function withLogSettings<T>(run: (cwd: string) => T): T {
+	const root = privateLogRoot();
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	try {
+		process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+		return run(root);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+}

--- a/pi-extensions/pi-background-tasks/tests/fixtures/registered-log.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/registered-log.ts
@@ -1,0 +1,48 @@
+import { mock } from "bun:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { RegistrationDeps } from "../../extensions/registrations.js";
+import type { BackgroundTaskSnapshot } from "../../extensions/types.js";
+import { fakeTask } from "./lifecycle.js";
+
+// Peer mocks stay in this child. Production result, snapshot, and log functions run unchanged.
+const unused = () => { throw new Error("registered log fixture reached an unrelated operation"); };
+mock.module("@earendil-works/pi-ai", () => ({ StringEnum: (values: readonly string[]) => ({ enum: values }) }));
+mock.module("typebox", () => ({ Type: { Object: (value: unknown) => value, Optional: (value: unknown) => value, Number: () => ({}), String: () => ({}), Boolean: () => ({}) } }));
+mock.module("@earendil-works/pi-tui", () => ({ matchesKey: unused, truncateToWidth: unused, visibleWidth: unused, wrapTextWithAnsi: unused }));
+const { registerAll } = await import("../../extensions/registrations.js");
+const { taskSnapshot } = await import("../../extensions/snapshot.js");
+
+interface InputRow { tool: string; output: string; task: Partial<BackgroundTaskSnapshot> }
+interface Tool {
+	name: string;
+	execute(id: string, params: { action: "log"; id?: string; pid?: number }): Promise<unknown>;
+}
+const rows: InputRow[] = JSON.parse(await Bun.stdin.text());
+const results = [];
+for (const row of rows) {
+	const task = fakeTask(row.task);
+	const calls: unknown[] = [];
+	const tools = new Map<string, Tool>();
+	const pi = {
+		registerTool(tool: Tool) { tools.set(tool.name, tool); },
+		registerCommand() {}, registerShortcut() {},
+	} as unknown as ExtensionAPI;
+	const deps: RegistrationDeps = {
+		getActiveCtx: () => ({ cwd: process.cwd() }) as ExtensionContext,
+		setActiveCtx: unused,
+		rememberSnapshot(value) { calls.push({ rememberSameTask: value === task }); return taskSnapshot(value); },
+		sortedTasks: unused, formatTaskListText: unused,
+		getTaskOutput(value) { calls.push({ outputSameTask: value === task }); return row.output; },
+		resolveTask(id, pid) { calls.push({ id: id ?? null, pid: pid ?? null }); return task; },
+		requestStop: unused, spawnTask: unused, clearFinishedTasks: unused,
+		armForcedBackground: unused, toggleWidget: unused,
+		dashboardDeps: { sortedTasks: unused, getTask: unused, getTaskOutput: unused, requestStop: unused, clearFinishedTasks: unused, formatTaskListText: unused },
+		dashboardShortcut: "none", backgroundBashShortcut: "none", widgetToggleShortcut: "none",
+	};
+	registerAll(pi, deps);
+	const tool = tools.get(row.tool);
+	if (!tool) throw new Error(`Missing registered tool: ${row.tool}`);
+	const result = await tool.execute("log-call", row.tool === "bg_task" ? { action: "log", id: task.id } : { action: "log", pid: task.pid });
+	results.push({ result, calls });
+}
+process.stdout.write(JSON.stringify(results));

--- a/pi-extensions/pi-background-tasks/tests/log-tool-result-bounds.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/log-tool-result-bounds.test.ts
@@ -1,230 +1,77 @@
-// bg_task / bg_status log tool-result transcript bounds.
-//
-// `bg_task log` and `bg_status log` add `details.tasks[i].outputTail` to the
-// transcript; their text content is bounded by `logTailMaxChars` (default
-// 10000) and the `details.task` snapshot is bounded by the wake manifest.
-// The test exercises the bound through the tool-result path that writes the
-// transcript.
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { DEFAULT_LOG_TAIL_MAX_CHARS as cap } from "../extensions/constants.js";
+import type { BackgroundTaskSnapshot, BackgroundLogTruncation } from "../extensions/types.js";
+import { WAKE_MANIFEST_FIELD_MAX_CHARS as fieldCap } from "../extensions/wake-events.js";
+import { privateLogRoot } from "./fixtures/log-settings.js";
 
-import { describe, expect, test } from "bun:test";
+const logFile = "/tmp/kendex-pi-bg/bg-log-1-1700000000000.log";
+const marker = "retained log tail\n";
+const tail = marker + "z".repeat(cap - marker.length - 1) + "!";
+const rows = [
+	{ name: "bg_task huge log and metadata", tool: "bg_task", output: "z".repeat(cap * 3) + tail, huge: true, path: logFile },
+	{ name: "bg_status huge log and metadata", tool: "bg_status", output: "z".repeat(cap * 3) + tail, huge: true, path: logFile },
+	{ name: "bg_task long log path", tool: "bg_task", output: "z".repeat(cap * 3) + tail, huge: true, path: "/tmp/" + "L".repeat(5_000) },
+	{ name: "bg_status long log path", tool: "bg_status", output: "z".repeat(cap * 3) + tail, huge: true, path: "/tmp/" + "L".repeat(5_000) },
+	{ name: "bg_task small output", tool: "bg_task", output: "all good\n", huge: false, path: logFile },
+	{ name: "bg_status small output", tool: "bg_status", output: "all good\n", huge: false, path: logFile },
+	{ name: "bg_task empty output", tool: "bg_task", output: "", huge: false, path: logFile },
+	{ name: "bg_status empty output", tool: "bg_status", output: "", huge: false, path: logFile },
+];
 
-import { bashBackgroundAckText } from "../extensions/auto-background.js";
-import { DEFAULT_LOG_TAIL_MAX_CHARS } from "../extensions/constants.js";
-import {
-	TASK_DISPLAY_NAME_MAX_CHARS,
-	buildTaskSummaryLine,
-	formatTaskLog,
-	taskDisplayNameForTranscript,
-	taskLogTruncation,
-} from "../extensions/format.js";
-import { taskSnapshot } from "../extensions/snapshot.js";
-import type { BashBackgroundDecision, ManagedTask } from "../extensions/types.js";
-import { WAKE_MANIFEST_FIELD_MAX_CHARS, compactBackgroundTaskSnapshot, emptyOutputWakeBudget, truncateForTranscript } from "../extensions/wake-events.js";
-
-function logTask(overrides: Partial<ManagedTask> = {}): ManagedTask {
-	const base: ManagedTask = {
-		child: null,
-		closed: true,
-		command: "echo log",
-		cwd: "/tmp",
-		exitCode: 0,
-		exitNotified: true,
-		expiresAt: null,
-		forceKillTimer: null,
-		id: "bg-log-1",
-		lastAnnouncedLength: 0,
-		lastOutputAt: 1_700_000_000_500,
-		logFile: "/tmp/bg-log-1.log",
-		matcher: null,
-		notifyMode: "always",
-		notifyOnExit: true,
-		notifyOnOutput: false,
-		output: "",
-		outputBytes: 0,
-		outputPatternMatched: false,
-		outputTimer: null,
-		outputWakeBudget: emptyOutputWakeBudget(),
-		pendingWakes: [],
-		pid: 4242,
-		startedAt: 1_700_000_000_000,
-		status: "completed",
-		stopReason: null,
-		timeoutTimer: null,
-		title: "log",
-		updatedAt: 1_700_000_000_500,
-		voidedWakeSequences: [],
-		voidedWakes: new Set(),
-		wakeEvents: [],
-		wakeSequence: 0,
-	};
-	return { ...base, ...overrides };
+interface ChildResult {
+	result: { content: { type: string; text: string }[]; details: { action: string; task: BackgroundTaskSnapshot; fullOutputPath?: string; truncation?: BackgroundLogTruncation } };
+	calls: unknown[];
 }
 
-describe("taskLogTruncation (kendex#210)", () => {
-	test("returns undefined for output below the cap", () => {
-		const output = "short\n".repeat(10);
-		expect(taskLogTruncation(output, "/tmp/log")).toBeUndefined();
-	});
-
-	test("returns a truncation descriptor pointing at the log file for huge output", () => {
-		const huge = "x".repeat(DEFAULT_LOG_TAIL_MAX_CHARS * 4);
-		const t = taskLogTruncation(huge, "/tmp/log");
-		expect(t).toBeDefined();
-		expect(t!.direction).toBe("tail");
-		expect(t!.truncated).toBe(true);
-		expect(t!.fullOutputPath).toBe("/tmp/log");
-		expect(t!.shownChars).toBe(DEFAULT_LOG_TAIL_MAX_CHARS);
-		expect(t!.totalChars).toBe(huge.length);
-	});
-});
-
-describe("formatTaskLog (kendex#210)", () => {
-	test("emits the full output when below the cap", () => {
-		const output = "all good\n".repeat(50);
-		expect(formatTaskLog(output, "/tmp/log")).toBe(output);
-	});
-
-	test("clips to the default cap and points at the on-disk log path", () => {
-		const huge = "y".repeat(DEFAULT_LOG_TAIL_MAX_CHARS * 5);
-		const formatted = formatTaskLog(huge, "/tmp/big.log");
-		expect(formatted.startsWith("[...truncated]\n")).toBe(true);
-		expect(formatted).toContain("/tmp/big.log");
-		expect(formatted).toContain(`Showing last ${DEFAULT_LOG_TAIL_MAX_CHARS} of ${huge.length} character(s)`);
-		// Allow the truncation banner + path tail to add a small amount of
-		// envelope text on top of the bounded slice.
-		expect(formatted.length).toBeLessThan(DEFAULT_LOG_TAIL_MAX_CHARS + 256);
-	});
-
-	test("(empty) sentinel for falsy output", () => {
-		expect(formatTaskLog("", "/tmp/log")).toBe("(empty)");
-	});
-});
-
-describe("transcript-facing content strings (kendex#210 round 2)", () => {
-	test("buildTaskSummaryLine clamps title/command to the display cap", () => {
-		const task = taskSnapshot(logTask({ command: "Q".repeat(50_000), title: "T".repeat(50_000) }));
-		const line = buildTaskSummaryLine(task);
-		// The summary line carries one bounded display name + short prefix
-		// columns; keep the whole line under a few hundred chars so a
-		// bg_task list rendered into chat content cannot bloat.
-		expect(line.length).toBeLessThan(TASK_DISPLAY_NAME_MAX_CHARS + 128);
-	});
-
-	test("taskDisplayNameForTranscript falls back to command when title is empty", () => {
-		const long = "Q".repeat(5_000);
-		expect(taskDisplayNameForTranscript({ title: "", command: long }).length).toBeLessThanOrEqual(TASK_DISPLAY_NAME_MAX_CHARS);
-	});
-
-	test("bashBackgroundAckText bounds command/cwd/logFile/notifyPattern", () => {
-		const snapshot = taskSnapshot(logTask({
-			command: "C".repeat(200_000),
-			cwd: "/path/" + "P".repeat(5_000),
-			logFile: "/tmp/" + "L".repeat(5_000),
-			notifyOnOutput: true,
-			notifyPattern: "R".repeat(5_000),
-			dedupeKey: "D".repeat(5_000),
-		}));
-		const decision: BashBackgroundDecision = {
-			forced: false,
-			notifyOnExit: true,
-			notifyOnOutput: true,
-			reason: "test",
-			title: "test",
-		};
-		const text = bashBackgroundAckText(snapshot, decision);
-		// One-line bounded fields plus envelope text; total well under 4 KB.
-		expect(Buffer.byteLength(text, "utf8")).toBeLessThan(4_096);
-		// No verbatim 4097-char bombs survived.
-		expect(text).not.toContain("C".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-		expect(text).not.toContain("P".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-		expect(text).not.toContain("L".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-		expect(text).not.toContain("R".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-		expect(text).not.toContain("D".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-	});
-
-	test("truncateForTranscript produces a bounded `Stopped …` message shape (kendex#210 round 3 unit check)", () => {
-		// Unit-level companion to `stop-content-e2e.test.ts`: documents the
-		// bounded format `requestStop` uses for stop tool-result content so
-		// the helper layer can be checked independently. The
-		// end-to-end test exercises the production call path; this one
-		// verifies the shared helper still produces a payload that fits the
-		// template under multi-KB input.
-		const huge = "B".repeat(100_000);
-		const task = logTask({ command: huge });
-		const safeCommand = truncateForTranscript(task.command, WAKE_MANIFEST_FIELD_MAX_CHARS) ?? "";
-		const stoppedMessage = `Stopped ${task.id} (${safeCommand}).`;
-		const stoppingMessage = `Stopping ${task.id} (${safeCommand}).`;
-
-		expect(safeCommand.length).toBeLessThanOrEqual(WAKE_MANIFEST_FIELD_MAX_CHARS);
-		for (const message of [stoppedMessage, stoppingMessage]) {
-			expect(Buffer.byteLength(message, "utf8")).toBeLessThan(WAKE_MANIFEST_FIELD_MAX_CHARS + 128);
-			expect(message).not.toContain("B".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-		}
-	});
-
-	test("formatTaskLog truncation banner uses a bounded log path", () => {
-		const huge = "z".repeat(DEFAULT_LOG_TAIL_MAX_CHARS * 4);
-		const longPath = "/tmp/" + "L".repeat(10_000);
-		const formatted = formatTaskLog(huge, longPath);
-		// The on-disk log path is bounded inside the truncation banner so a
-		// pathologically long taskDir cannot bloat the inline log payload.
-		expect(formatted).not.toContain("L".repeat(WAKE_MANIFEST_FIELD_MAX_CHARS + 1));
-		expect(formatted.length).toBeLessThan(DEFAULT_LOG_TAIL_MAX_CHARS + WAKE_MANIFEST_FIELD_MAX_CHARS + 256);
-	});
-
-	test("taskLogTruncation descriptor uses a bounded fullOutputPath", () => {
-		const huge = "z".repeat(DEFAULT_LOG_TAIL_MAX_CHARS * 4);
-		const longPath = "/tmp/" + "L".repeat(10_000);
-		const truncation = taskLogTruncation(huge, longPath);
-		expect(truncation).toBeDefined();
-		expect(truncation!.fullOutputPath.length).toBeLessThanOrEqual(WAKE_MANIFEST_FIELD_MAX_CHARS);
-	});
-});
-
-describe("log tool-result details bound the task snapshot (kendex#210)", () => {
-	test("log action keeps task command/title/cwd/logFile under the wake manifest cap", () => {
-		const task = logTask({
-			command: "C".repeat(200_000),
-			title: "T".repeat(2_000),
-			cwd: "/path/" + "P".repeat(5_000),
-			logFile: "/tmp/" + "L".repeat(5_000),
-		});
-		const compact = compactBackgroundTaskSnapshot(taskSnapshot(task));
-		expect(compact.command.length).toBeLessThanOrEqual(WAKE_MANIFEST_FIELD_MAX_CHARS);
-		expect(compact.title.length).toBeLessThanOrEqual(WAKE_MANIFEST_FIELD_MAX_CHARS);
-		expect(compact.cwd.length).toBeLessThanOrEqual(WAKE_MANIFEST_FIELD_MAX_CHARS);
-		expect(compact.logFile.length).toBeLessThanOrEqual(WAKE_MANIFEST_FIELD_MAX_CHARS);
-	});
-
-	test("a log tool-result-shaped payload stays under the byte cap with huge output and metadata", () => {
-		const huge = "z".repeat(DEFAULT_LOG_TAIL_MAX_CHARS * 4);
-		// A realistic log path. The test targets
-		// command/title/cwd bombs, which the compact manifest bounds.
-		const realisticLogFile = "/tmp/kendex-pi-bg/bg-log-1-1700000000000.log";
-		const task = logTask({
-			command: "Q".repeat(200_000),
-			title: "T".repeat(5_000),
-			cwd: "/" + "C".repeat(5_000),
-			logFile: realisticLogFile,
-		});
-		const compactSnapshot = compactBackgroundTaskSnapshot(taskSnapshot(task));
-		const truncation = taskLogTruncation(huge, task.logFile);
-
-		// Approximate the tool result that registrations.ts produces: bounded
-		// text + bounded task manifest + fullOutputPath + truncation marker.
-		const payload = {
-			content: [{ type: "text", text: formatTaskLog(huge, task.logFile) }],
-			details: {
-				action: "log",
-				task: compactSnapshot,
-				...(truncation ? { fullOutputPath: task.logFile, truncation } : {}),
+test("registered log tool result rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "registered log table must contain cases").toBeGreaterThan(0);
+	const root = privateLogRoot();
+	try {
+		const inputs = rows.map((row) => ({
+			tool: row.tool, output: row.output,
+			task: {
+				id: "bg-log-1", pid: 4242, logFile: row.path,
+				command: row.huge ? "Q".repeat(200_000) : "echo log",
+				title: row.huge ? "T".repeat(5_000) : "log",
+				cwd: row.huge ? "/" + "C".repeat(5_000) : "/path/work",
+				procIdent: { pid: 4242, startToken: "private-start", comm: "private-command" },
 			},
-		};
-		const payloadBytes = Buffer.byteLength(JSON.stringify(payload), "utf8");
-		// Bounded text (~10KB) + bounded manifest (~1KB) + envelope <= 16KB.
-		expect(payloadBytes).toBeLessThan(16_384);
-		expect(payload.details.fullOutputPath).toBe(task.logFile);
-		expect(payload.details.truncation?.fullOutputPath).toBe(task.logFile);
-		expect(payload.details.truncation?.shownChars).toBe(DEFAULT_LOG_TAIL_MAX_CHARS);
-	});
+		}));
+		const child = spawnSync(process.execPath, [join(import.meta.dir, "fixtures", "registered-log.ts")], {
+			cwd: root, env: { ...process.env, PI_CODING_AGENT_DIR: join(root, "agent"), PI_BG_TASK_DIR: join(root, "logs") },
+			input: JSON.stringify(inputs), encoding: "utf8", timeout: 10_000, killSignal: "SIGKILL", maxBuffer: 2_000_000,
+		});
+		if (child.error) throw new Error(`registered log child spawn failed: ${child.error.message}`);
+		if (child.status !== 0) throw new Error(`registered log child exited ${child.status ?? child.signal}: ${child.stderr}`);
+		const results: ChildResult[] = JSON.parse(child.stdout);
+		if (results.length !== rows.length) throw new Error(`registered log child returned ${results.length} rows; expected ${rows.length}`);
+		for (const [index, row] of rows.entries()) {
+			const { result, calls } = results[index]!;
+			const task = result.details.task;
+			const safePath = row.path.length <= fieldCap ? row.path : "/tmp/" + "L".repeat(fieldCap - 6) + "…";
+			const text = row.huge
+				? `[...truncated]\n${tail}\n\n[Background log truncated. Showing last ${cap} of ${row.output.length} character(s). Full log: ${safePath}]`
+				: row.output || "(empty)";
+			expect({
+				content: result.content, action: result.details.action,
+				task: { id: task.id, pid: task.pid, command: task.command, title: task.title, cwd: task.cwd, logFile: task.logFile },
+				fullOutputPath: result.details.fullOutputPath, truncation: result.details.truncation,
+				bounded: Buffer.byteLength(JSON.stringify(result), "utf8") < 16_384,
+				internalIdentity: task.procIdent, calls,
+			}, row.name).toStrictEqual({
+				content: [{ type: "text", text }], action: "log",
+				task: { id: "bg-log-1", pid: 4242, command: row.huge ? "Q".repeat(fieldCap - 1) + "…" : "echo log", title: row.huge ? "T".repeat(fieldCap - 1) + "…" : "log", cwd: row.huge ? "/" + "C".repeat(fieldCap - 2) + "…" : "/path/work", logFile: safePath },
+				fullOutputPath: row.huge ? safePath : undefined,
+				truncation: row.huge ? { direction: "tail", truncated: true, fullOutputPath: safePath, shownChars: cap, totalChars: row.output.length } : undefined,
+				bounded: true, internalIdentity: undefined,
+				calls: [{ id: row.tool === "bg_task" ? "bg-log-1" : null, pid: row.tool === "bg_status" ? 4242 : null }, { outputSameTask: true }, { rememberSameTask: true }],
+			});
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });

--- a/pi-extensions/pi-background-tasks/tests/task-display-summary.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/task-display-summary.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { TASK_DISPLAY_NAME_MAX_CHARS as cap, buildTaskSummaryLine, taskDisplayNameForTranscript } from "../extensions/format.js";
+import { fakeSnapshot } from "./fixtures/lifecycle.js";
+
+const rows = [
+	{ name: "summary bounds huge title and command", title: "T".repeat(50_000), command: "Q".repeat(50_000), expected: "T".repeat(cap - 1) + "…" },
+	{ name: "empty title falls back to bounded command", title: "", command: "Q".repeat(5_000), expected: "Q".repeat(cap - 1) + "…" },
+	{ name: "short title is retained", title: "log", command: "echo log", expected: "log" },
+];
+
+test("transcript display and summary rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "display table must contain cases").toBeGreaterThan(0);
+	for (const row of rows) {
+		const task = fakeSnapshot({ title: row.title, command: row.command, id: "bg-log-1", pid: 4242, status: "completed", exitCode: 0 });
+		const name = taskDisplayNameForTranscript(task);
+		const line = buildTaskSummaryLine(task, task.updatedAt);
+		expect({ name, line, nameBounded: name.length <= cap, lineBounded: line.length < cap + 128 }, row.name).toStrictEqual({
+			name: row.expected, line: `bg-log-1 · completed (exit 0) · pid 4242 · ${row.expected} · now`, nameBounded: true, lineBounded: true,
+		});
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/task-log-format.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/task-log-format.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { DEFAULT_LOG_TAIL_MAX_CHARS as cap } from "../extensions/constants.js";
+import { formatTaskLog, taskLogTruncation } from "../extensions/format.js";
+import { WAKE_MANIFEST_FIELD_MAX_CHARS as fieldCap } from "../extensions/wake-events.js";
+import { withLogSettings } from "./fixtures/log-settings.js";
+
+const marker = "retained log tail\n";
+const tail = marker + "y".repeat(cap - marker.length - 1) + "!";
+const rows = [
+	{ name: "short descriptor is absent", output: "short\n".repeat(10), path: "/tmp/log", clipped: false },
+	{ name: "small output is unchanged", output: "all good\n".repeat(50), path: "/tmp/log", clipped: false },
+	{ name: "exact cap is unchanged", output: "x".repeat(cap), path: "/tmp/log", clipped: false },
+	{ name: "huge output retains the exact tail and descriptor", output: "x".repeat(cap * 4) + tail, path: "/tmp/big.log", clipped: true },
+	{ name: "empty output uses sentinel", output: "", path: "/tmp/log", clipped: false },
+	{ name: "long log path is bounded in banner and descriptor", output: "z".repeat(cap * 3) + tail, path: "/tmp/" + "L".repeat(10_000), clipped: true },
+];
+
+test("log formatting and descriptor rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "log formatting table must contain cases").toBeGreaterThan(0);
+	withLogSettings((cwd) => {
+		for (const row of rows) {
+			const formatted = formatTaskLog(row.output, row.path, cwd);
+			const descriptor = taskLogTruncation(row.output, row.path, cwd);
+			const safePath = row.path.length <= fieldCap ? row.path : row.path.slice(0, fieldCap - 1) + "…";
+			const expected = row.clipped
+				? `[...truncated]\n${tail}\n\n[Background log truncated. Showing last ${cap} of ${row.output.length} character(s). Full log: ${safePath}]`
+				: row.output || "(empty)";
+			expect({ formatted, descriptor, bounded: formatted.length < cap + (row.path.length > fieldCap ? fieldCap : 0) + 256, excludesLongPath: !formatted.includes("L".repeat(fieldCap + 1)) }, row.name).toStrictEqual({
+				formatted: expected,
+				descriptor: row.clipped ? { direction: "tail", truncated: true, fullOutputPath: safePath, shownChars: cap, totalChars: row.output.length } : undefined,
+				bounded: true, excludesLongPath: true,
+			});
+		}
+	});
+});

--- a/pi-extensions/pi-background-tasks/tests/task-status-format.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/task-status-format.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { summarizeTaskStatus } from "../extensions/format.js";
+import type { BackgroundTaskStatus } from "../extensions/types.js";
+
+const rows: { name: string; status: BackgroundTaskStatus; exitCode: number | null; reason?: string; expected: string }[] = [
+	{ name: "completed self-exit omits reason", status: "completed", exitCode: 0, reason: "self-exit", expected: "completed (exit 0)" },
+	{ name: "failed self-exit omits reason", status: "failed", exitCode: 137, reason: "self-exit", expected: "failed (exit 137)" },
+	{ name: "extension stop appends reason", status: "stopped", exitCode: null, reason: "extension-stop", expected: "stopped (extension-stop)" },
+	{ name: "restart reconciliation appends reason", status: "stopped", exitCode: null, reason: "reconcile-on-restart", expected: "stopped (reconcile-on-restart)" },
+	{ name: "gone orphan appends reason", status: "failed", exitCode: null, reason: "orphaned-pid-gone", expected: "failed (exit ?) (orphaned-pid-gone)" },
+	{ name: "external exit appends reason", status: "failed", exitCode: null, reason: "external", expected: "failed (exit ?) (external)" },
+	{ name: "stopped without reason", status: "stopped", exitCode: null, expected: "stopped" },
+	{ name: "completed without reason", status: "completed", exitCode: 0, expected: "completed (exit 0)" },
+];
+
+test("task status formatting rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "status table must contain cases").toBeGreaterThan(0);
+	for (const row of rows) {
+		expect(summarizeTaskStatus(row.status, row.exitCode, row.reason), row.name).toBe(row.expected);
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/termination-reason.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/termination-reason.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, test } from "bun:test";
 
 import type { LifecycleHooks } from "../extensions/lifecycle.js";
 import { createOrphanWatcher } from "../extensions/orphan-watcher.js";
-import { summarizeTaskStatus } from "../extensions/format.js";
 import { taskSnapshot } from "../extensions/snapshot.js";
 import type {
 	BackgroundTaskSnapshot,
@@ -114,29 +113,3 @@ describe("orphan-watcher annotation (kendex#97)", () => {
 	});
 });
 
-describe("summarizeTaskStatus formatting (kendex#97)", () => {
-	test("self-exit annotation is omitted so historical rows stay terse", () => {
-		expect(summarizeTaskStatus("completed", 0, "self-exit")).toBe("completed (exit 0)");
-		expect(summarizeTaskStatus("failed", 137, "self-exit")).toBe("failed (exit 137)");
-	});
-
-	test("non-self-exit reasons are appended in parentheses", () => {
-		expect(summarizeTaskStatus("stopped", null, "extension-stop")).toBe(
-			"stopped (extension-stop)",
-		);
-		expect(summarizeTaskStatus("stopped", null, "reconcile-on-restart")).toBe(
-			"stopped (reconcile-on-restart)",
-		);
-		expect(summarizeTaskStatus("failed", null, "orphaned-pid-gone")).toBe(
-			"failed (exit ?) (orphaned-pid-gone)",
-		);
-		expect(summarizeTaskStatus("failed", null, "external")).toBe(
-			"failed (exit ?) (external)",
-		);
-	});
-
-	test("undefined termination reason matches the legacy output (back-compat)", () => {
-		expect(summarizeTaskStatus("stopped", null, undefined)).toBe("stopped");
-		expect(summarizeTaskStatus("completed", 0, undefined)).toBe("completed (exit 0)");
-	});
-});

--- a/pi-extensions/pi-background-tasks/tests/transcript-truncation.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/transcript-truncation.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { WAKE_MANIFEST_FIELD_MAX_CHARS as cap, truncateForTranscript } from "../extensions/wake-events.js";
+
+// Stop templates exercise the helper only; registered stop coverage has its own fixture.
+const rows = [
+	{ name: "Stopped template bounds huge command", value: "B".repeat(100_000), expected: "B".repeat(cap - 1) + "…", verb: "Stopped" },
+	{ name: "Stopping template bounds huge command", value: "B".repeat(100_000), expected: "B".repeat(cap - 1) + "…", verb: "Stopping" },
+	{ name: "small value is unchanged", value: "echo log", expected: "echo log", verb: "Stopped" },
+	{ name: "empty value is unchanged", value: "", expected: "", verb: "Stopped" },
+	{ name: "missing value remains undefined", value: undefined, expected: undefined, verb: "Stopped" },
+	{ name: "exact cap is unchanged", value: "B".repeat(cap), expected: "B".repeat(cap), verb: "Stopped" },
+];
+
+test("transcript truncation rows", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "truncation table must contain cases").toBeGreaterThan(0);
+	for (const row of rows) {
+		const command = truncateForTranscript(row.value, cap);
+		const message = `${row.verb} bg-log-1 (${command ?? ""}).`;
+		expect({ command, message, boundedCommand: command === undefined || command.length <= cap, boundedMessage: Buffer.byteLength(message, "utf8") < cap + 128, excludesBomb: !message.includes("B".repeat(cap + 1)) }, row.name).toStrictEqual({
+			command: row.expected, message: `${row.verb} bg-log-1 (${row.expected ?? ""}).`, boundedCommand: true, boundedMessage: true, excludesBomb: true,
+		});
+	}
+});


### PR DESCRIPTION
The log tests now call the registered `bg_task` and `bg_status` handlers. The previous payload test constructed its own result and could miss a regression in either handler.

The tests preserve bounded output and metadata while requiring actual retained content. Separate tables cover log formatting and descriptors, display names and summaries, background acknowledgements, direct transcript truncation, compact log fields, and status formatting.

| Former requirement | Current test surface |
|---|---|
| Log caps, descriptor fields, path relationships, short output, empty sentinel | Direct formatter/descriptor table and actual registered log handlers |
| Summary, fallback name, acknowledgement and compact-field bounds | Separate tables with positive retained-content checks |
| Stopped and Stopping template bounds | Direct truncation table |
| Status reason formatting | Moved status formatter table |

Generated records use strict comparisons. The former undefined short-log descriptor remains a direct raw observation. Compiling null-return and omitted-observation controls fail at the owning assertions. Optional raw production fields may remain absent.

The registered-handler fixture runs in a private child with external peer mocks and injected task/output dependencies. Production formatting, compaction, snapshots, and result construction remain real. Private settings and cwd prevent live user settings from changing the test inputs.

This change moves only the status-formatting group from `termination-reason.test.ts`. Finalize and snapshot group moves are already merged; the orphan group remains for its later move. The identical neutral lifecycle helper is already in the base, so this diff adds no second helper.

Part of KEN-1241. The audit remains open.

## Integration

- Committed head: `e94257864f1e9a6541b99d66e6a6d5fe56acc96d`. Base: `7995f8c68fb909853d3f2ebd057346b280f63a04`.
- All seven suite files, both private fixtures and the canonical lifecycle helper retain the exact bytes and modes used for the accepted controls. Production bytes are unchanged.
- Only the owned status group and its import were removed from the integrated termination-reason file. The retained orphan group is unchanged.

## Validation

- The original strict-comparison proof passed 7 tests with 45 assertions. The direct formatter proof passed 1 test with 7 assertions. Parent and child inputs compiled.
- All 57 original, 5 observation-omission and 1 undefined-value controls compiled and failed at the owning assertion. All 131 baseline/restored/loose-comparator runs passed. Each empty-table and removed-assertion control failed as intended.
- Controls ran sequentially in private full package copies with external temporary storage, all five explicit private Pi paths and cleared Git redirects. Source hashes remained unchanged and private copies were removed.
- Normal commit hooks passed. The integration receipt binds the committed head to the accepted control-source hashes.
- The single reviewer-test round passed with no findings at the committed head. Its ordinary focused proof passed 9 tests and 49 assertions across the seven log suites and retained termination-reason tests. All private state and child processes were cleaned up.
- Formal Copilot review completed at this exact head with no findings or unresolved threads. The commit retains its historical full-pending marker; the subsequently granted full guard passed at the unchanged head.

## Full guard

- The required `tools/guard --full` passed with exit 0 at this exact head. Its owned worktree used external TMPDIR, all five explicit private Pi paths and cleared Git redirects. Before/after source hashes, modes and HEAD matched; the worktree was clean and private state was removed.
- Merge requires exact-head merge approval and a separate main-checkout grant.

## CI retry

- Current CI passed after one authorized failed-job-only retry of the macOS guards shard and its dependent aggregate. The retry's full log shows the owning doc-drift row passed; that suite reported 44 passes and no failures.
- The original unchanged doc-drift test saw an extra normalized stderr category. The raw line was not retained, so the emitter and cause remain unknown. Original logs, the read-only trace and retry logs are preserved. The passing retry does not establish a cause. No diagnostic source edit or second retry occurred.

## Size

- Added lines: 0 production, 307 test, 0 render mirror. KEN-1241 states no size allowance.
