### PR TITLE
test(KEN-1241): audit pi-session-manager test surfaces

### DIFF
--- a/pi-extensions/pi-session-manager/tests/lib/session-fixture.ts
+++ b/pi-extensions/pi-session-manager/tests/lib/session-fixture.ts
@@ -1,0 +1,10 @@
+import { afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+export function sessionFixture(): string {
+	mkdirSync(join(process.cwd(), "tmp"), { recursive: true });
+	const root = mkdtempSync(join(process.cwd(), "tmp", "session-manager-"));
+	afterEach(() => rmSync(root, { recursive: true, force: true }));
+	return root;
+}

--- a/pi-extensions/pi-session-manager/tests/session-data.test.ts
+++ b/pi-extensions/pi-session-manager/tests/session-data.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { sessionFixture } from "./lib/session-fixture.ts";
+
+mock.module("@earendil-works/pi-tui", () => ({
+	truncateToWidth: (text: string, width: number) => text.slice(0, width),
+	visibleWidth: (text: string) => text.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g, "").length,
+}));
+
+afterEach(async () => {
+	const { sessionUserMessagesCache } = await import("../extensions/session-data.ts");
+	sessionUserMessagesCache.clear();
+});
+
+test("session user messages select user text, image markers and timestamps", async () => {
+	const { userMessagesForSession } = await import("../extensions/session-data.ts");
+	const dir = sessionFixture();
+	const path = join(dir, "session.jsonl");
+	writeFileSync(path, [
+		JSON.stringify({ type: "message", timestamp: "2026-06-04T00:00:00.000Z", message: { role: "user", content: [{ type: "text", text: "first prompt" }] } }),
+		JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "answer" }] } }),
+		JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "image" }, { type: "text", text: "second prompt" }] } }),
+	].join("\n"));
+
+	const messages = userMessagesForSession({ path, firstMessage: "", name: "" } as never);
+	expect(messages.map((message) => message.text)).toEqual(["first prompt", "[image] second prompt"]);
+	expect(messages[0]?.timestamp).toBe(new Date("2026-06-04T00:00:00.000Z").getTime());
+});

--- a/pi-extensions/pi-session-manager/tests/session-lines.test.ts
+++ b/pi-extensions/pi-session-manager/tests/session-lines.test.ts
@@ -1,29 +1,12 @@
-import { afterEach, expect, mock, test } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { sessionFixture } from "./lib/session-fixture.ts";
+
 import { forEachSessionJsonlLine } from "../extensions/session-lines.ts";
 
-mock.module("@earendil-works/pi-tui", () => ({
-	truncateToWidth: (text: string, width: number) => text.slice(0, width),
-	visibleWidth: (text: string) => text.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g, "").length,
-}));
-
-const root = join(process.cwd(), "tmp", "session-manager-lines");
-
-function resetRoot(): void {
-	rmSync(root, { recursive: true, force: true });
-	mkdirSync(root, { recursive: true });
-}
-
-afterEach(async () => {
-	const { sessionUserMessagesCache } = await import("../extensions/session-data.ts");
-	sessionUserMessagesCache.clear();
-	rmSync(root, { recursive: true, force: true });
-});
-
 test("session JSONL line reader streams across small chunks", () => {
-	resetRoot();
-	const dir = mkdtempSync(join(root, "case-"));
+	const dir = sessionFixture();
 	const path = join(dir, "chunks.jsonl");
 	writeFileSync(path, "one\r\ntwo\nthree");
 	const lines: string[] = [];
@@ -31,18 +14,3 @@ test("session JSONL line reader streams across small chunks", () => {
 	expect(lines).toEqual(["one", "two", "three"]);
 });
 
-test("session user messages parse without loading the whole JSONL file", async () => {
-	const { userMessagesForSession } = await import("../extensions/session-data.ts");
-	resetRoot();
-	const dir = mkdtempSync(join(root, "case-"));
-	const path = join(dir, "session.jsonl");
-	writeFileSync(path, [
-		JSON.stringify({ type: "message", timestamp: "2026-06-04T00:00:00.000Z", message: { role: "user", content: [{ type: "text", text: "first prompt" }] } }),
-		JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "answer" }] } }),
-		JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "image" }, { type: "text", text: "second prompt" }] } }),
-	].join("\n"));
-
-	const messages = userMessagesForSession({ path, firstMessage: "", name: "" } as never);
-	expect(messages.map((message) => message.text)).toEqual(["first prompt", "[image] second prompt"]);
-	expect(messages[0]?.timestamp).toBe(new Date("2026-06-04T00:00:00.000Z").getTime());
-});

