### PR TITLE
test(KEN-1241): audit nested instruction contracts

### DIFF
--- a/pi-extensions/pi-nested-agents-md/CHANGELOG.md
+++ b/pi-extensions/pi-nested-agents-md/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### 0.1.0
 
-- First release. On a successful `read`, every `AGENTS.md` between the file's directory and the project root that Pi did not load at startup is appended to the read result once per session, root-most first; a file that cannot be read is reported in one line instead. Master `enabled` toggle via pi-extension-manager.
+- First release. On a successful `read`, every `AGENTS.md` between the file's directory and the project root that Pi did not load at startup is appended to the read result once per session, root-most first; a file that cannot be read is reported with a path key followed by an explanation instead. Master `enabled` toggle via pi-extension-manager.

--- a/pi-extensions/pi-nested-agents-md/DEVELOPMENT.md
+++ b/pi-extensions/pi-nested-agents-md/DEVELOPMENT.md
@@ -8,7 +8,7 @@ For maintainers. What it does for a consumer is [README.md](README.md); the mech
 - The project root is kendex's own rule, `extensions/config.ts::projectRoot` copying `crates/core/src/discover.rs::project_root_from` with the marker set and lock file pi-hooks carries. The root this finds is the root kendex rendered shims into; a marker only one side knows is an `AGENTS.md` attached from the wrong tree or never.
 - Order is root-most first, the order Claude Code layers nested `CLAUDE.md`; `directoriesBetween` throws rather than walk to the filesystem top when handed a file outside the root, because its callers hold that precondition.
 - A file is recorded as attached when taken, the unreadable ones included, so the model hears about each file once per session; the record is replaced on every `session_start`.
-- An unreadable `AGENTS.md` never fails the read. The block is one line naming the file and the reason.
+- An unreadable `AGENTS.md` never fails the read. The first line gives `unreadable_path` and the file path. The next line explains the failure.
 - Project settings are read only after `recordProjectTrust` saw Pi report the workspace trusted, and `PI_CODING_AGENT_DIR` counts only when root-anchored, matching `crates/core/src/harness/pi.rs::pi_root_is_absolute_for`.
 
 ## Tests

--- a/pi-extensions/pi-nested-agents-md/extensions/nested-agents-md.ts
+++ b/pi-extensions/pi-nested-agents-md/extensions/nested-agents-md.ts
@@ -6,6 +6,12 @@ import { getBool, projectRoot, readConfig, recordProjectTrust } from "./config.j
 
 const INSTALL_SYMBOL = Symbol.for("kendex.pi-nested-agents-md.installed");
 
+const messages = {
+	attached: (path: string, content: string) => `instructions_path=${path}\n${content}`,
+	outsideRoot: (file: string, root: string) => `outside_root=${file}\nThe directory walk started outside ${root}.`,
+	unreadable: (path: string, reason: string) => `unreadable_path=${path}\nThe instructions could not be read: ${reason.replace(/\s+/g, " ").trim()}`,
+};
+
 /** The one file name the walk looks for. Pi's own loader also takes
  * `AGENTS.override.md` and `CLAUDE.md`; the shim convention kendex renders
  * puts a directory's instructions in this file, so it is the only one here. */
