### PR TITLE
test(KEN-1241): audit task panel state contracts

### DIFF
--- a/pi-extensions/pi-task-panel/extensions/diagnostics.ts
+++ b/pi-extensions/pi-task-panel/extensions/diagnostics.ts
@@ -24,7 +24,7 @@ export function reportTaskPanelPersistenceFailure(where: string, error: unknown,
 	logTaskPanelDiagnostic("persistence failed", { where, error: msg });
 	try {
 		ctx?.ui.notify?.(
-			`Task panel state persistence failed (${where}). Falling back to session history where available.`,
+			`persistence_failure=${where}\nTask panel state persistence failed. Falling back to session history where available.`,
 			"warning",
 		);
 	} catch {

--- a/pi-extensions/pi-task-panel/tests/diagnostics.test.ts
+++ b/pi-extensions/pi-task-panel/tests/diagnostics.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { reportTaskPanelPersistenceFailure } from "../extensions/diagnostics.ts";
+
+for (const operation of ["sidecar-read", "sidecar-write"]) {
+	test(`persistence notice identifies ${operation}`, () => {
+		const root = mkdtempSync(join(tmpdir(), "task-panel-diagnostics-"));
+		const previous = process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG;
+		try {
+			process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG = join(root, "diagnostics.log");
+			const notices: Array<{ message: string; level: string }> = [];
+			reportTaskPanelPersistenceFailure(operation, new Error("fixture failure"), {
+				ui: { notify: (message: string, level: string) => notices.push({ message, level }) },
+			} as never);
+			expect(notices.map(({ message, level }) => ({ key: message.split("\n")[0], level }))).toEqual([
+				{ key: `persistence_failure=${operation}`, level: "warning" },
+			]);
+		} finally {
+			if (previous === undefined) delete process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG;
+			else process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG = previous;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+}

--- a/pi-extensions/pi-task-panel/tests/extension-sidecar-fallback.test.ts
+++ b/pi-extensions/pi-task-panel/tests/extension-sidecar-fallback.test.ts
@@ -1,5 +1,5 @@
 import { expect, mock, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -42,20 +42,6 @@ function fakePi() {
 	};
 }
 
-function failingSidecarEnv(): { base: string; previousPiDir: string | undefined } {
-	const previousPiDir = process.env.PI_CODING_AGENT_DIR;
-	const base = mkdtempSync(join(tmpdir(), "pi-task-panel-sidecar-fail-"));
-	const fileNotDirectory = join(base, "not-a-directory");
-	writeFileSync(fileNotDirectory, "x", "utf8");
-	process.env.PI_CODING_AGENT_DIR = fileNotDirectory;
-	return { base, previousPiDir };
-}
-
-function restorePiDir(previousPiDir: string | undefined): void {
-	if (previousPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-	else process.env.PI_CODING_AGENT_DIR = previousPiDir;
-}
-
 function fakeCtx(base: string, notifications: Array<{ message: string; level: string }>) {
 	return {
 		cwd: base,
@@ -72,61 +58,50 @@ function fakeCtx(base: string, notifications: Array<{ message: string; level: st
 	};
 }
 
-test("tasks_write keeps full details.state and warns when oversized sidecar write fails", async () => {
-	const { base, previousPiDir } = failingSidecarEnv();
-
-	try {
-		const [{ default: taskPanel }, { isTaskPanelToolResultBoundedState }] = await Promise.all([
-			import("../extensions/task-panel.js"),
-			import("../extensions/tool-result-details.js"),
-		]);
-		const pi = fakePi();
-		taskPanel(pi as any);
-		const tasksWrite = pi.tools.get("tasks_write");
-		expect(tasksWrite).toBeDefined();
-
-		const notifications: Array<{ message: string; level: string }> = [];
-		const ctx = fakeCtx(base, notifications);
-		const tasks = Array.from({ length: 200 }, (_value, index) => ({ content: `${"x".repeat(400)} task ${index}` }));
-		const result = await tasksWrite.execute("tool-call-1", { action: "replace", tasks }, undefined, undefined, ctx);
-		const detailsState = result.details.state;
-
-		expect(isTaskPanelToolResultBoundedState(detailsState)).toBe(false);
-		expect(detailsState.tasks).toHaveLength(200);
-		expect(notifications.some((note) => note.level === "warning" && note.message.includes("sidecar-write"))).toBe(true);
-		expect(notifications.some((note) => note.message.includes("tool-result"))).toBe(false);
-	} finally {
-		restorePiDir(previousPiDir);
-	}
-});
-
-test("non-tool task mutations keep full session-entry fallback when oversized sidecar write fails", async () => {
-	const { base, previousPiDir } = failingSidecarEnv();
-
-	try {
-		const [{ default: taskPanel }, { isTaskPanelToolResultBoundedState }] = await Promise.all([
-			import("../extensions/task-panel.js"),
-			import("../extensions/tool-result-details.js"),
-		]);
-		const pi = fakePi();
-		taskPanel(pi as any);
-		const tasksImport = pi.commands.get("tasks:import");
-		expect(tasksImport).toBeDefined();
-
-		const notifications: Array<{ message: string; level: string }> = [];
-		const ctx = fakeCtx(base, notifications);
-		const importPath = join(base, "tasks.md");
-		writeFileSync(importPath, Array.from({ length: 200 }, (_value, index) => `- ${"x".repeat(400)} task ${index}`).join("\n"), "utf8");
-
-		await tasksImport.handler(importPath, ctx);
-
-		const stateEntries = pi.appended.map((entry: any) => entry.data).filter((data: any) => data?.version === 1 || data?.fullSnapshot === false);
-		expect(stateEntries).toHaveLength(1);
-		expect(isTaskPanelToolResultBoundedState(stateEntries[0])).toBe(false);
-		expect(stateEntries[0].tasks).toHaveLength(200);
-		expect(notifications.some((note) => note.level === "warning" && note.message.includes("sidecar-write"))).toBe(true);
-		expect(notifications.some((note) => note.message.includes("tool-result"))).toBe(false);
-	} finally {
-		restorePiDir(previousPiDir);
-	}
-});
+for (const entry of ["tool", "command"] as const) {
+	test(`${entry} keeps full state when oversized sidecar persistence fails`, async () => {
+		const previousPiDir = process.env.PI_CODING_AGENT_DIR;
+		const previousDiagnosticLog = process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG;
+		const base = mkdtempSync(join(tmpdir(), "pi-task-panel-sidecar-fail-"));
+		try {
+			const fileNotDirectory = join(base, "not-a-directory");
+			writeFileSync(fileNotDirectory, "x", "utf8");
+			process.env.PI_CODING_AGENT_DIR = fileNotDirectory;
+			process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG = join(base, "diagnostics.log");
+			const [{ default: taskPanel }, { isTaskPanelToolResultBoundedState }] = await Promise.all([
+				import("../extensions/task-panel.js"), import("../extensions/tool-result-details.js"),
+			]);
+			const pi = fakePi();
+			taskPanel(pi as never);
+			const notifications: Array<{ message: string; level: string }> = [];
+			const ctx = fakeCtx(base, notifications);
+			let detailsState;
+			if (entry === "tool") {
+				const tasksWrite = pi.tools.get("tasks_write");
+				expect(tasksWrite).toBeDefined();
+				const tasks = Array.from({ length: 200 }, (_value, index) => ({ content: `${"x".repeat(400)} task ${index}` }));
+				const result = await tasksWrite.execute("tool-call-1", { action: "replace", tasks }, undefined, undefined, ctx);
+				detailsState = result.details.state;
+			} else {
+				const tasksImport = pi.commands.get("tasks:import");
+				expect(tasksImport).toBeDefined();
+				const importPath = join(base, "tasks.md");
+				writeFileSync(importPath, Array.from({ length: 200 }, (_value, index) => `- ${"x".repeat(400)} task ${index}`).join("\n"), "utf8");
+				await tasksImport.handler(importPath, ctx);
+				const stateEntries = pi.appended.map((entry) => entry.data).filter((data) => data?.version === 1 || data?.fullSnapshot === false);
+				expect(stateEntries).toHaveLength(1);
+				detailsState = stateEntries[0];
+			}
+			expect(isTaskPanelToolResultBoundedState(detailsState)).toBe(false);
+			expect(detailsState.tasks).toHaveLength(200);
+			expect(notifications.filter((note) => note.level === "warning").map((note) => note.message.split("\n")[0])).toEqual(["persistence_failure=sidecar-write"]);
+			expect(notifications.some((note) => note.message.split("\n")[0] === "persistence_failure=tool-result")).toBe(false);
+		} finally {
+			if (previousPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousPiDir;
+			if (previousDiagnosticLog === undefined) delete process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG;
+			else process.env.PI_TASK_PANEL_DIAGNOSTIC_LOG = previousDiagnosticLog;
+			rmSync(base, { recursive: true, force: true });
+		}
+	});
+}

--- a/pi-extensions/pi-task-panel/tests/lib/task-state.ts
+++ b/pi-extensions/pi-task-panel/tests/lib/task-state.ts
@@ -1,0 +1,20 @@
+export function stateWithTasks(count: number, taskText = "Task") {
+	return {
+		autoShownThisSession: true,
+		hiddenByUser: false,
+		lastVisiblePanel: "compact",
+		panel: "compact",
+		phases: [{ id: "phase-1", order: 0, title: "Phase" }],
+		tasks: Array.from({ length: count }, (_value, index) => ({
+			content: `${taskText} ${index}`,
+			id: `task-${index}`,
+			notes: [`note ${index}`],
+			order: index,
+			phaseId: "phase-1",
+			status: index === 0 ? "in_progress" : "pending",
+		})),
+		updatedAt: "2026-05-20T00:00:00.000Z",
+		version: 1,
+	};
+}
+

--- a/pi-extensions/pi-task-panel/tests/tool-result-details.test.ts
+++ b/pi-extensions/pi-task-panel/tests/tool-result-details.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { isTaskPanelToolResultBoundedState, taskPanelToolResultState } from "../extensions/tool-result-details.js";
 import { stateWithTasks } from "./lib/task-state.ts";
 

--- a/pi-extensions/pi-task-panel/tests/tool-result-details.test.ts
+++ b/pi-extensions/pi-task-panel/tests/tool-result-details.test.ts
@@ -1,98 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { isTaskPanelToolResultBoundedState, taskPanelToolResultState } from "../extensions/tool-result-details.js";
+import { stateWithTasks } from "./lib/task-state.ts";
 
-import {
-	applyTaskPanelToolResultRestore,
-	isTaskPanelToolResultBoundedState,
-	taskPanelToolResultState,
-} from "../extensions/tool-result-details.js";
-
-function stateWithTasks(count: number, taskText = "Task"): any {
-	return {
-		autoShownThisSession: true,
-		hiddenByUser: false,
-		lastVisiblePanel: "compact",
-		panel: "compact",
-		phases: [{ id: "phase-1", order: 0, title: "Phase" }],
-		tasks: Array.from({ length: count }, (_value, index) => ({
-			content: `${taskText} ${index}`,
-			id: `task-${index}`,
-			notes: [`note ${index}`],
-			order: index,
-			phaseId: "phase-1",
-			status: index === 0 ? "in_progress" : "pending",
-		})),
-		updatedAt: "2026-05-20T00:00:00.000Z",
-		version: 1,
-	};
-}
-
-function hasStateContent(state: any): boolean {
-	return state.tasks.length > 0 || state.phases.length > 0;
-}
-
-function normalizeState(value: unknown): any {
-	return value;
-}
-
-test("small task-panel tool result details keep full state for legacy restore", () => {
-	const state = stateWithTasks(3);
-	const detailsState = taskPanelToolResultState(state);
-	assert.equal(isTaskPanelToolResultBoundedState(detailsState), false);
-	assert.equal((detailsState as any).tasks.length, 3);
-	assert.notEqual(detailsState, state);
-});
-
-test("large task-panel tool result details downgrade to a compact manifest", () => {
-	const state = stateWithTasks(200, "x".repeat(80));
-	const detailsState = taskPanelToolResultState(state);
-	assert.equal(isTaskPanelToolResultBoundedState(detailsState), true);
-	assert.equal((detailsState as any).counts.tasks, 200);
-	assert.equal((detailsState as any).taskIds.length, 20);
-	assert.equal((detailsState as any).omitted.tasks, 180);
-	assert.equal((detailsState as any).fullSnapshot, false);
-	assert.ok(Buffer.byteLength(JSON.stringify(detailsState), "utf8") <= 4 * 1024);
-	assert.ok(Buffer.byteLength(JSON.stringify({ action: "replace", message: "200 task(s), 200 remaining", summary: "200 tasks written", state: detailsState }), "utf8") <= 4 * 1024);
-});
-
-test("oversized task-panel tool result details downgrade even below task-count threshold", () => {
-	const state = stateWithTasks(2, "x".repeat(80 * 1024));
-	const detailsState = taskPanelToolResultState(state);
-	assert.equal(isTaskPanelToolResultBoundedState(detailsState), true);
-	assert.equal((detailsState as any).reason, "payload-too-large");
-	assert.equal((detailsState as any).counts.tasks, 2);
-	assert.ok(Buffer.byteLength(JSON.stringify(detailsState), "utf8") <= 4 * 1024);
-	assert.ok(Buffer.byteLength(JSON.stringify({ action: "replace", message: "2 task(s), 2 remaining", summary: "2 tasks written", state: detailsState }), "utf8") <= 4 * 1024);
-});
-
-test("tool-result restore barrier re-applies sidecar state after older full details", () => {
-	const sidecarState = stateWithTasks(200, "sidecar");
-	const olderState = stateWithTasks(1, "older");
-	let currentState = sidecarState;
-
-	currentState = applyTaskPanelToolResultRestore({
-		currentState,
-		detailsState: olderState,
-		hasStateContent,
-		normalizeState,
-		sidecarState,
+for (const row of [
+	{ name: "small full snapshot", count: 3, text: "Task", forceFull: false, bounded: false, reason: undefined, sampled: undefined, omitted: undefined },
+	{ name: "task count bounds the snapshot", count: 200, text: "x".repeat(80), forceFull: false, bounded: true, reason: "task-count-threshold", sampled: 20, omitted: 180 },
+	{ name: "bytes bound a snapshot below the task count threshold", count: 2, text: "x".repeat(80 * 1024), forceFull: false, bounded: true, reason: "payload-too-large", sampled: 2, omitted: 0 },
+	{ name: "sidecar failure forces full snapshot", count: 200, text: "x".repeat(80), forceFull: true, bounded: false, reason: undefined, sampled: undefined, omitted: undefined },
+] as const) {
+	test(row.name, () => {
+		const state = stateWithTasks(row.count, row.text);
+		const details = taskPanelToolResultState(state, { forceFullSnapshot: row.forceFull });
+		assert.equal(isTaskPanelToolResultBoundedState(details), row.bounded);
+		assert.notEqual(details, state);
+		if (isTaskPanelToolResultBoundedState(details)) {
+			assert.equal(details.reason, row.reason);
+			assert.equal(details.counts.tasks, row.count);
+			assert.equal(details.taskIds.length, row.sampled);
+			assert.equal(details.omitted.tasks, row.omitted);
+			assert.equal(details.fullSnapshot, false);
+			assert.ok(Buffer.byteLength(JSON.stringify(details), "utf8") <= 4 * 1024);
+			assert.ok(Buffer.byteLength(JSON.stringify({ action: "replace", message: `${row.count} task(s), ${row.count} remaining`, summary: `${row.count} tasks written`, state: details }), "utf8") <= 4 * 1024);
+		} else {
+			assert.equal(details.tasks.length, row.count);
+		}
 	});
-	assert.equal(currentState.tasks[0]?.content, "older 0");
-
-	currentState = applyTaskPanelToolResultRestore({
-		currentState,
-		detailsState: taskPanelToolResultState(sidecarState),
-		hasStateContent,
-		normalizeState,
-		sidecarState,
-	});
-	assert.equal(currentState.tasks.length, 200);
-	assert.equal(currentState.tasks[0]?.content, "sidecar 0");
-});
-
-test("sidecar write failure can force full tool-result state fallback", () => {
-	const state = stateWithTasks(200, "x".repeat(80));
-	const detailsState = taskPanelToolResultState(state, { forceFullSnapshot: true });
-	assert.equal(isTaskPanelToolResultBoundedState(detailsState), false);
-	assert.equal((detailsState as any).tasks.length, 200);
-});
+}

--- a/pi-extensions/pi-task-panel/tests/tool-result-restore.test.ts
+++ b/pi-extensions/pi-task-panel/tests/tool-result-restore.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyTaskPanelToolResultRestore, taskPanelToolResultState } from "../extensions/tool-result-details.js";
+import { stateWithTasks } from "./lib/task-state.ts";
+
+type State = ReturnType<typeof stateWithTasks>;
+function hasStateContent(state: State): boolean {
+	return state.tasks.length > 0 || state.phases.length > 0;
+}
+function normalizeState(value: unknown): State { return value as State; }
+
+test("tool-result restore barrier re-applies sidecar state after older full details", () => {
+	const sidecarState = stateWithTasks(200, "sidecar");
+	const olderState = stateWithTasks(1, "older");
+	let currentState = sidecarState;
+
+	currentState = applyTaskPanelToolResultRestore({
+		currentState,
+		detailsState: olderState,
+		hasStateContent,
+		normalizeState,
+		sidecarState,
+	});
+	assert.equal(currentState.tasks[0]?.content, "older 0");
+
+	currentState = applyTaskPanelToolResultRestore({
+		currentState,
+		detailsState: taskPanelToolResultState(sidecarState),
+		hasStateContent,
+		normalizeState,
+		sidecarState,
+	});
+	assert.equal(currentState.tasks.length, 200);
+	assert.equal(currentState.tasks[0]?.content, "sidecar 0");
+});
+

--- a/pi-extensions/pi-task-panel/tests/tool-result-restore.test.ts
+++ b/pi-extensions/pi-task-panel/tests/tool-result-restore.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { applyTaskPanelToolResultRestore, taskPanelToolResultState } from "../extensions/tool-result-details.js";
 import { stateWithTasks } from "./lib/task-state.ts";
 

--- a/pi-extensions/pi-task-panel/tests/visibility.test.ts
+++ b/pi-extensions/pi-task-panel/tests/visibility.test.ts
@@ -30,11 +30,9 @@ test("task panel auto-shows first task once, then user hide blocks later task mu
 	assert.equal(panel.panel, "hidden");
 	assert.equal(panel.hiddenByUser, true);
 
-	for (const _mutation of ["tasks_write add_task", "tasks_write replace", "tasks_write start_task", "tasks_write mark_done -> new pending"]) {
-		pendingChange(panel);
-		assert.equal(panel.panel, "hidden");
-		assert.equal(panel.hiddenByUser, true);
-	}
+	pendingChange(panel);
+	assert.equal(panel.panel, "hidden");
+	assert.equal(panel.hiddenByUser, true);
 });
 
 test("task panel replace preserves user-hidden visibility snapshot", () => {
@@ -72,23 +70,17 @@ test("task panel explicit toggle-in restores last visible mode", () => {
 	assert.equal(panel.hiddenByUser, false);
 });
 
-test("toggle from compact hides, then reopens compact", () => {
-	const panel = createTaskPanelVisibility("compact");
-	toggleTaskPanelVisibility(panel);
-	assert.equal(panel.panel, "hidden");
-	assert.equal(panel.hiddenByUser, true);
-	toggleTaskPanelVisibility(panel);
-	assert.equal(panel.panel, "compact");
-	assert.equal(panel.hiddenByUser, false);
-});
-
-test("toggle from expanded hides, then reopens expanded", () => {
-	const panel = createTaskPanelVisibility("expanded");
-	toggleTaskPanelVisibility(panel);
-	assert.equal(panel.panel, "hidden");
-	toggleTaskPanelVisibility(panel);
-	assert.equal(panel.panel, "expanded");
-});
+for (const initial of ["compact", "expanded"] as const) {
+	test(`toggle from ${initial} hides and restores that mode`, () => {
+		const panel = createTaskPanelVisibility(initial);
+		toggleTaskPanelVisibility(panel);
+		assert.equal(panel.panel, "hidden");
+		assert.equal(panel.hiddenByUser, true);
+		toggleTaskPanelVisibility(panel);
+		assert.equal(panel.panel, initial);
+		assert.equal(panel.hiddenByUser, false);
+	});
+}
 
 test("toggle on a fresh hidden panel opens compact", () => {
 	const panel = createTaskPanelVisibility("hidden");
@@ -110,9 +102,8 @@ test("cycle behavior walks hidden, compact, expanded, hidden regardless of last 
 	assert.equal(panel.panel, "compact");
 });
 
-test("toggle behavior setting values normalize with a toggle default", () => {
-	assert.equal(normalizePanelToggleBehavior("cycle"), "cycle");
-	assert.equal(normalizePanelToggleBehavior("toggle"), "toggle");
-	assert.equal(normalizePanelToggleBehavior("bogus"), "toggle");
-	assert.equal(normalizePanelToggleBehavior(undefined), "toggle");
-});
+for (const [value, expected] of [["cycle", "cycle"], ["toggle", "toggle"], ["bogus", "toggle"], [undefined, "toggle"]] as const) {
+	test(`toggle behavior setting ${String(value)}`, () => {
+		assert.equal(normalizePanelToggleBehavior(value), expected);
+	});
+}

--- a/pi-extensions/pi-task-panel/tests/visibility.test.ts
+++ b/pi-extensions/pi-task-panel/tests/visibility.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import {
 	applyTaskPanelContentVisibility,
 	createTaskPanelVisibility,


### PR DESCRIPTION
Task-panel tests repeated visibility checks under mutation names they never invoked and left failed-sidecar fixtures behind. Tests now table the real inputs, remove owned files and logs, and separate saved-state projection from restoration. Persistence notices use a stable key and operation value before the English explanation.

Validation: package suite passes with every suite registered through Bun. One planted defect per changed surface failed its target test, including separate tool and command fallback controls. `env -u TMPDIR tools/guard --full` exits 0 on 44e24851b. System temporary storage avoids the existing CLI ancestor-discovery fixture defect owned by the CLI audit lane.

Changed under `pi-extensions/pi-task-panel/`: `extensions/diagnostics.ts`, `tests/extension-sidecar-fallback.test.ts`, `tests/tool-result-details.test.ts`, `tests/tool-result-restore.test.ts`, `tests/visibility.test.ts`, `tests/lib/task-state.ts`, `tests/diagnostics.test.ts`.
Compliant test files left unchanged: none. All original package tests required changes. Declined: none.

Linear: KEN-1241.