--- a/pi-extensions/pi-session-manager/tests/tree.test.ts
+++ b/pi-extensions/pi-session-manager/tests/tree.test.ts
@@ -1,31 +1,37 @@
 import { expect, test } from "bun:test";
 import { buildSessionTree } from "../extensions/tree.ts";
+import type { SessionInfo } from "../extensions/types.ts";
 
-function session(path: string, modified: string, parentSessionPath?: string) {
-	return {
-		path,
-		parentSessionPath,
-		modified: new Date(modified),
-	} as any;
+function session(path: string, modified: string, parentSessionPath?: string): SessionInfo {
+	return { path, parentSessionPath, modified: new Date(modified) } as SessionInfo;
 }
 
-test("session trees sort roots by latest activity anywhere in each subtree", () => {
-	const roots = buildSessionTree([
-		session("/older-root.jsonl", "2026-01-01T00:00:00Z"),
-		session("/recent-child.jsonl", "2026-03-01T00:00:00Z", "/older-root.jsonl"),
-		session("/newer-root.jsonl", "2026-02-01T00:00:00Z"),
-	]);
-
-	expect(roots.map((node) => node.session.path)).toEqual(["/older-root.jsonl", "/newer-root.jsonl"]);
-});
-
-test("session trees sort siblings by latest descendant activity", () => {
-	const roots = buildSessionTree([
-		session("/root.jsonl", "2026-01-01T00:00:00Z"),
-		session("/older-child.jsonl", "2026-01-02T00:00:00Z", "/root.jsonl"),
-		session("/recent-grandchild.jsonl", "2026-04-01T00:00:00Z", "/older-child.jsonl"),
-		session("/newer-child.jsonl", "2026-03-01T00:00:00Z", "/root.jsonl"),
-	]);
-
-	expect(roots[0]?.children.map((node) => node.session.path)).toEqual(["/older-child.jsonl", "/newer-child.jsonl"]);
-});
+for (const row of [
+	{
+		name: "roots sort by latest activity anywhere in each subtree",
+		sessions: [
+			session("/older-root.jsonl", "2026-01-01T00:00:00Z"),
+			session("/recent-child.jsonl", "2026-03-01T00:00:00Z", "/older-root.jsonl"),
+			session("/newer-root.jsonl", "2026-02-01T00:00:00Z"),
+		],
+		children: false,
+		expected: ["/older-root.jsonl", "/newer-root.jsonl"],
+	},
+	{
+		name: "siblings sort by latest descendant activity",
+		sessions: [
+			session("/root.jsonl", "2026-01-01T00:00:00Z"),
+			session("/older-child.jsonl", "2026-01-02T00:00:00Z", "/root.jsonl"),
+			session("/recent-grandchild.jsonl", "2026-04-01T00:00:00Z", "/older-child.jsonl"),
+			session("/newer-child.jsonl", "2026-03-01T00:00:00Z", "/root.jsonl"),
+		],
+		children: true,
+		expected: ["/older-child.jsonl", "/newer-child.jsonl"],
+	},
+]) {
+	test(row.name, () => {
+		const roots = buildSessionTree(row.sessions);
+		const nodes = row.children ? roots[0]?.children : roots;
+		expect(nodes?.map((node) => node.session.path)).toEqual(row.expected);
+	});
+}


### PR DESCRIPTION
Session-manager tests shared a fixed temporary directory and mixed line reading with message parsing. The tests now own their temporary directory, separate those functions, and table root versus sibling activity ordering.

Validation: affected suite passes (4 tests). Planted defects in CRLF handling, user-role selection, and descendant activity each failed their target tests. `tools/guard --full` exits 0 on 2028e1bd8 with system temporary storage (`env -u TMPDIR`). The first run exposed the existing CLI ancestor-discovery fixture defect with inherited TMPDIR; the CLI audit lane owns that fix.

Changed test files: `tests/session-lines.test.ts`, `tests/session-data.test.ts`, `tests/tree.test.ts`, and neutral fixture `tests/lib/session-fixture.ts`, all under `pi-extensions/pi-session-manager/`.
Compliant test files left unchanged: none. All original package test files required changes. Declined: none.

Linear: KEN-1241.