@@ -13,8 +19,7 @@ export const INSTRUCTIONS_FILE = "AGENTS.md";
 
 /** One instructions file the walk reached: `path` is what the session now
  * counts as attached, `text` the block that goes into the read result — the
- * file's content under a line naming it, or the one line saying why there is
- * none. */
+ * file's content under a line naming it, or a diagnostic naming the missing instructions. */
 export interface Attachment {
 	path: string;
 	text: string;
@@ -54,7 +59,7 @@ export function directoriesBetween(file: string, root: string): string[] {
 		dirs.push(current);
 		const parent = dirname(current);
 		if (parent === current) {
-			throw new Error(`pi-nested-agents-md: ${file} is not under ${root}; the walk was started outside the project`);
+			throw Object.assign(new Error(messages.outsideRoot(file, root)), { code: "OUTSIDE_ROOT", path: file, root });
 		}
 		current = parent;
 	}
@@ -70,7 +75,7 @@ function loadedByPi(dir: string, cwd: string): boolean {
 
 /**
  * The content of one instructions file as the block that carries it, or the
- * one line that stands in for it. A file the extension cannot read is not a
+ * diagnostic that stands in for it. A file the extension cannot read is not a
  * throw: a `read` that succeeded stays succeeded, and the model is told which
  * instructions it did not get.
  */
@@ -80,9 +85,9 @@ function block(path: string): string {
 		content = readFileSync(path, "utf8");
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
-		return `[pi-nested-agents-md: ${path} could not be read (${reason.replace(/\s+/g, " ").trim()}); its instructions are not attached]`;
+		return messages.unreadable(path, reason);
 	}
-	return `[Directory instructions from ${path}]\n${content}`;
+	return messages.attached(path, content);
 }
 
 /**

--- a/pi-extensions/pi-nested-agents-md/tests/directories-between.test.ts
+++ b/pi-extensions/pi-nested-agents-md/tests/directories-between.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { directoriesBetween } from "../extensions/nested-agents-md.ts";
+
+for (const row of [
+	{ name: "root-most first with root excluded", file: "/r/a/b/x.ts", expected: ["/r/a", "/r/a/b"] },
+	{ name: "root file excludes the root", file: "/r/x.ts", expected: [] },
+]) {
+	test(row.name, () => {
+		expect(directoriesBetween(row.file, "/r")).toEqual(row.expected);
+	});
+}
+
+test("refuses an outside file before walking beyond the filesystem root", () => {
+	let failure: unknown;
+	try { directoriesBetween("/elsewhere/x.ts", "/r"); } catch (error) { failure = error; }
+	expect(failure).toMatchObject({ code: "OUTSIDE_ROOT", path: "/elsewhere/x.ts", root: "/r" });
+	expect((failure as Error).message.split("\n")[0]).toBe("outside_root=/elsewhere/x.ts");
+});

--- a/pi-extensions/pi-nested-agents-md/tests/nested-agents-md.test.ts
+++ b/pi-extensions/pi-nested-agents-md/tests/nested-agents-md.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { CONFIG_ID } from "../extensions/config.ts";
-import nestedAgentsMd, { directoriesBetween, INSTRUCTIONS_FILE } from "../extensions/nested-agents-md.ts";
+import nestedAgentsMd, { INSTRUCTIONS_FILE } from "../extensions/nested-agents-md.ts";
 
 type Handler = (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown> | unknown;
 
@@ -94,31 +94,21 @@ afterEach(() => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-// The walk's own bound. Every read the handler makes reaches the root through
-// the cwd chain as well, since the root is an ancestor of the cwd, so a walk
-// that overran the root would still attach nothing there; this is what holds
-// the bound itself, and the refusal that keeps a miscall from walking to the
-// filesystem top.
-describe("directoriesBetween", () => {
-	test("lists the directories below the root, root-most first, the root excluded", () => {
-		expect(directoriesBetween("/r/a/b/x.ts", "/r")).toEqual(["/r/a", "/r/a/b"]);
-		expect(directoriesBetween("/r/x.ts", "/r")).toEqual([]);
-	});
-
-	test("refuses a file outside the root rather than walking to the top", () => {
-		expect(() => directoriesBetween("/elsewhere/x.ts", "/r")).toThrow("is not under /r");
-	});
-});
-
 describe("attaching", () => {
-	test("the first read under a directory attaches its AGENTS.md after the file, naming the path", async () => {
-		const root = fixture();
-		const { toolResult } = install();
-		const blocks = texts(await toolResult(readEvent(join(root, "a/shallow.ts")), ctx(root)));
-		expect(blocks).toHaveLength(2);
-		expect(blocks[0]).toBe("the file");
-		expect(blocks[1]).toBe(`[Directory instructions from ${join(root, "a", INSTRUCTIONS_FILE)}]\n# a rules\n`);
-	});
+	for (const row of [
+		{ name: "a shallow absolute read", path: "a/shallow.ts", relative: false, instructions: ["a"], repeat: undefined },
+		{ name: "a deep read orders both files and consumes the shallow file", path: "a/b/deep.ts", relative: false, instructions: ["a", "a/b"], repeat: "a/shallow.ts" },
+		{ name: "a relative read resolves against the session cwd", path: "a/shallow.ts", relative: true, instructions: ["a"], repeat: undefined },
+	]) {
+		test(row.name, async () => {
+			const root = fixture();
+			const { toolResult } = install();
+			const blocks = texts(await toolResult(readEvent(row.relative ? row.path : join(root, row.path)), ctx(root)));
+			expect(blocks).toEqual(["the file", ...row.instructions.map((dir) =>
+				`instructions_path=${join(root, dir, INSTRUCTIONS_FILE)}\n# ${dir === "a" ? "a" : "b"} rules\n`)]);
+			if (row.repeat) expect(await toolResult(readEvent(join(root, row.repeat)), ctx(root))).toBeUndefined();
+		});
+	}
 
 	test("the project root's own AGENTS.md is never attached", async () => {
 		const root = fixture();
@@ -136,25 +126,6 @@ describe("attaching", () => {
 		expect(await toolResult(readEvent(join(root, "a/other.ts")), ctx(root))).toBeUndefined();
 	});
 
-	test("a read two levels deep attaches both intermediate files, root-most first", async () => {
-		const root = fixture();
-		const { toolResult } = install();
-		const blocks = texts(await toolResult(readEvent(join(root, "a/b/deep.ts")), ctx(root)));
-		expect(blocks).toHaveLength(3);
-		expect(blocks[1]).toContain(join(root, "a", INSTRUCTIONS_FILE));
-		expect(blocks[1]).toContain("# a rules");
-		expect(blocks[2]).toContain(join(root, "a", "b", INSTRUCTIONS_FILE));
-		expect(blocks[2]).toContain("# b rules");
-		// The deep read took `a/` with it, so a shallower read has nothing left.
-		expect(await toolResult(readEvent(join(root, "a/shallow.ts")), ctx(root))).toBeUndefined();
-	});
-
-	test("a relative path resolves against the session's cwd", async () => {
-		const root = fixture();
-		const { toolResult } = install();
-		const blocks = texts(await toolResult(readEvent("a/shallow.ts"), ctx(root)));
-		expect(blocks[1]).toContain("# a rules");
-	});
 
 	test("a directory Pi loaded at startup — the cwd or one above it — is not attached again", async () => {
 		const root = fixture();
@@ -178,19 +149,19 @@ describe("attaching", () => {
 });
 
 describe("attaching nothing", () => {
-	test("a path outside the project root, spelled directly or reached through a symlink", async () => {
-		const root = fixture();
-		const outside = realpathSync(mkdtempSync(join(tmpdir(), "pi-nested-agents-md-outside-")));
-		roots.push(outside);
-		write(outside, `${INSTRUCTIONS_FILE}`, "# outside rules\n");
-		write(outside, "leaf/file.ts", "x");
-		symlinkSync(outside, join(root, "a", "escape"));
-		const { toolResult } = install();
-		expect(await toolResult(readEvent(join(outside, "leaf/file.ts")), ctx(root))).toBeUndefined();
-		// The spelled path sits under `a/`, whose AGENTS.md has not been
-		// attached; the file it resolves to does not, so not even that is.
-		expect(await toolResult(readEvent(join(root, "a/escape/leaf/file.ts")), ctx(root))).toBeUndefined();
-	});
+	for (const spelling of ["direct", "symlink"] as const) {
+		test(`a path outside the project root through ${spelling}`, async () => {
+			const root = fixture();
+			const outside = realpathSync(mkdtempSync(join(tmpdir(), "pi-nested-agents-md-outside-")));
+			roots.push(outside);
+			write(outside, `${INSTRUCTIONS_FILE}`, "# outside rules\n");
+			write(outside, "leaf/file.ts", "x");
+			symlinkSync(outside, join(root, "a", "escape"));
+			const { toolResult } = install();
+			const path = spelling === "direct" ? join(outside, "leaf/file.ts") : join(root, "a/escape/leaf/file.ts");
+			expect(await toolResult(readEvent(path), ctx(root))).toBeUndefined();
+		});
+	}
 
 	test("a directory holding no AGENTS.md", async () => {
 		const root = fixture();
@@ -207,14 +178,17 @@ describe("attaching nothing", () => {
 		expect(await toolResult(readEvent(join(bare, "a/file.ts")), ctx(bare))).toBeUndefined();
 	});
 
-	test("a failed read, and a tool other than read", async () => {
-		const root = fixture();
-		const { toolResult } = install();
-		expect(await toolResult({ ...readEvent(join(root, "a/shallow.ts")), isError: true }, ctx(root))).toBeUndefined();
-		expect(await toolResult({ ...readEvent(join(root, "a/shallow.ts")), toolName: "bash" }, ctx(root))).toBeUndefined();
-		// Neither consumed `a/`: the next real read still attaches it.
-		expect(texts(await toolResult(readEvent(join(root, "a/shallow.ts")), ctx(root)))).toHaveLength(2);
-	});
+	for (const row of [
+		{ name: "a failed read", patch: { isError: true } },
+		{ name: "a tool other than read", patch: { toolName: "bash" } },
+	]) {
+		test(row.name, async () => {
+			const root = fixture();
+			const { toolResult } = install();
+			expect(await toolResult({ ...readEvent(join(root, "a/shallow.ts")), ...row.patch }, ctx(root))).toBeUndefined();
+			expect(texts(await toolResult(readEvent(join(root, "a/shallow.ts")), ctx(root)))).toHaveLength(2);
+		});
+	}
 
 	test("the master toggle off, read from the trusted project's settings", async () => {
 		const root = fixture();
@@ -231,7 +205,7 @@ describe("attaching nothing", () => {
 
 describe("an unreadable AGENTS.md", () => {
 	// Root reads a mode-000 file, so under it the case cannot be planted.
-	test.skipIf(process.getuid?.() === 0)("is reported in one line, once, and the read still succeeds", async () => {
+	test.skipIf(process.getuid?.() === 0)("reports its key and path once while the read succeeds", async () => {
 		const root = fixture();
 		const unreadable = join(root, "a", INSTRUCTIONS_FILE);
 		chmodSync(unreadable, 0o000);
@@ -239,8 +213,7 @@ describe("an unreadable AGENTS.md", () => {
 			const { toolResult } = install();
 			const blocks = texts(await toolResult(readEvent(join(root, "a/b/deep.ts")), ctx(root)));
 			expect(blocks).toHaveLength(3);
-			expect(blocks[1]).not.toContain("\n");
-			expect(blocks[1]).toContain(unreadable);
+			expect(blocks[1]?.split("\n")[0]).toBe(`unreadable_path=${unreadable}`);
 			expect(blocks[1]).not.toContain("# a rules");
 			expect(blocks[2]).toContain("# b rules");
 			expect(await toolResult(readEvent(join(root, "a/shallow.ts")), ctx(root))).toBeUndefined();

--- a/pi-extensions/pi-nested-agents-md/tests/nested-agents-md.test.ts
+++ b/pi-extensions/pi-nested-agents-md/tests/nested-agents-md.test.ts
@@ -214,6 +214,7 @@ describe("an unreadable AGENTS.md", () => {
 			const blocks = texts(await toolResult(readEvent(join(root, "a/b/deep.ts")), ctx(root)));
 			expect(blocks).toHaveLength(3);
 			expect(blocks[1]?.split("\n")[0]).toBe(`unreadable_path=${unreadable}`);
+			expect(blocks[1]?.split("\n")[1]?.length).toBeGreaterThan(0);
 			expect(blocks[1]).not.toContain("# a rules");
 			expect(blocks[2]).toContain("# b rules");
 			expect(await toolResult(readEvent(join(root, "a/shallow.ts")), ctx(root))).toBeUndefined();


### PR DESCRIPTION
Nested instruction tests mixed directory walking with attachment lifecycle and pinned English error text. The extension now centralizes notices with stable path keys and places explanations below. Tests split the walk contract and table input paths while retaining session reset, settings changes, attachment order, and unreadable-file behavior.

Validation: package suite passes (18 tests). Planted defects in directory order, attachment order, and unreadable-path notices each failed their target tests. `env -u TMPDIR tools/guard --full` exits 0 on e62ee339f. The first run exposed the existing CLI ancestor-discovery fixture defect with inherited TMPDIR; the CLI audit lane owns that fix.

Changed: `pi-extensions/pi-nested-agents-md/extensions/nested-agents-md.ts`, `tests/nested-agents-md.test.ts`, `tests/directories-between.test.ts`, `DEVELOPMENT.md`, and `CHANGELOG.md` in the same package.
Compliant test files left unchanged: none. The original package test file required changes. Declined: none.

Linear: KEN-1241.
