### PR TITLE
fix(KEN-1241): stabilize CLI fixtures and installer messages

### DIFF
--- a/changelog.d/fixed/installer-message-keys.md
+++ b/changelog.d/fixed/installer-message-keys.md
@@ -1,0 +1,1 @@
+- Installer notices and errors start with stable keys and values, so automation does not need to parse English explanations.

--- a/changelog.d/fixed/installer-message-keys.md
+++ b/changelog.d/fixed/installer-message-keys.md
@@ -1,1 +1,1 @@
-- Installer notices and errors start with stable keys and values, so automation does not need to parse English explanations.
+- Installer notices and errors start with stable keys and values. Invalid version options report option errors before a download starts.

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -68,8 +68,9 @@ fn list_sees_global_and_current_project_scopes() {
 fn scope_project_outside_a_project_is_an_error() {
     let tmp = fixture_home();
     let home = tmp.path();
-    let output = kendex(home, home, &["list", "--scope", "project"]);
-    assert!(!output.status.success());
+    // The filesystem root has no parent whose harness markers can leak into this case.
+    let output = kendex(home, Path::new("/"), &["list", "--scope", "project"]);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
 }
 
 #[test]

--- a/crates/cli/tests/dev_sandbox.rs
+++ b/crates/cli/tests/dev_sandbox.rs
@@ -88,7 +88,23 @@ fn a_debug_build_writes_to_the_dev_home_not_the_one_it_was_given() {
 #[test]
 fn a_sandboxed_build_still_knows_the_real_home_is_not_a_project() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let home = tmp.path().join("home");
+    let project = test_util::rooted(&tmp);
+    let home = project.join("home");
+    // A private ancestor catches the walk after it skips home, before it can reach the host.
+    std::fs::create_dir_all(project.join(".claude")).expect("ancestor marker");
+    std::fs::create_dir_all(project.join("catalog/skills/ancestor")).expect("catalog skill");
+    let skill = "---\nname: ancestor\ndescription: fixture skill\n---\nUse the ancestor project.\n";
+    std::fs::write(
+        project.join("catalog/kendex.toml"),
+        "is_source_catalog = true\n",
+    )
+    .expect("catalog declaration");
+    std::fs::write(project.join("catalog/skills/ancestor/SKILL.md"), skill).expect("catalog body");
+    std::fs::write(
+        project.join("kendex.toml"),
+        "schema = 6\n[sources.catalog]\npath = \"catalog\"\n[install]\nharnesses = [\"claude\"]\nmethod = \"copy\"\n[skills.ancestor]\nsource = \"catalog\"\n",
+    )
+    .expect("ancestor manifest");
     // The marker that makes an ordinary home look like a project.
     std::fs::create_dir_all(home.join(".claude")).expect("marker");
     let cwd = home.join("scratch");
@@ -100,11 +116,14 @@ fn a_sandboxed_build_still_knows_the_real_home_is_not_a_project() {
         .output()
         .expect("run kendex");
 
-    let said =
-        String::from_utf8_lossy(&out.stdout).into_owned() + &String::from_utf8_lossy(&out.stderr);
     assert!(
-        said.contains("not inside a project"),
-        "the home was taken for a project: {said}"
+        out.status.success(),
+        "the private ancestor was not selected: {out:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(project.join(".claude/skills/ancestor/SKILL.md"))
+            .expect("the ancestor project received its declared skill"),
+        skill
     );
     assert!(
         !home.join("kendex.toml").exists(),

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -192,8 +192,8 @@ fn release_matrix_and_feed_name_the_same_targets() {
     assert_eq!(lanes, feed);
 }
 
-/// An HTTP asset failure names the release target; a connection failure
-/// retains its own exit code without blaming a missing release build.
+/// An HTTP failure names the release target; a connection failure
+/// retains its own exit code without claiming an HTTP response.
 #[test]
 fn download_failures_report_their_exit_code_and_release_target() {
     for (exit, target) in [(22, Some("x86_64-apple-darwin")), (7, None)] {
@@ -207,7 +207,7 @@ fn download_failures_report_their_exit_code_and_release_target() {
             value(&output.stderr, "command-download-failed"),
             Some(exit.to_string().as_str())
         );
-        assert_eq!(value(&output.stderr, "release-asset-unavailable"), target);
+        assert_eq!(value(&output.stderr, "release-http-error"), target);
         assert_eq!(value(&output.stdout, "command-installed"), None);
     }
 }
@@ -219,6 +219,24 @@ fn installer_options_report_a_stable_key_and_value() {
     for (args, code, key, expected) in [
         (&["--unknown"][..], 2, "unknown-option", "--unknown"),
         (&["--version"][..], 2, "missing-option-value", "--version"),
+        (
+            &["--version", ""][..],
+            2,
+            "missing-option-value",
+            "--version",
+        ),
+        (
+            &["--unknown\\tail"][..],
+            2,
+            "unknown-option",
+            "--unknown\\\\tail",
+        ),
+        (
+            &["--unknown\ninstall.sh: command-installed=/forged"][..],
+            2,
+            "unknown-option",
+            "--unknown\\ninstall.sh: command-installed=/forged",
+        ),
         (&["--help"][..], 0, "usage", "install.sh"),
     ] {
         let output = Command::new("sh")
@@ -233,6 +251,7 @@ fn installer_options_report_a_stable_key_and_value() {
             &output.stderr
         };
         assert_eq!(value(channel, key), Some(expected), "{output:?}");
+        assert_eq!(value(channel, "command-installed"), None, "{output:?}");
         assert!(
             std::str::from_utf8(channel)
                 .expect("message is UTF-8")

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -86,7 +86,8 @@ fn run_install_in(
     // Logs the URL; `-o FILE` gets a runnable stand-in for the download,
     // and the release lookup gets a tag.
     let miss = fail.map_or(String::new(), |(url, code)| {
-        format!("case \"$url\" in *{url}*) exit {code} ;; esac\n")
+        // A failed transfer can leave a file; a later chmod must not supply the failure verdict.
+        format!("case \"$url\" in *{url}*) [ -z \"$out\" ] || : > \"$out\"; exit {code} ;; esac\n")
     });
     write_exe(
         &fake.join("curl"),
@@ -206,6 +207,12 @@ fn download_failures_report_their_exit_code_and_release_target() {
         assert_eq!(
             value(&output.stderr, "command-download-failed"),
             Some(exit.to_string().as_str())
+        );
+        assert_eq!(
+            value(&output.stderr, "command-download-url"),
+            Some(
+                "https://github.com/vanillagreencom/kendex/releases/download/v9.9.9/kendex-x86_64-apple-darwin"
+            )
         );
         assert_eq!(value(&output.stderr, "release-http-error"), target);
         assert_eq!(value(&output.stdout, "command-installed"), None);

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -13,6 +13,10 @@ use std::process::Command;
 mod test_util;
 use test_util::{SUDO_STUB, install_stub, rooted};
 
+#[path = "support/installer_message.rs"]
+mod installer_message;
+use installer_message::value;
+
 #[allow(clippy::unwrap_used)]
 fn write_exe(path: &Path, body: &str) {
     fs::write(path, body).unwrap();
@@ -188,38 +192,53 @@ fn release_matrix_and_feed_name_the_same_targets() {
     assert_eq!(lanes, feed);
 }
 
-/// curl exits 22 on an HTTP error: the release exists but has no such asset.
+/// An HTTP asset failure names the release target; a connection failure
+/// retains its own exit code without blaming a missing release build.
 #[test]
-fn a_release_without_this_target_says_so_instead_of_a_bare_curl_error() {
-    let (output, _) = run_install("Darwin", "x86_64", Some(("kendex-x86_64-apple-darwin", 22)));
-    assert_eq!(output.status.code(), Some(1));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("could not download kendex-x86_64-apple-darwin from"),
-        "{stderr}"
-    );
-    assert!(
-        stderr.contains("release v9.9.9 may have no build for x86_64-apple-darwin"),
-        "{stderr}"
-    );
-    // The script stops at its own message; a crash on the next step would
-    // exit 1 too, but through chmod complaining about the missing file.
-    assert!(!stderr.contains("chmod"), "{stderr}");
+fn download_failures_report_their_exit_code_and_release_target() {
+    for (exit, target) in [(22, Some("x86_64-apple-darwin")), (7, None)] {
+        let (output, _) = run_install(
+            "Darwin",
+            "x86_64",
+            Some(("kendex-x86_64-apple-darwin", exit)),
+        );
+        assert_eq!(output.status.code(), Some(1), "{output:?}");
+        assert_eq!(
+            value(&output.stderr, "command-download-failed"),
+            Some(exit.to_string().as_str())
+        );
+        assert_eq!(value(&output.stderr, "release-asset-unavailable"), target);
+        assert_eq!(value(&output.stdout, "command-installed"), None);
+    }
 }
 
-/// curl exits 7 when it cannot connect: the release is not to blame, so
-/// the no-build hint stays out.
+/// Invalid options fail before downloads; help answers without installing.
 #[test]
-fn a_network_failure_does_not_blame_the_release() {
-    let (output, _) = run_install("Darwin", "x86_64", Some(("kendex-x86_64-apple-darwin", 7)));
-    assert_eq!(output.status.code(), Some(1));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("could not download kendex-x86_64-apple-darwin from"),
-        "{stderr}"
-    );
-    assert!(!stderr.contains("may have no build"), "{stderr}");
-    assert!(!stderr.contains("chmod"), "{stderr}");
+fn installer_options_report_a_stable_key_and_value() {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../install.sh");
+    for (args, code, key, expected) in [
+        (&["--unknown"][..], 2, "unknown-option", "--unknown"),
+        (&["--version"][..], 2, "missing-option-value", "--version"),
+        (&["--help"][..], 0, "usage", "install.sh"),
+    ] {
+        let output = Command::new("sh")
+            .arg(&script)
+            .args(args)
+            .output()
+            .expect("installer runs");
+        assert_eq!(output.status.code(), Some(code), "{output:?}");
+        let channel = if code == 0 {
+            &output.stdout
+        } else {
+            &output.stderr
+        };
+        assert_eq!(value(channel, key), Some(expected), "{output:?}");
+        assert!(
+            std::str::from_utf8(channel)
+                .expect("message is UTF-8")
+                .starts_with(&format!("install.sh: {key}="))
+        );
+    }
 }
 
 /// Every directory `install.sh` can install the command into, read out of
@@ -378,10 +397,8 @@ fn path_order_does_not_decide_where_a_re_run_lands() {
         "install.sh reached past the fixture: {stderr}"
     );
     let said = String::from_utf8_lossy(&output.stdout);
-    let installed = said
-        .lines()
-        .find_map(|line| line.strip_prefix("Installed the kendex command to "))
-        .unwrap_or_else(|| panic!("install.sh did not say where it installed:\n{said}"));
+    let installed = value(&output.stdout, "command-installed")
+        .unwrap_or_else(|| panic!("install.sh did not report its installed path:\n{said}"));
     assert_eq!(
         PathBuf::from(installed),
         home.join(".local/bin/kendex"),
@@ -397,10 +414,8 @@ fn path_order_does_not_decide_where_a_re_run_lands() {
 fn where_a_real_install_puts_the_command_is_a_candidate() {
     let (output, _) = run_install("Linux", "x86_64", None);
     let said = String::from_utf8_lossy(&output.stdout);
-    let installed = said
-        .lines()
-        .find_map(|line| line.strip_prefix("Installed the kendex command to "))
-        .unwrap_or_else(|| panic!("install.sh did not say where it installed:\n{said}"));
+    let installed = value(&output.stdout, "command-installed")
+        .unwrap_or_else(|| panic!("install.sh did not report its installed path:\n{said}"));
     let home = PathBuf::from(installed)
         .parent()
         .unwrap()
@@ -442,10 +457,8 @@ fn install_sh_records_the_command_it_installed() {
         String::from_utf8_lossy(&output.stderr)
     );
     let said = String::from_utf8_lossy(&output.stdout);
-    let installed = said
-        .lines()
-        .find_map(|line| line.strip_prefix("Installed the kendex command to "))
-        .unwrap_or_else(|| panic!("install.sh did not say where it installed:\n{said}"));
+    let installed = value(&output.stdout, "command-installed")
+        .unwrap_or_else(|| panic!("install.sh did not report its installed path:\n{said}"));
 
     // Asked of the resolver rather than spelled a second time: the data
     // directory differs by platform and a second spelling agrees until it
@@ -484,12 +497,13 @@ fn install_sh_says_when_it_cannot_record_the_command() {
         "a record that would not be written cost the install itself:\n{said}"
     );
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains("Installed the kendex command to"),
+        value(&output.stdout, "command-installed")
+            == Some(home.join(".local/bin/kendex").to_str().unwrap()),
         "the command was never installed, so the record is not what this proves:\n{}",
         String::from_utf8_lossy(&output.stdout)
     );
     assert!(
-        said.contains("could not record the command's identity"),
+        value(&output.stderr, "command-record-failed") == env.installed_command_file().to_str(),
         "the run said nothing about the record it did not write:\n{said}"
     );
     assert_eq!(
@@ -591,10 +605,7 @@ fn the_privileged_branch_installs_with_flags_bsd_install_reads_alike() {
     // Asked first: a run that took the writable branch would install
     // perfectly well and prove nothing about the one under test.
     assert!(
-        said.contains(&format!(
-            "Installing to {} needs elevated permissions.",
-            bindir.display()
-        )),
+        value(&output.stdout, "privilege-required") == bindir.to_str(),
         "install.sh did not take the branch that needs privilege:\n{said}{stderr}"
     );
     assert!(
@@ -648,7 +659,7 @@ fn the_privileged_branch_makes_the_bindir_it_could_not_make_unprivileged() {
     let said = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        said.contains("needs elevated permissions."),
+        value(&output.stdout, "privilege-required") == home.join(".local/bin").to_str(),
         "install.sh did not take the branch that needs privilege:\n{said}{stderr}"
     );
     assert!(

--- a/crates/cli/tests/installer/main.rs
+++ b/crates/cli/tests/installer/main.rs
@@ -6,6 +6,9 @@
 mod desktop;
 mod icons;
 
+#[path = "../support/installer_message.rs"]
+mod installer_message;
+
 #[path = "../../../test_util.rs"]
 mod test_util;
 use test_util::{SUDO_STUB, install_stub};
@@ -219,11 +222,10 @@ fn installer_output(
 #[test]
 fn a_release_lookup_that_answers_with_nothing_stops_the_install() {
     let (tmp, output) = installer_output(&repo_root(), CURL_WITHOUT_RELEASES, DATA_DIR, |_| {});
-    assert!(!output.status.success(), "the install carried on");
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("could not resolve the latest release"),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert_eq!(
+        installer_message::value(&output.stderr, "release-unavailable"),
+        Some("latest")
     );
     assert!(
         !tmp.path().join(".local/bin/kendex").exists(),

--- a/crates/cli/tests/support/installer_message.rs
+++ b/crates/cli/tests/support/installer_message.rs
@@ -1,0 +1,10 @@
+//! Stable first-line values from installer-owned messages.
+
+#[allow(clippy::expect_used)]
+pub fn value<'a>(output: &'a [u8], key: &str) -> Option<&'a str> {
+    let prefix = format!("install.sh: {key}=");
+    std::str::from_utf8(output)
+        .expect("installer output is UTF-8")
+        .lines()
+        .find_map(|line| line.strip_prefix(&prefix))
+}

--- a/install.sh
+++ b/install.sh
@@ -12,22 +12,34 @@
 # lines below, which says more than an abrupt exit would.
 set -eu
 
+# Each installer-owned message starts with install.sh: KEY=VALUE. Values
+# escape backslashes and newlines; English explanation follows on later lines.
+message() {
+  printf 'install.sh: %s=' "$1"
+  printf '%s\n' "$2" | sed -e 's/\\/\\\\/g' -e '$!s/$/\\n/' | tr -d '\n'
+  printf '\n'
+  shift 2
+  printf '%s\n' "$@"
+}
+
 repo="vanillagreencom/kendex"
 version="latest"
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) version="${2:?missing version after --version}"; shift 2 ;;
+    --version)
+      [ "$#" -ge 2 ] || { message missing-option-value --version "A version must follow --version." >&2; exit 2; }
+      version="$2"; shift 2 ;;
     -h|--help)
-      echo "Usage: install.sh [--version vX.Y.Z]"
+      message usage install.sh "Usage: install.sh [--version vX.Y.Z]"
       exit 0
       ;;
-    *) echo "install.sh: unknown option: $1" >&2; exit 2 ;;
+    *) message unknown-option "$1" "The installer does not accept this option." >&2; exit 2 ;;
   esac
 done
 
 for cmd in curl install; do
-  command -v "$cmd" >/dev/null || { echo "install.sh: missing required command: $cmd" >&2; exit 1; }
+  command -v "$cmd" >/dev/null || { message missing-command "$cmd" "Install this required command before running the installer." >&2; exit 1; }
 done
 
 os="$(uname -s)"
@@ -40,7 +52,7 @@ case "$os-$arch" in
   Darwin-arm64|Darwin-aarch64) target="aarch64-apple-darwin";      kind="macos" ;;
   Darwin-x86_64)               target="x86_64-apple-darwin";       kind="macos" ;;
   *)
-    echo "install.sh: unsupported platform: $os $arch" >&2
+    message unsupported-platform "$os $arch" "This platform has no installer build." >&2
     echo "  See https://kendex.ai/download for the desktop app, or build from source." >&2
     exit 1 ;;
 esac
@@ -49,7 +61,7 @@ if [ "$version" = latest ]; then
   version="$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" \
     | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
 fi
-[ -n "$version" ] || { echo "install.sh: could not resolve the latest release" >&2; exit 1; }
+[ -n "$version" ] || { message release-unavailable latest "The latest release could not be resolved." >&2; exit 1; }
 plain="${version#v}"
 base="https://github.com/$repo/releases/download/$version"
 
@@ -57,7 +69,7 @@ base="https://github.com/$repo/releases/download/$version"
 # `sh` has no per-function cleanup — `trap ... RETURN` is bash's alone — and
 # an installer that leaves a temp directory behind on every failed attempt
 # fills a machine over time.
-work="$(mktemp -d)" || { echo "install.sh: nowhere to download to" >&2; exit 1; }
+work="$(mktemp -d)" || { message temporary-directory-unavailable "${TMPDIR:-/tmp}" "No temporary download directory could be created." >&2; exit 1; }
 trap 'rm -rf "$work"' EXIT
 
 # Where kendex keeps its own state, spelled the way the app's resolver
@@ -93,7 +105,7 @@ done
 # a signature under the release key covers the bytes it fetched. A machine
 # kept current by re-running this script never gets that check.
 install_cli() {
-  echo "Downloading the kendex command ($target)…"
+  message command-download "$target" "Downloading the kendex command."
   # curl exits 22 on an HTTP error — here a 404 for an asset the release
   # lacks; any other failure is the network, not the release. Testing curl
   # in the condition and reading `$?` in the else is what keeps that code:
@@ -102,8 +114,8 @@ install_cli() {
     :
   else
     rc=$?
-    echo "install.sh: could not download kendex-$target from $base" >&2
-    [ "$rc" -eq 22 ] && echo "  release $version may have no build for $target (see https://github.com/$repo/releases)" >&2
+    message command-download-failed "$rc" "Could not download kendex-$target from $base." >&2
+    [ "$rc" -eq 22 ] && message release-asset-unavailable "$target" "Release $version may have no build for this target (see https://github.com/$repo/releases)." >&2
     exit 1
   fi
   chmod +x "$work/kendex"
@@ -113,7 +125,7 @@ install_cli() {
   if [ -w "$bindir" ]; then
     install -m 0755 "$work/kendex" "$bindir/kendex"
   else
-    echo "Installing to $bindir needs elevated permissions."
+    message privilege-required "$bindir" "Installing the command here needs elevated permissions."
     # The branch is taken because the directory is not writable, whether or
     # not it exists. Two commands rather than the one `install -D` that
     # made the directory itself: -D makes directories on GNU coreutils
@@ -134,7 +146,7 @@ install_cli() {
     [ -d "$bindir" ] || sudo mkdir -m 0755 -p "$bindir"
     sudo install -m 0755 "$work/kendex" "$bindir/kendex"
   fi
-  echo "Installed the kendex command to $bindir/kendex"
+  message command-installed "$bindir/kendex" "The kendex command is installed."
   # What this script installed, so the desktop app can tell this file from
   # any other executable someone has named `kendex` — a wrapper script in a
   # writable directory answers every other test the same way, and the app
@@ -144,7 +156,7 @@ install_cli() {
   state="$(kendex_data)"
   if ! { mkdir -p "$state" 2>/dev/null \
      && printf '%s\n' "$bindir/kendex" > "$state/installed-command"; }; then
-    echo "install.sh: could not record the command's identity in $state; the desktop app will not update it." >&2
+    message command-record-failed "$state/installed-command" "The command identity could not be recorded; the desktop app will not update it." >&2
   fi
 }
 
@@ -163,9 +175,9 @@ install_icon() {
   size=${size##*/}
   file="$work/$size.png"
   if ! curl -fsSL --proto '=https' -o "$file" "$source"; then
-    echo "install.sh: no $size icon this time; kendex keeps the one it has." >&2
+    message icon-download-failed "$size" "The icon could not be downloaded; kendex keeps the one it has." >&2
   elif ! { mkdir -p "$dir" && install -m 0644 "$file" "$dir/kendex.png"; }; then
-    echo "install.sh: cannot write $dir; skipped the $size icon." >&2
+    message icon-install-failed "$dir" "The icon could not be written and was skipped." >&2
   fi
   return 0
 }
@@ -213,10 +225,10 @@ install_app_linux() {
   local data libdir
   data="${XDG_DATA_HOME:-$HOME/.local/share}"
   libdir="$(kendex_data)"
-  echo "Downloading the desktop app…"
+  message app-download "$appimage_arch" "Downloading the desktop app."
   if ! curl -fSL --proto '=https' -o "$work/kendex.AppImage" \
       "$base/kendex_${plain}_${appimage_arch}.AppImage"; then
-    echo "install.sh: could not download the desktop app; the kendex command is installed." >&2
+    message app-download-failed "$appimage_arch" "The desktop app could not be downloaded; the kendex command is installed." >&2
     return 0
   fi
   mkdir -p "$libdir" "$data/applications"
@@ -241,19 +253,19 @@ StartupWMClass=kendex-app
 Categories=Development;Utility;
 Terminal=false
 DESKTOP
-  echo "Installed the desktop app to $libdir/kendex.AppImage"
+  message app-installed "$libdir/kendex.AppImage" "The desktop app is installed."
 }
 
 install_cli
 if [ "$kind" = linux ]; then
   install_app_linux
 else
-  echo "Desktop app: brew install vanillagreencom/kendex/kendex, or https://kendex.ai/download"
+  message app-install-method macos "Desktop app: brew install vanillagreencom/kendex/kendex, or https://kendex.ai/download"
 fi
 
 case ":$PATH:" in
   *":$bindir:"*) ;;
-  *) echo "Note: $bindir is not on your PATH. Add it, e.g.:"
+  *) message path-missing "$bindir" "This directory is not on your PATH. Add it, for example:"
      echo "  echo 'export PATH=\"$bindir:\$PATH\"' >> ~/.profile" ;;
 esac
 "$bindir/kendex" --version || true

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ version="latest"
 while [ $# -gt 0 ]; do
   case "$1" in
     --version)
-      [ "$#" -ge 2 ] || { message missing-option-value --version "A version must follow --version." >&2; exit 2; }
+      [ "$#" -ge 2 ] && [ -n "$2" ] || { message missing-option-value --version "A version must follow --version." >&2; exit 2; }
       version="$2"; shift 2 ;;
     -h|--help)
       message usage install.sh "Usage: install.sh [--version vX.Y.Z]"
@@ -114,8 +114,9 @@ install_cli() {
     :
   else
     rc=$?
-    message command-download-failed "$rc" "Could not download kendex-$target from $base." >&2
-    [ "$rc" -eq 22 ] && message release-asset-unavailable "$target" "Release $version may have no build for this target (see https://github.com/$repo/releases)." >&2
+    message command-download-failed "$rc" "The kendex command could not be downloaded." >&2
+    message command-download-url "$base/kendex-$target" "The command download used this URL." >&2
+    [ "$rc" -eq 22 ] && message release-http-error "$target" "The release server returned an HTTP error for this target." >&2
     exit 1
   fi
   chmod +x "$work/kendex"
@@ -265,7 +266,6 @@ fi
 
 case ":$PATH:" in
   *":$bindir:"*) ;;
-  *) message path-missing "$bindir" "This directory is not on your PATH. Add it, for example:"
-     echo "  echo 'export PATH=\"$bindir:\$PATH\"' >> ~/.profile" ;;
+  *) message path-missing "$bindir" "Add this directory to PATH in your shell profile." ;;
 esac
 "$bindir/kendex" --version || true


### PR DESCRIPTION
The outside-project CLI test could discover the real account's harness markers when its temporary home lived under that account. The Unix test now runs from the filesystem root and checks exit 1. The sandboxed-home test has a private ancestor project and checks that its declared skill is installed there. This prevents the fixture from reaching the real account while proving that the fake home is skipped. Project discovery behavior stays unchanged.

Installer notices and refusals now start with `install.sh: KEY=VALUE`, followed by English explanation. Installer tests check those keys, values, and exit codes. Download failures retain curl's exit code and distinguish HTTP errors from connection failures without assuming an asset is missing. Dynamic values stay in escaped fields. The shared message writer escapes backslashes and newlines in values.

Validation: the affected CLI, sandbox, installer-script and desktop-installer suites pass (11, 2, 13 and 9 tests). A temporary production change accepting a missing project as global fails the project-scope assertion. Changing the shared installer prefix fails the message-key assertion. Both controls are removed. The empty-version regression row failed before its correction and now passes. Substituting the sandbox home for the real home in project discovery fails the ancestor-install assertion; that control is removed. A failed-transfer fixture leaves a partial file; removing the installer's exit then fails the download assertion. That control is removed. Full validation passed on `53ddd63480830afc99aea61f721ee951dc858f25`, using the ordinary system temporary directory (`env -u TMPDIR tools/guard --full`). The same inherited-ancestor assumption in a core fixture is handled in #2456.

Unchanged tests retain the earlier CLI package audit dispositions. This PR does not claim a new review of every unchanged file. The known fixture failure and the new installer-message rule are the changes to that earlier disposition.

Compliant test files left unchanged:

- `crates/cli/tests/add_kinds.rs`
- `crates/cli/tests/bundles_cli.rs`
- `crates/cli/tests/catalog_check.rs`
- `crates/cli/tests/catalog_check/render_lint.rs`
- `crates/cli/tests/cli_smoke.rs`
- `crates/cli/tests/command_record.rs`
- `crates/cli/tests/commit_offer_cli.rs`
- `crates/cli/tests/compat.rs`
- `crates/cli/tests/compat/report.rs`
- `crates/cli/tests/deps_cli.rs`
- `crates/cli/tests/fixture_global_root.rs`
- `crates/cli/tests/guard_hooks/arming.rs`
- `crates/cli/tests/guard_hooks/consent.rs`
- `crates/cli/tests/guard_hooks/gating.rs`
- `crates/cli/tests/guard_hooks/main.rs`
- `crates/cli/tests/index_cli.rs`
- `crates/cli/tests/install_ux/adopting.rs`
- `crates/cli/tests/install_ux/cloning.rs`
- `crates/cli/tests/install_ux/code_scrub.rs`
- `crates/cli/tests/install_ux/coexistence.rs`
- `crates/cli/tests/install_ux/disclosing.rs`
- `crates/cli/tests/install_ux/guarding.rs`
- `crates/cli/tests/install_ux/installing.rs`
- `crates/cli/tests/install_ux/main.rs`
- `crates/cli/tests/installer/desktop.rs`
- `crates/cli/tests/installer/icons.rs`
- `crates/cli/tests/instruction_shims_cli.rs`
- `crates/cli/tests/marketplace_author.rs`
- `crates/cli/tests/marketplace_cli.rs`
- `crates/cli/tests/missing_remedy.rs`
- `crates/cli/tests/packaging_recipes.rs`
- `crates/cli/tests/pi_extension_only_lock.rs`
- `crates/cli/tests/pi_staleness.rs`
- `crates/cli/tests/presentation/main.rs`
- `crates/cli/tests/presentation/plain.rs`
- `crates/cli/tests/presentation/pretty.rs`
- `crates/cli/tests/presentation/snapshots.rs`
- `crates/cli/tests/presentation/verbs.rs`
- `crates/cli/tests/refresh_ledger/conflicts.rs`
- `crates/cli/tests/refresh_ledger/main.rs`
- `crates/cli/tests/release_workflow/channel.rs`
- `crates/cli/tests/release_workflow/channel_point.rs`
- `crates/cli/tests/release_workflow/channel_point_failure.rs`
- `crates/cli/tests/release_workflow/main.rs`
- `crates/cli/tests/release_workflow/signing.rs`
- `crates/cli/tests/remote_e2e.rs`
- `crates/cli/tests/safety_print.rs`
- `crates/cli/tests/support/pty.rs`
- `crates/cli/tests/terms_first_run.rs`
- `crates/cli/tests/unmanaged.rs`
- `crates/cli/tests/unmanaged_exits/main.rs`
- `crates/cli/tests/unmanaged_exits/refusals.rs`
- `crates/cli/tests/unmanaged_names.rs`
- `crates/cli/tests/update_pi.rs`

Unchanged unit-test files:

- `crates/cli/src/commands/add_collection.rs`
- `crates/cli/src/commands/advisory.rs`
- `crates/cli/src/commands/blocked.rs`
- `crates/cli/src/commands/check.rs`
- `crates/cli/src/commands/commit_offer/tests.rs`
- `crates/cli/src/commands/update/tests.rs`
- `crates/cli/src/scope.rs`
- `crates/cli/src/ui.rs`
- `crates/cli/src/ui/prompt.rs`
- `crates/cli/src/ui/refusal.rs`

Refs KEN-1241.
