### PR TITLE
fix(KEN-1241): stabilize decider diagnostics

### DIFF
--- a/.agents/skills/decider/scripts/decisions
+++ b/.agents/skills/decider/scripts/decisions
@@ -293,13 +293,30 @@ search_decisions() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --issue) issue="$2"; shift 2 ;;
+      --issue)
+        if [[ $# -lt 2 ]]; then
+          emit_error argument-value-missing option=--issue "--issue requires an ID."
+          return 1
+        fi
+        issue="$2"; shift 2
+        ;;
       --issue=*) issue="${1#--issue=}"; shift ;;
-      --limit) limit="$2"; shift 2 ;;
+      --limit)
+        if [[ $# -lt 2 ]]; then
+          emit_error argument-value-missing option=--limit "--limit requires a number."
+          return 1
+        fi
+        limit="$2"; shift 2
+        ;;
       --limit=*) limit="${1#--limit=}"; shift ;;
       *) query="$1"; shift ;;
     esac
   done
+
+  if [[ ! "$limit" =~ ^[0-9]+$ ]]; then
+    emit_error limit-invalid "value=$limit" "--limit must be a non-negative integer."
+    return 1
+  fi
 
   if [[ -z "$issue" && -z "$query" ]]; then
     emit_error search-input-missing value=query-or-issue "Provide a search query or --issue ID."
@@ -450,7 +467,11 @@ cmd_next_id() {
 }
 
 cmd_get() {
-  local id="${1:?Usage: decisions get <DECISION_ID>}"
+  if [[ $# -lt 1 || -z "$1" ]]; then
+    emit_error argument-value-missing action=get "decisions get requires a decision ID."
+    return 1
+  fi
+  local id="$1"
 
   local match
   match=$(parse_index | jq --arg id "$id" '[.[] | select(.id == $id)] | .[0] // empty')

--- a/.agents/skills/decider/scripts/decisions
+++ b/.agents/skills/decider/scripts/decisions
@@ -5,8 +5,9 @@
 # Read-only lookups (search, list) treat an absent decisions directory as "no
 # decisions recorded": empty JSON array, note on stderr, exit 0. Commands that
 # feed the creation workflow (next-id, get) require an initialized directory.
-# Diagnostic protocol: a refusal starts with `error=KEY FIELD=VALUE`; a notice
-# starts with `notice=KEY FIELD=VALUE`. English guidance follows on later lines.
+# Diagnostic protocol: a refusal starts with `error=KEY` and one or more
+# `FIELD=VALUE` pairs; a notice starts with `notice=KEY` and the same field
+# form. English guidance follows on later lines.
 set -euo pipefail
 
 emit_error() { # KEY FIELD=VALUE EXPLANATION
@@ -197,6 +198,10 @@ split_decision_id() {
   return 1
 }
 
+regex_valid() { # REGEX
+  jq -n --arg regex "$1" '"" | test($regex)' >/dev/null 2>&1
+}
+
 # Parse the INDEX.md table into JSON, one jq pass over the whole file.
 #
 # Column order is a machine contract: a row is a line starting `| YYYY-` and
@@ -300,7 +305,14 @@ search_decisions() {
         fi
         issue="$2"; shift 2
         ;;
-      --issue=*) issue="${1#--issue=}"; shift ;;
+      --issue=*)
+        issue="${1#--issue=}"
+        if [[ -z "$issue" ]]; then
+          emit_error argument-value-missing option=--issue "--issue requires an ID."
+          return 1
+        fi
+        shift
+        ;;
       --limit)
         if [[ $# -lt 2 ]]; then
           emit_error argument-value-missing option=--limit "--limit requires a number."
@@ -308,7 +320,14 @@ search_decisions() {
         fi
         limit="$2"; shift 2
         ;;
-      --limit=*) limit="${1#--limit=}"; shift ;;
+      --limit=*)
+        limit="${1#--limit=}"
+        if [[ -z "$limit" ]]; then
+          emit_error argument-value-missing option=--limit "--limit requires a number."
+          return 1
+        fi
+        shift
+        ;;
       *) query="$1"; shift ;;
     esac
   done
@@ -334,6 +353,10 @@ search_decisions() {
 
   if [[ -n "$issue" ]]; then
     # Negative lookahead prevents PROJ-18 matching PROJ-189.
+    if ! regex_valid "$issue(?![0-9])"; then
+      emit_error regex-invalid "value=$issue" "The issue value is not a valid regular expression."
+      return 1
+    fi
     echo "$all" | jq --arg issue "$issue" '[
       .[] | select(.research | test($issue + "(?![0-9])"; "i")) |
       {id, decision, path}
@@ -342,6 +365,10 @@ search_decisions() {
   fi
 
   if echo "$query" | grep -qE '[|()\\]'; then
+    if ! regex_valid "$query"; then
+      emit_error regex-invalid "value=$query" "The search query is not a valid regular expression."
+      return 1
+    fi
     local rx_bodies
     rx_bodies=$(body_term_hits "$all" "$query")
     echo "$all" | jq --arg q "$query" --argjson limit "$limit" --argjson bodies "$rx_bodies" '[

--- a/.agents/skills/decider/scripts/decisions
+++ b/.agents/skills/decider/scripts/decisions
@@ -220,11 +220,15 @@ parse_index() {
   # ever recorded, so every such row is named on stderr. stdout still carries
   # exactly the rows that parse.
   jq -R -s -r --arg f "$INDEX_FILE" '
+    def cells:
+      split("|")
+      | if .[0] == "" then .[1:] else . end
+      | if .[-1] == "" then .[:-1] else . end;
     split("\n")
     | to_entries[]
     | select(.value | test("^\\| [0-9]{4}-"))
-    | select((.value | split("|") | length) < 9)
-    | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | split("|") | length)\nINDEX row needs at least 9 cells and was skipped: \(.value)"
+    | select((.value | cells | length) < 8)
+    | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | cells | length)\nINDEX row needs at least 8 columns and was skipped: \(.value)"
   ' "$INDEX_FILE" >&2
   jq -R -s -c --arg dir "$DECISIONS_DIR" '
     def cell_path:

--- a/.agents/skills/decider/scripts/decisions
+++ b/.agents/skills/decider/scripts/decisions
@@ -231,6 +231,10 @@ parse_index() {
     | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | cells | length)\nINDEX row needs at least 8 columns and was skipped: \(.value)"
   ' "$INDEX_FILE" >&2
   jq -R -s -c --arg dir "$DECISIONS_DIR" '
+    def cells:
+      split("|")
+      | if .[0] == "" then .[1:] else . end
+      | if .[-1] == "" then .[:-1] else . end;
     def cell_path:
       . as $cell
       | ( [ $cell | scan("\\(([^)]+)\\)") ]
@@ -239,11 +243,11 @@ parse_index() {
       | if length > 0 then .[0][0] else "" end;
     [ split("\n")[]
       | select(test("^\\| [0-9]{4}-"))
-      | split("|")
-      | select(length >= 9)
+      | cells
+      | select(length >= 8)
       | map(sub("^\\s+"; "") | sub("\\s+$"; ""))
-      | { id: .[2], research: .[3], decision: .[4], rationale: .[5],
-          status: .[7], path: (.[8] | cell_path) }
+      | { id: .[1], research: .[2], decision: .[3], rationale: .[4],
+          status: .[6], path: (.[7] | cell_path) }
       | .path |= (if . == "" then "" else $dir + "/" + . end)
     ]' "$INDEX_FILE"
 }

--- a/.agents/skills/decider/scripts/decisions
+++ b/.agents/skills/decider/scripts/decisions
@@ -5,7 +5,23 @@
 # Read-only lookups (search, list) treat an absent decisions directory as "no
 # decisions recorded": empty JSON array, note on stderr, exit 0. Commands that
 # feed the creation workflow (next-id, get) require an initialized directory.
+# Diagnostic protocol: a refusal starts with `error=KEY FIELD=VALUE`; a notice
+# starts with `notice=KEY FIELD=VALUE`. English guidance follows on later lines.
 set -euo pipefail
+
+emit_error() { # KEY FIELD=VALUE EXPLANATION
+  local key="$1" field="$2"
+  shift 2
+  printf 'error=%s %s\n' "$key" "$field" >&2
+  printf '%s\n' "$*" >&2
+}
+
+emit_notice() { # KEY FIELD=VALUE EXPLANATION
+  local key="$1" field="$2"
+  shift 2
+  printf 'notice=%s %s\n' "$key" "$field" >&2
+  printf '%s\n' "$*" >&2
+}
 
 # Help is answered before project configuration is read: sourcing a repo's
 # .env.local under --help would execute repository-controlled shell code.
@@ -100,7 +116,7 @@ source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
 
 if ! command -v jq &>/dev/null; then
-  echo "Error: jq is required but not installed" >&2
+  emit_error dependency-missing command=jq "jq is required but is not installed."
   exit 1
 fi
 
@@ -131,7 +147,7 @@ if [[ -z "${DECISIONS_DIR:-}" ]]; then
 elif [[ ! -e "$DECISIONS_DIR" ]]; then
   DECISIONS_DIR_ABSENT=1
 elif [[ ! -d "$DECISIONS_DIR" ]]; then
-  echo "Error: DECISIONS_DIR '$DECISIONS_DIR' is not a directory" >&2
+  emit_error decisions-dir-type "path=$DECISIONS_DIR" "DECISIONS_DIR is not a directory."
   exit 1
 fi
 
@@ -139,7 +155,7 @@ INDEX_FILE=""
 if [[ "$DECISIONS_DIR_ABSENT" -eq 0 ]]; then
   INDEX_FILE="$DECISIONS_DIR/INDEX.md"
   if [[ ! -f "$INDEX_FILE" ]]; then
-    echo "Error: INDEX.md not found in '$DECISIONS_DIR'" >&2
+    emit_error index-missing "path=$INDEX_FILE" "The decisions directory has no INDEX.md file."
     exit 1
   fi
 fi
@@ -147,18 +163,18 @@ fi
 require_decisions_dir() {
   [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]] || return 0
   if [[ -n "$DECISIONS_DIR" ]]; then
-    echo "Error: DECISIONS_DIR '$DECISIONS_DIR' does not exist" >&2
+    emit_error decisions-dir-absent "path=$DECISIONS_DIR" "DECISIONS_DIR does not exist."
   else
-    echo "Error: Could not find decisions directory. Set DECISIONS_DIR or create docs/decisions/INDEX.md" >&2
+    emit_error decisions-dir-absent path=auto "No decisions directory was found. Set DECISIONS_DIR or create docs/decisions/INDEX.md."
   fi
   exit 1
 }
 
 note_missing_decisions_dir() {
   if [[ -n "$DECISIONS_DIR" ]]; then
-    echo "note: decisions directory '$DECISIONS_DIR' not present — no decisions recorded" >&2
+    emit_notice decisions-dir-absent "path=$DECISIONS_DIR" "The decisions directory is absent, so no decisions are recorded."
   else
-    echo "note: no decisions directory found — no decisions recorded" >&2
+    emit_notice decisions-dir-absent path=auto "No decisions directory was found, so no decisions are recorded."
   fi
 }
 
@@ -203,7 +219,7 @@ parse_index() {
     | to_entries[]
     | select(.value | test("^\\| [0-9]{4}-"))
     | select((.value | split("|") | length) < 9)
-    | "WARNING: \($f):\(.key + 1): INDEX row has \(.value | split("|") | length) cells, need at least 9 — row skipped: \(.value)"
+    | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | split("|") | length)\nINDEX row needs at least 9 cells and was skipped: \(.value)"
   ' "$INDEX_FILE" >&2
   jq -R -s -c --arg dir "$DECISIONS_DIR" '
     def cell_path:
@@ -286,7 +302,7 @@ search_decisions() {
   done
 
   if [[ -z "$issue" && -z "$query" ]]; then
-    echo '{"error": "Provide a search query or --issue ID"}' >&2
+    emit_error search-input-missing value=query-or-issue "Provide a search query or --issue ID."
     return 1
   fi
 
@@ -384,7 +400,7 @@ cmd_next_id() {
 
   if [[ "${DECISION_ID_WIDTH+x}" == "x" ]]; then
     if [[ ! "$DECISION_ID_WIDTH" =~ ^[1-9][0-9]*$ ]]; then
-      echo "Error: DECISION_ID_WIDTH must be a positive integer" >&2
+      emit_error id-width-invalid "value=$DECISION_ID_WIDTH" "DECISION_ID_WIDTH must be a positive integer."
       return 1
     fi
     width="$DECISION_ID_WIDTH"
@@ -398,7 +414,7 @@ cmd_next_id() {
     if [[ "${#ids[@]}" -gt 0 ]]; then
       local last_id="${ids[${#ids[@]} - 1]}"
       if ! split_decision_id "$last_id"; then
-        echo "Error: Last decision ID '$last_id' in INDEX.md has no numeric suffix. Set DECISION_ID_PREFIX and DECISION_ID_WIDTH to select a scheme explicitly." >&2
+        emit_error id-suffix-missing "value=$last_id" "The last decision ID in INDEX.md has no numeric suffix. Set DECISION_ID_PREFIX and DECISION_ID_WIDTH to select a scheme explicitly."
         return 1
       fi
       prefix="$PARSED_ID_PREFIX"
@@ -440,7 +456,7 @@ cmd_get() {
   match=$(parse_index | jq --arg id "$id" '[.[] | select(.id == $id)] | .[0] // empty')
 
   if [[ -z "$match" || "$match" == "null" ]]; then
-    echo "Error: Decision $id not found" >&2
+    emit_error decision-not-found "id=$id" "The decision was not found."
     exit 1
   fi
 
@@ -477,11 +493,11 @@ case "$action" in
     cmd_get "$@"
     ;;
   issue|issues)
-    echo "Error: Unknown action '$action' — issue lookup is: decisions search --issue <ISSUE_ID>" >&2
+    emit_error action-unknown "action=$action hint=search--issue" "Use decisions search --issue <ISSUE_ID> for issue lookup."
     exit 1
     ;;
   *)
-    echo "Error: Unknown action '$action'" >&2
+    emit_error action-unknown "action=$action" "The action is not supported."
     show_help
     exit 1
     ;;

--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -44,6 +44,7 @@ cat >"$BAD_REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-02-01 | D101 | PROJ-1 | Well-formed row | Reason one | Never | Active | [Full](D101.md) |
 | 2026-02-02 | D102 | PROJ-2 | Truncated row | Active |
 | 2026-02-03 | D103 | PROJ-3 | Second well-formed | Reason three | Never | Active | [Full](D103.md) |
+| 2026-02-04 | D104 | PROJ-4 | Seven-cell row | Reason four | Active | [Full](D104.md) |
 EOF
 
 run_decisions() {
@@ -225,6 +226,10 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
   warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | cells | length) < 8)' '| select(false)' 1)"
   failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
   expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
+
+  row_filter_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wide-row-filter/decisions" '| select(length >= 8)' '| select(length >= 7)' 1)"
+  failures="$(evaluate_diagnostic_rows "$row_filter_mutant" control)"
+  expect_control_failure "$failures" malformed-row-results "a seven-cell row fails the result filter control"
 
   link_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-link-table/decider/tests/decider-index-parse.test.sh" LINK_CASES)"
   if decider_test_fails_with "$link_table_mutant" "link table executed no rows"; then

--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -162,13 +162,7 @@ evaluate_diagnostic_rows() {
         ;;
       malformed-warning)
         first_line="${err%%$'\n'*}"
-        first=0
-        second=0
-        third=0
-        [[ "$first_line" == *"notice=index-row-invalid"* ]] && first=1
-        [[ "$first_line" == *"path=$BAD_REPO/docs/decisions/INDEX.md"* ]] && second=1
-        [[ "$first_line" == *"line=6"* ]] && third=1
-        actual="$rc~$first~$second~$third"
+        actual="$rc~$first_line"
         ;;
       empty-stderr)
         actual="$rc~${err:-<empty>}"
@@ -178,10 +172,11 @@ evaluate_diagnostic_rows() {
         continue
         ;;
     esac
+    expected="${expected//<bad-index>/$BAD_REPO\/docs\/decisions\/INDEX.md}"
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103
-malformed-row-diagnostic~malformed~malformed-warning~0~1~1~1
+malformed-row-diagnostic~malformed~malformed-warning~0~notice=index-row-invalid path=<bad-index> line=6 cells=5
 healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
 DIAGNOSTIC_CASES
   if [[ "$executed_rows" -eq 0 ]]; then
@@ -226,7 +221,7 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
   failures="$(evaluate_link_rows "$date_mutant" control)"
   expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
 
-  warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
+  warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | cells | length) < 8)' '| select(false)' 1)"
   failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
   expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
 

--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -141,7 +141,7 @@ LINK_CASES
 }
 
 evaluate_diagnostic_rows() {
-  local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second guard
+  local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second third guard first_line
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name fixture projection expected; do
@@ -161,11 +161,14 @@ evaluate_diagnostic_rows() {
         expected="0~0~$expected"
         ;;
       malformed-warning)
+        first_line="${err%%$'\n'*}"
         first=0
         second=0
-        [[ "$err" == *D102* || "$err" == *:6:* ]] && first=1
-        [[ "$err" == *:6:* ]] && second=1
-        actual="$rc~$first~$second"
+        third=0
+        [[ "$first_line" == *"notice=index-row-invalid"* ]] && first=1
+        [[ "$first_line" == *"path=$BAD_REPO/docs/decisions/INDEX.md"* ]] && second=1
+        [[ "$first_line" == *"line=6"* ]] && third=1
+        actual="$rc~$first~$second~$third"
         ;;
       empty-stderr)
         actual="$rc~${err:-<empty>}"
@@ -178,7 +181,7 @@ evaluate_diagnostic_rows() {
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103
-malformed-row-diagnostic~malformed~malformed-warning~0~1~1
+malformed-row-diagnostic~malformed~malformed-warning~0~1~1~1
 healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
 DIAGNOSTIC_CASES
   if [[ "$executed_rows" -eq 0 ]]; then

--- a/.agents/skills/decider/tests/decider-index-parse.test.sh
+++ b/.agents/skills/decider/tests/decider-index-parse.test.sh
@@ -142,6 +142,7 @@ LINK_CASES
 
 evaluate_diagnostic_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second third guard first_line
+  local bad_index="$BAD_REPO/docs/decisions/INDEX.md"
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name fixture projection expected; do
@@ -172,7 +173,7 @@ evaluate_diagnostic_rows() {
         continue
         ;;
     esac
-    expected="${expected//<bad-index>/$BAD_REPO\/docs\/decisions\/INDEX.md}"
+    expected="${expected//<bad-index>/$bad_index}"
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103

--- a/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/.agents/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -55,7 +55,7 @@ record_row() {
 
 evaluate_action_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual guard
-  local first second projected projection_rc
+  local first second projected projection_rc first_line
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name kind argument expected; do
@@ -66,24 +66,29 @@ evaluate_action_rows() {
     case "$kind" in
       issue)
         run_decisions "$script" issue "$argument"
+        first_line="${err%%$'\n'*}"
         first=0
         second=0
-        [[ "$err" == *"Unknown action 'issue'"* ]] && first=1
-        [[ "$err" == *"search --issue"* ]] && second=1
+        [[ "$first_line" == *"error=action-unknown"* && "$first_line" == *"action=issue"* ]] && first=1
+        [[ "$first_line" == *"hint=search--issue"* ]] && second=1
         actual="$rc~$out~$first~$second"
         ;;
       issues)
         run_decisions "$script" issues "$argument"
+        first_line="${err%%$'\n'*}"
         first=0
-        [[ "$err" == *"search --issue"* ]] && first=1
-        actual="$rc~$first"
+        second=0
+        [[ "$first_line" == *"error=action-unknown"* && "$first_line" == *"action=issues"* ]] && first=1
+        [[ "$first_line" == *"hint=search--issue"* ]] && second=1
+        actual="$rc~$first~$second"
         ;;
       unknown)
         run_decisions "$script" "$argument" CC-125
+        first_line="${err%%$'\n'*}"
         first=0
         second=0
-        [[ "$err" == *"Unknown action '$argument'"* ]] && first=1
-        [[ "$out" == *"Usage: decisions"* ]] && second=1
+        [[ "$first_line" == *"error=action-unknown"* ]] && first=1
+        [[ "$first_line" == *"action=$argument"* ]] && second=1
         actual="$rc~$first~$second"
         ;;
       lookup)
@@ -102,7 +107,7 @@ evaluate_action_rows() {
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'ACTION_CASES'
 issue-action~issue~CC-125~1~~1~1
-issues-action~issues~CC-125~1~1
+issues-action~issues~CC-125~1~1~1
 generic-unknown-action~unknown~bogus~1~1~1
 supported-issue-lookup~lookup~CC-125~0~0~D001
 ACTION_CASES
@@ -133,6 +138,14 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "wrong lookup result fails the supported lookup row"
   else
     fail "wrong lookup result did not fail the supported lookup row"
+  fi
+
+  diagnostic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/action-diagnostic-key/decisions" '    emit_error action-unknown "action=$action hint=search--issue"' '    emit_error action-invalid "action=$action hint=search--issue"' 1)"
+  failures="$(evaluate_action_rows "$diagnostic_mutant" control issue-action)"
+  if [[ "$failures" == *'|issue-action|'* ]]; then
+    pass "a changed action key fails its row"
+  else
+    fail "a changed action key did not fail its row"
   fi
 
   action_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-action-table/decider/tests/decider-issue-action-hint.test.sh" ACTION_CASES)"

--- a/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/.agents/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -114,7 +114,7 @@ record_row() {
 
 evaluate_next_id_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name repo_name environment expected_status
-  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected guard
+  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected guard first_line
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name repo_name environment expected_status stdout_rule expected_stdout stderr_rule; do
@@ -129,6 +129,7 @@ evaluate_next_id_rows() {
       ignore) actual_stdout=ignored; expected_stdout=ignored ;;
       *) fail "unknown stdout rule: $stdout_rule"; continue ;;
     esac
+    first_line="${err%%$'\n'*}"
     case "$stderr_rule" in
       empty)
         actual_stderr="$err"
@@ -140,14 +141,15 @@ evaluate_next_id_rows() {
         ;;
       bad-id-prefix)
         actual_stderr=0,0
-        [[ "$err" == *ADR-current* ]] && actual_stderr=1,0
-        [[ "$err" == *ADR-current* && "$err" == *DECISION_ID_PREFIX* ]] && actual_stderr=1,1
+        [[ "$first_line" == *"error=id-suffix-missing"* ]] && actual_stderr=1,0
+        [[ "$first_line" == *"error=id-suffix-missing"* && "$first_line" == *"value=ADR-current"* ]] && actual_stderr=1,1
         expected=1,1
         ;;
       width)
-        actual_stderr=0
-        [[ "$err" == *DECISION_ID_WIDTH* ]] && actual_stderr=1
-        expected=1
+        actual_stderr=0,0
+        [[ "$first_line" == *"error=id-width-invalid"* ]] && actual_stderr=1,0
+        [[ "$first_line" == *"error=id-width-invalid"* && "$first_line" == *"value=zero"* ]] && actual_stderr=1,1
+        expected=1,1
         ;;
       *) fail "unknown stderr rule: $stderr_rule"; continue ;;
     esac
@@ -191,6 +193,14 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "wrong next ID fails the inferred scheme row"
   else
     fail "wrong next ID did not fail the inferred scheme row"
+  fi
+
+  diagnostic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/id-diagnostic-key/decisions" '        emit_error id-suffix-missing "value=$last_id"' '        emit_error id-suffix-invalid "value=$last_id"' 1)"
+  failures="$(evaluate_next_id_rows "$diagnostic_mutant" control unparseable-last-id)"
+  if [[ "$failures" == *'|unparseable-last-id|'* ]]; then
+    pass "a changed ID diagnostic key fails its row"
+  else
+    fail "a changed ID diagnostic key did not fail its row"
   fi
 
   next_id_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-next-id-table/decider/tests/decider-next-id-scheme.test.sh" NEXT_ID_CASES)"

--- a/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -35,6 +35,15 @@ cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-10 | D001 | PROJ-100 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
 EOF
 
+NO_INDEX_DIR="$TMP_ROOT/no-index-project"
+mkdir -p "$NO_INDEX_DIR/docs/decisions"
+
+NO_JQ_BIN="$TMP_ROOT/no-jq-bin"
+mkdir -p "$NO_JQ_BIN"
+ln -s "$(command -v git)" "$NO_JQ_BIN/git"
+ln -s "$(command -v dirname)" "$NO_JQ_BIN/dirname"
+BASH_BIN="$(command -v bash)"
+
 NOT_A_DIR="$TMP_ROOT/not-a-dir"
 touch "$NOT_A_DIR"
 
@@ -51,6 +60,12 @@ run_decisions() {
       ;;
     existing)
       out=$( (cd "$HAS_DIR" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    missing-index)
+      out=$( (cd "$NO_INDEX_DIR" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    missing-dependency)
+      out=$( (cd "$HAS_DIR" && env -u DECISIONS_DIR PATH="$NO_JQ_BIN" DECISIONS_DIR=docs/decisions "$BASH_BIN" "$script" "$@") 2>"$ERR_FILE")
       ;;
     configured-file)
       out=$( (cd "$NO_DIR" && env -u DECISIONS_DIR DECISIONS_DIR="$NOT_A_DIR" "$script" "$@") 2>"$ERR_FILE")
@@ -93,10 +108,16 @@ evaluate_directory_rows() {
     fi
     executed_rows=$((executed_rows + 1))
     case "$action" in
+      dependency) run_decisions "$script" "$state" list ;;
       issue) run_decisions "$script" "$state" search --issue "$argument" ;;
+      issue-missing) run_decisions "$script" "$state" search --issue ;;
       keyword) run_decisions "$script" "$state" search "$argument" ;;
+      limit-missing) run_decisions "$script" "$state" search "$argument" --limit ;;
+      limit-invalid) run_decisions "$script" "$state" search "$argument" --limit nope ;;
+      search-empty) run_decisions "$script" "$state" search --limit 1 ;;
       list|next-id|help) run_decisions "$script" "$state" "$action" ;;
       get) run_decisions "$script" "$state" get "$argument" ;;
+      get-missing) run_decisions "$script" "$state" get ;;
       *) fail "unknown directory-row action: $action"; continue ;;
     esac
 
@@ -128,10 +149,8 @@ evaluate_directory_rows() {
     [[ "$needle_two" == '<not-a-dir>' ]] && needle_two="path=$NOT_A_DIR"
     case "$stderr_rule" in
       key-value)
-        actual_stderr=0,0
-        [[ "$first_line" == *"$needle_one"* ]] && actual_stderr=1,0
-        [[ "$first_line" == *"$needle_one"* && "$first_line" == *"$needle_two"* ]] && actual_stderr=1,1
-        expected=1,1
+        actual_stderr="$first_line"
+        expected="$needle_one $needle_two"
         ;;
       empty)
         actual_stderr="$err"
@@ -158,6 +177,14 @@ existing-keyword-miss~existing~keyword~zzz nonexistent term~0~exact~[]~empty~~
 existing-issue-miss~existing~issue~PROJ-999~0~exact~[]~empty~~
 existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
 existing-next-id~existing~next-id~~0~exact~D002~ignore~~
+missing-jq~missing-dependency~dependency~~1~ignore~~key-value~error=dependency-missing~command=jq
+missing-index~missing-index~list~~1~ignore~~key-value~error=index-missing~path=docs/decisions/INDEX.md
+missing-search-input~existing~search-empty~~1~ignore~~key-value~error=search-input-missing~value=query-or-issue
+missing-decision~existing~get~D999~1~ignore~~key-value~error=decision-not-found~id=D999
+missing-issue-value~existing~issue-missing~~1~ignore~~key-value~error=argument-value-missing~option=--issue
+missing-limit-value~existing~limit-missing~redis~1~ignore~~key-value~error=argument-value-missing~option=--limit
+invalid-limit-value~existing~limit-invalid~redis~1~ignore~~key-value~error=limit-invalid~value=nope
+missing-get-value~existing~get-missing~~1~ignore~~key-value~error=argument-value-missing~action=get
 configured-file-search~configured-file~issue~PROJ-557~1~exact~~key-value~error=decisions-dir-type~<not-a-dir>
 configured-file-next-id~configured-file~next-id~~1~ignore~~key-value~error=decisions-dir-type~<not-a-dir>
 DIRECTORY_CASES

--- a/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -83,7 +83,7 @@ record_row() {
 
 evaluate_directory_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name state action argument expected_status
-  local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr
+  local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr first_line
   local projected projection_rc actual expected guard
   local executed_rows=0
   table_failures=""
@@ -124,16 +124,13 @@ evaluate_directory_rows() {
       *) fail "unknown stdout rule: $stdout_rule"; continue ;;
     esac
 
+    first_line="${err%%$'\n'*}"
+    [[ "$needle_two" == '<not-a-dir>' ]] && needle_two="path=$NOT_A_DIR"
     case "$stderr_rule" in
-      contains)
-        actual_stderr=0
-        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1
-        expected=1
-        ;;
-      both)
+      key-value)
         actual_stderr=0,0
-        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1,0
-        [[ "$err" == *"$needle_one"* && "$err" == *"$needle_two"* ]] && actual_stderr=1,1
+        [[ "$first_line" == *"$needle_one"* ]] && actual_stderr=1,0
+        [[ "$first_line" == *"$needle_one"* && "$first_line" == *"$needle_two"* ]] && actual_stderr=1,1
         expected=1,1
         ;;
       empty)
@@ -150,19 +147,19 @@ evaluate_directory_rows() {
     actual="$rc~$actual_stdout~$actual_stderr"
     record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
   done <<'DIRECTORY_CASES'
-configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~both~docs/decisions~not present
-configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~contains~not present~
-configured-absent-list~configured-absent~list~~0~exact~[]~contains~not present~
-configured-absent-next-id~configured-absent~next-id~~1~ignore~~contains~does not exist~
-configured-absent-get~configured-absent~get~D001~1~ignore~~contains~does not exist~
-undiscovered-issue~undiscovered~issue~PROJ-557~0~exact~[]~contains~no decisions directory found~
+configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~key-value~notice=decisions-dir-absent~path=docs/decisions
+configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~key-value~notice=decisions-dir-absent~path=docs/decisions
+configured-absent-list~configured-absent~list~~0~exact~[]~key-value~notice=decisions-dir-absent~path=docs/decisions
+configured-absent-next-id~configured-absent~next-id~~1~ignore~~key-value~error=decisions-dir-absent~path=docs/decisions
+configured-absent-get~configured-absent~get~D001~1~ignore~~key-value~error=decisions-dir-absent~path=docs/decisions
+undiscovered-issue~undiscovered~issue~PROJ-557~0~exact~[]~key-value~notice=decisions-dir-absent~path=auto
 help-without-directory~undiscovered~help~~0~contains~Decision Lookup Tool~ignore~~
 existing-keyword-miss~existing~keyword~zzz nonexistent term~0~exact~[]~empty~~
 existing-issue-miss~existing~issue~PROJ-999~0~exact~[]~empty~~
 existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
 existing-next-id~existing~next-id~~0~exact~D002~ignore~~
-configured-file-search~configured-file~issue~PROJ-557~1~exact~~contains~is not a directory~
-configured-file-next-id~configured-file~next-id~~1~ignore~~contains~is not a directory~
+configured-file-search~configured-file~issue~PROJ-557~1~exact~~key-value~error=decisions-dir-type~<not-a-dir>
+configured-file-next-id~configured-file~next-id~~1~ignore~~key-value~error=decisions-dir-type~<not-a-dir>
 DIRECTORY_CASES
   if [[ "$executed_rows" -eq 0 ]]; then
     guard="directory table executed no rows"
@@ -205,6 +202,14 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "absent keyword-search failure fails its row"
   else
     fail "absent keyword-search failure did not fail its row"
+  fi
+
+  diagnostic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/diagnostic-key/decisions" '    emit_notice decisions-dir-absent "path=$DECISIONS_DIR"' '    emit_notice decisions-dir-missing "path=$DECISIONS_DIR"' 1)"
+  failures="$(evaluate_directory_rows "$diagnostic_mutant" control configured-absent-issue)"
+  if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
+    pass "a changed diagnostic key fails its row"
+  else
+    fail "a changed diagnostic key did not fail its row"
   fi
 
   directory_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-directory-table/decider/tests/decider-search-missing-dir.test.sh" DIRECTORY_CASES)"

--- a/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/.agents/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -111,9 +111,13 @@ evaluate_directory_rows() {
       dependency) run_decisions "$script" "$state" list ;;
       issue) run_decisions "$script" "$state" search --issue "$argument" ;;
       issue-missing) run_decisions "$script" "$state" search --issue ;;
+      issue-empty) run_decisions "$script" "$state" search --issue= ;;
+      issue-regex-invalid) run_decisions "$script" "$state" search --issue "$argument" ;;
       keyword) run_decisions "$script" "$state" search "$argument" ;;
       limit-missing) run_decisions "$script" "$state" search "$argument" --limit ;;
+      limit-empty) run_decisions "$script" "$state" search "$argument" --limit= ;;
       limit-invalid) run_decisions "$script" "$state" search "$argument" --limit nope ;;
+      query-regex-invalid) run_decisions "$script" "$state" search "$argument" ;;
       search-empty) run_decisions "$script" "$state" search --limit 1 ;;
       list|next-id|help) run_decisions "$script" "$state" "$action" ;;
       get) run_decisions "$script" "$state" get "$argument" ;;
@@ -182,8 +186,12 @@ missing-index~missing-index~list~~1~ignore~~key-value~error=index-missing~path=d
 missing-search-input~existing~search-empty~~1~ignore~~key-value~error=search-input-missing~value=query-or-issue
 missing-decision~existing~get~D999~1~ignore~~key-value~error=decision-not-found~id=D999
 missing-issue-value~existing~issue-missing~~1~ignore~~key-value~error=argument-value-missing~option=--issue
+empty-issue-value~existing~issue-empty~~1~ignore~~key-value~error=argument-value-missing~option=--issue
 missing-limit-value~existing~limit-missing~redis~1~ignore~~key-value~error=argument-value-missing~option=--limit
+empty-limit-value~existing~limit-empty~redis~1~ignore~~key-value~error=argument-value-missing~option=--limit
 invalid-limit-value~existing~limit-invalid~redis~1~ignore~~key-value~error=limit-invalid~value=nope
+invalid-query-regex~existing~query-regex-invalid~(~1~ignore~~key-value~error=regex-invalid~value=(
+invalid-issue-regex~existing~issue-regex-invalid~[~1~ignore~~key-value~error=regex-invalid~value=[
 missing-get-value~existing~get-missing~~1~ignore~~key-value~error=argument-value-missing~action=get
 configured-file-search~configured-file~issue~PROJ-557~1~exact~~key-value~error=decisions-dir-type~<not-a-dir>
 configured-file-next-id~configured-file~next-id~~1~ignore~~key-value~error=decisions-dir-type~<not-a-dir>

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -293,13 +293,30 @@ search_decisions() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --issue) issue="$2"; shift 2 ;;
+      --issue)
+        if [[ $# -lt 2 ]]; then
+          emit_error argument-value-missing option=--issue "--issue requires an ID."
+          return 1
+        fi
+        issue="$2"; shift 2
+        ;;
       --issue=*) issue="${1#--issue=}"; shift ;;
-      --limit) limit="$2"; shift 2 ;;
+      --limit)
+        if [[ $# -lt 2 ]]; then
+          emit_error argument-value-missing option=--limit "--limit requires a number."
+          return 1
+        fi
+        limit="$2"; shift 2
+        ;;
       --limit=*) limit="${1#--limit=}"; shift ;;
       *) query="$1"; shift ;;
     esac
   done
+
+  if [[ ! "$limit" =~ ^[0-9]+$ ]]; then
+    emit_error limit-invalid "value=$limit" "--limit must be a non-negative integer."
+    return 1
+  fi
 
   if [[ -z "$issue" && -z "$query" ]]; then
     emit_error search-input-missing value=query-or-issue "Provide a search query or --issue ID."
@@ -450,7 +467,11 @@ cmd_next_id() {
 }
 
 cmd_get() {
-  local id="${1:?Usage: decisions get <DECISION_ID>}"
+  if [[ $# -lt 1 || -z "$1" ]]; then
+    emit_error argument-value-missing action=get "decisions get requires a decision ID."
+    return 1
+  fi
+  local id="$1"
 
   local match
   match=$(parse_index | jq --arg id "$id" '[.[] | select(.id == $id)] | .[0] // empty')

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -5,8 +5,9 @@
 # Read-only lookups (search, list) treat an absent decisions directory as "no
 # decisions recorded": empty JSON array, note on stderr, exit 0. Commands that
 # feed the creation workflow (next-id, get) require an initialized directory.
-# Diagnostic protocol: a refusal starts with `error=KEY FIELD=VALUE`; a notice
-# starts with `notice=KEY FIELD=VALUE`. English guidance follows on later lines.
+# Diagnostic protocol: a refusal starts with `error=KEY` and one or more
+# `FIELD=VALUE` pairs; a notice starts with `notice=KEY` and the same field
+# form. English guidance follows on later lines.
 set -euo pipefail
 
 emit_error() { # KEY FIELD=VALUE EXPLANATION
@@ -197,6 +198,10 @@ split_decision_id() {
   return 1
 }
 
+regex_valid() { # REGEX
+  jq -n --arg regex "$1" '"" | test($regex)' >/dev/null 2>&1
+}
+
 # Parse the INDEX.md table into JSON, one jq pass over the whole file.
 #
 # Column order is a machine contract: a row is a line starting `| YYYY-` and
@@ -300,7 +305,14 @@ search_decisions() {
         fi
         issue="$2"; shift 2
         ;;
-      --issue=*) issue="${1#--issue=}"; shift ;;
+      --issue=*)
+        issue="${1#--issue=}"
+        if [[ -z "$issue" ]]; then
+          emit_error argument-value-missing option=--issue "--issue requires an ID."
+          return 1
+        fi
+        shift
+        ;;
       --limit)
         if [[ $# -lt 2 ]]; then
           emit_error argument-value-missing option=--limit "--limit requires a number."
@@ -308,7 +320,14 @@ search_decisions() {
         fi
         limit="$2"; shift 2
         ;;
-      --limit=*) limit="${1#--limit=}"; shift ;;
+      --limit=*)
+        limit="${1#--limit=}"
+        if [[ -z "$limit" ]]; then
+          emit_error argument-value-missing option=--limit "--limit requires a number."
+          return 1
+        fi
+        shift
+        ;;
       *) query="$1"; shift ;;
     esac
   done
@@ -334,6 +353,10 @@ search_decisions() {
 
   if [[ -n "$issue" ]]; then
     # Negative lookahead prevents PROJ-18 matching PROJ-189.
+    if ! regex_valid "$issue(?![0-9])"; then
+      emit_error regex-invalid "value=$issue" "The issue value is not a valid regular expression."
+      return 1
+    fi
     echo "$all" | jq --arg issue "$issue" '[
       .[] | select(.research | test($issue + "(?![0-9])"; "i")) |
       {id, decision, path}
@@ -342,6 +365,10 @@ search_decisions() {
   fi
 
   if echo "$query" | grep -qE '[|()\\]'; then
+    if ! regex_valid "$query"; then
+      emit_error regex-invalid "value=$query" "The search query is not a valid regular expression."
+      return 1
+    fi
     local rx_bodies
     rx_bodies=$(body_term_hits "$all" "$query")
     echo "$all" | jq --arg q "$query" --argjson limit "$limit" --argjson bodies "$rx_bodies" '[

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -220,11 +220,15 @@ parse_index() {
   # ever recorded, so every such row is named on stderr. stdout still carries
   # exactly the rows that parse.
   jq -R -s -r --arg f "$INDEX_FILE" '
+    def cells:
+      split("|")
+      | if .[0] == "" then .[1:] else . end
+      | if .[-1] == "" then .[:-1] else . end;
     split("\n")
     | to_entries[]
     | select(.value | test("^\\| [0-9]{4}-"))
-    | select((.value | split("|") | length) < 9)
-    | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | split("|") | length)\nINDEX row needs at least 9 cells and was skipped: \(.value)"
+    | select((.value | cells | length) < 8)
+    | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | cells | length)\nINDEX row needs at least 8 columns and was skipped: \(.value)"
   ' "$INDEX_FILE" >&2
   jq -R -s -c --arg dir "$DECISIONS_DIR" '
     def cell_path:

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -231,6 +231,10 @@ parse_index() {
     | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | cells | length)\nINDEX row needs at least 8 columns and was skipped: \(.value)"
   ' "$INDEX_FILE" >&2
   jq -R -s -c --arg dir "$DECISIONS_DIR" '
+    def cells:
+      split("|")
+      | if .[0] == "" then .[1:] else . end
+      | if .[-1] == "" then .[:-1] else . end;
     def cell_path:
       . as $cell
       | ( [ $cell | scan("\\(([^)]+)\\)") ]
@@ -239,11 +243,11 @@ parse_index() {
       | if length > 0 then .[0][0] else "" end;
     [ split("\n")[]
       | select(test("^\\| [0-9]{4}-"))
-      | split("|")
-      | select(length >= 9)
+      | cells
+      | select(length >= 8)
       | map(sub("^\\s+"; "") | sub("\\s+$"; ""))
-      | { id: .[2], research: .[3], decision: .[4], rationale: .[5],
-          status: .[7], path: (.[8] | cell_path) }
+      | { id: .[1], research: .[2], decision: .[3], rationale: .[4],
+          status: .[6], path: (.[7] | cell_path) }
       | .path |= (if . == "" then "" else $dir + "/" + . end)
     ]' "$INDEX_FILE"
 }

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -5,7 +5,23 @@
 # Read-only lookups (search, list) treat an absent decisions directory as "no
 # decisions recorded": empty JSON array, note on stderr, exit 0. Commands that
 # feed the creation workflow (next-id, get) require an initialized directory.
+# Diagnostic protocol: a refusal starts with `error=KEY FIELD=VALUE`; a notice
+# starts with `notice=KEY FIELD=VALUE`. English guidance follows on later lines.
 set -euo pipefail
+
+emit_error() { # KEY FIELD=VALUE EXPLANATION
+  local key="$1" field="$2"
+  shift 2
+  printf 'error=%s %s\n' "$key" "$field" >&2
+  printf '%s\n' "$*" >&2
+}
+
+emit_notice() { # KEY FIELD=VALUE EXPLANATION
+  local key="$1" field="$2"
+  shift 2
+  printf 'notice=%s %s\n' "$key" "$field" >&2
+  printf '%s\n' "$*" >&2
+}
 
 # Help is answered before project configuration is read: sourcing a repo's
 # .env.local under --help would execute repository-controlled shell code.
@@ -100,7 +116,7 @@ source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
 
 if ! command -v jq &>/dev/null; then
-  echo "Error: jq is required but not installed" >&2
+  emit_error dependency-missing command=jq "jq is required but is not installed."
   exit 1
 fi
 
@@ -131,7 +147,7 @@ if [[ -z "${DECISIONS_DIR:-}" ]]; then
 elif [[ ! -e "$DECISIONS_DIR" ]]; then
   DECISIONS_DIR_ABSENT=1
 elif [[ ! -d "$DECISIONS_DIR" ]]; then
-  echo "Error: DECISIONS_DIR '$DECISIONS_DIR' is not a directory" >&2
+  emit_error decisions-dir-type "path=$DECISIONS_DIR" "DECISIONS_DIR is not a directory."
   exit 1
 fi
 
@@ -139,7 +155,7 @@ INDEX_FILE=""
 if [[ "$DECISIONS_DIR_ABSENT" -eq 0 ]]; then
   INDEX_FILE="$DECISIONS_DIR/INDEX.md"
   if [[ ! -f "$INDEX_FILE" ]]; then
-    echo "Error: INDEX.md not found in '$DECISIONS_DIR'" >&2
+    emit_error index-missing "path=$INDEX_FILE" "The decisions directory has no INDEX.md file."
     exit 1
   fi
 fi
@@ -147,18 +163,18 @@ fi
 require_decisions_dir() {
   [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]] || return 0
   if [[ -n "$DECISIONS_DIR" ]]; then
-    echo "Error: DECISIONS_DIR '$DECISIONS_DIR' does not exist" >&2
+    emit_error decisions-dir-absent "path=$DECISIONS_DIR" "DECISIONS_DIR does not exist."
   else
-    echo "Error: Could not find decisions directory. Set DECISIONS_DIR or create docs/decisions/INDEX.md" >&2
+    emit_error decisions-dir-absent path=auto "No decisions directory was found. Set DECISIONS_DIR or create docs/decisions/INDEX.md."
   fi
   exit 1
 }
 
 note_missing_decisions_dir() {
   if [[ -n "$DECISIONS_DIR" ]]; then
-    echo "note: decisions directory '$DECISIONS_DIR' not present — no decisions recorded" >&2
+    emit_notice decisions-dir-absent "path=$DECISIONS_DIR" "The decisions directory is absent, so no decisions are recorded."
   else
-    echo "note: no decisions directory found — no decisions recorded" >&2
+    emit_notice decisions-dir-absent path=auto "No decisions directory was found, so no decisions are recorded."
   fi
 }
 
@@ -203,7 +219,7 @@ parse_index() {
     | to_entries[]
     | select(.value | test("^\\| [0-9]{4}-"))
     | select((.value | split("|") | length) < 9)
-    | "WARNING: \($f):\(.key + 1): INDEX row has \(.value | split("|") | length) cells, need at least 9 — row skipped: \(.value)"
+    | "notice=index-row-invalid path=\($f) line=\(.key + 1) cells=\(.value | split("|") | length)\nINDEX row needs at least 9 cells and was skipped: \(.value)"
   ' "$INDEX_FILE" >&2
   jq -R -s -c --arg dir "$DECISIONS_DIR" '
     def cell_path:
@@ -286,7 +302,7 @@ search_decisions() {
   done
 
   if [[ -z "$issue" && -z "$query" ]]; then
-    echo '{"error": "Provide a search query or --issue ID"}' >&2
+    emit_error search-input-missing value=query-or-issue "Provide a search query or --issue ID."
     return 1
   fi
 
@@ -384,7 +400,7 @@ cmd_next_id() {
 
   if [[ "${DECISION_ID_WIDTH+x}" == "x" ]]; then
     if [[ ! "$DECISION_ID_WIDTH" =~ ^[1-9][0-9]*$ ]]; then
-      echo "Error: DECISION_ID_WIDTH must be a positive integer" >&2
+      emit_error id-width-invalid "value=$DECISION_ID_WIDTH" "DECISION_ID_WIDTH must be a positive integer."
       return 1
     fi
     width="$DECISION_ID_WIDTH"
@@ -398,7 +414,7 @@ cmd_next_id() {
     if [[ "${#ids[@]}" -gt 0 ]]; then
       local last_id="${ids[${#ids[@]} - 1]}"
       if ! split_decision_id "$last_id"; then
-        echo "Error: Last decision ID '$last_id' in INDEX.md has no numeric suffix. Set DECISION_ID_PREFIX and DECISION_ID_WIDTH to select a scheme explicitly." >&2
+        emit_error id-suffix-missing "value=$last_id" "The last decision ID in INDEX.md has no numeric suffix. Set DECISION_ID_PREFIX and DECISION_ID_WIDTH to select a scheme explicitly."
         return 1
       fi
       prefix="$PARSED_ID_PREFIX"
@@ -440,7 +456,7 @@ cmd_get() {
   match=$(parse_index | jq --arg id "$id" '[.[] | select(.id == $id)] | .[0] // empty')
 
   if [[ -z "$match" || "$match" == "null" ]]; then
-    echo "Error: Decision $id not found" >&2
+    emit_error decision-not-found "id=$id" "The decision was not found."
     exit 1
   fi
 
@@ -477,11 +493,11 @@ case "$action" in
     cmd_get "$@"
     ;;
   issue|issues)
-    echo "Error: Unknown action '$action' — issue lookup is: decisions search --issue <ISSUE_ID>" >&2
+    emit_error action-unknown "action=$action hint=search--issue" "Use decisions search --issue <ISSUE_ID> for issue lookup."
     exit 1
     ;;
   *)
-    echo "Error: Unknown action '$action'" >&2
+    emit_error action-unknown "action=$action" "The action is not supported."
     show_help
     exit 1
     ;;

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -44,6 +44,7 @@ cat >"$BAD_REPO/docs/decisions/INDEX.md" <<'EOF'
 | 2026-02-01 | D101 | PROJ-1 | Well-formed row | Reason one | Never | Active | [Full](D101.md) |
 | 2026-02-02 | D102 | PROJ-2 | Truncated row | Active |
 | 2026-02-03 | D103 | PROJ-3 | Second well-formed | Reason three | Never | Active | [Full](D103.md) |
+| 2026-02-04 | D104 | PROJ-4 | Seven-cell row | Reason four | Active | [Full](D104.md) |
 EOF
 
 run_decisions() {
@@ -225,6 +226,10 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
   warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | cells | length) < 8)' '| select(false)' 1)"
   failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
   expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
+
+  row_filter_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/wide-row-filter/decisions" '| select(length >= 8)' '| select(length >= 7)' 1)"
+  failures="$(evaluate_diagnostic_rows "$row_filter_mutant" control)"
+  expect_control_failure "$failures" malformed-row-results "a seven-cell row fails the result filter control"
 
   link_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-link-table/decider/tests/decider-index-parse.test.sh" LINK_CASES)"
   if decider_test_fails_with "$link_table_mutant" "link table executed no rows"; then

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -162,13 +162,7 @@ evaluate_diagnostic_rows() {
         ;;
       malformed-warning)
         first_line="${err%%$'\n'*}"
-        first=0
-        second=0
-        third=0
-        [[ "$first_line" == *"notice=index-row-invalid"* ]] && first=1
-        [[ "$first_line" == *"path=$BAD_REPO/docs/decisions/INDEX.md"* ]] && second=1
-        [[ "$first_line" == *"line=6"* ]] && third=1
-        actual="$rc~$first~$second~$third"
+        actual="$rc~$first_line"
         ;;
       empty-stderr)
         actual="$rc~${err:-<empty>}"
@@ -178,10 +172,11 @@ evaluate_diagnostic_rows() {
         continue
         ;;
     esac
+    expected="${expected//<bad-index>/$BAD_REPO\/docs\/decisions\/INDEX.md}"
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103
-malformed-row-diagnostic~malformed~malformed-warning~0~1~1~1
+malformed-row-diagnostic~malformed~malformed-warning~0~notice=index-row-invalid path=<bad-index> line=6 cells=5
 healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
 DIAGNOSTIC_CASES
   if [[ "$executed_rows" -eq 0 ]]; then
@@ -226,7 +221,7 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
   failures="$(evaluate_link_rows "$date_mutant" control)"
   expect_control_failure "$failures" date-enrichment "date mutation fails the enrichment row"
 
-  warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | split("|") | length) < 9)' '| select(false)' 1)"
+  warning_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/no-warning/decisions" '| select((.value | cells | length) < 8)' '| select(false)' 1)"
   failures="$(evaluate_diagnostic_rows "$warning_mutant" control)"
   expect_control_failure "$failures" malformed-row-diagnostic "warning suppression fails the diagnostic row"
 

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -141,7 +141,7 @@ LINK_CASES
 }
 
 evaluate_diagnostic_rows() {
-  local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second guard
+  local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second third guard first_line
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name fixture projection expected; do
@@ -161,11 +161,14 @@ evaluate_diagnostic_rows() {
         expected="0~0~$expected"
         ;;
       malformed-warning)
+        first_line="${err%%$'\n'*}"
         first=0
         second=0
-        [[ "$err" == *D102* || "$err" == *:6:* ]] && first=1
-        [[ "$err" == *:6:* ]] && second=1
-        actual="$rc~$first~$second"
+        third=0
+        [[ "$first_line" == *"notice=index-row-invalid"* ]] && first=1
+        [[ "$first_line" == *"path=$BAD_REPO/docs/decisions/INDEX.md"* ]] && second=1
+        [[ "$first_line" == *"line=6"* ]] && third=1
+        actual="$rc~$first~$second~$third"
         ;;
       empty-stderr)
         actual="$rc~${err:-<empty>}"
@@ -178,7 +181,7 @@ evaluate_diagnostic_rows() {
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103
-malformed-row-diagnostic~malformed~malformed-warning~0~1~1
+malformed-row-diagnostic~malformed~malformed-warning~0~1~1~1
 healthy-index-diagnostic~healthy~empty-stderr~0~<empty>
 DIAGNOSTIC_CASES
   if [[ "$executed_rows" -eq 0 ]]; then

--- a/skills/decider/tests/decider-index-parse.test.sh
+++ b/skills/decider/tests/decider-index-parse.test.sh
@@ -142,6 +142,7 @@ LINK_CASES
 
 evaluate_diagnostic_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name fixture projection expected actual first second third guard first_line
+  local bad_index="$BAD_REPO/docs/decisions/INDEX.md"
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name fixture projection expected; do
@@ -172,7 +173,7 @@ evaluate_diagnostic_rows() {
         continue
         ;;
     esac
-    expected="${expected//<bad-index>/$BAD_REPO\/docs\/decisions\/INDEX.md}"
+    expected="${expected//<bad-index>/$bad_index}"
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'DIAGNOSTIC_CASES'
 malformed-row-results~malformed~ids~D101,D103

--- a/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -55,7 +55,7 @@ record_row() {
 
 evaluate_action_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name kind argument expected actual guard
-  local first second projected projection_rc
+  local first second projected projection_rc first_line
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name kind argument expected; do
@@ -66,24 +66,29 @@ evaluate_action_rows() {
     case "$kind" in
       issue)
         run_decisions "$script" issue "$argument"
+        first_line="${err%%$'\n'*}"
         first=0
         second=0
-        [[ "$err" == *"Unknown action 'issue'"* ]] && first=1
-        [[ "$err" == *"search --issue"* ]] && second=1
+        [[ "$first_line" == *"error=action-unknown"* && "$first_line" == *"action=issue"* ]] && first=1
+        [[ "$first_line" == *"hint=search--issue"* ]] && second=1
         actual="$rc~$out~$first~$second"
         ;;
       issues)
         run_decisions "$script" issues "$argument"
+        first_line="${err%%$'\n'*}"
         first=0
-        [[ "$err" == *"search --issue"* ]] && first=1
-        actual="$rc~$first"
+        second=0
+        [[ "$first_line" == *"error=action-unknown"* && "$first_line" == *"action=issues"* ]] && first=1
+        [[ "$first_line" == *"hint=search--issue"* ]] && second=1
+        actual="$rc~$first~$second"
         ;;
       unknown)
         run_decisions "$script" "$argument" CC-125
+        first_line="${err%%$'\n'*}"
         first=0
         second=0
-        [[ "$err" == *"Unknown action '$argument'"* ]] && first=1
-        [[ "$out" == *"Usage: decisions"* ]] && second=1
+        [[ "$first_line" == *"error=action-unknown"* ]] && first=1
+        [[ "$first_line" == *"action=$argument"* ]] && second=1
         actual="$rc~$first~$second"
         ;;
       lookup)
@@ -102,7 +107,7 @@ evaluate_action_rows() {
     record_row "$mode" "$name" "$actual" "$expected"
   done <<'ACTION_CASES'
 issue-action~issue~CC-125~1~~1~1
-issues-action~issues~CC-125~1~1
+issues-action~issues~CC-125~1~1~1
 generic-unknown-action~unknown~bogus~1~1~1
 supported-issue-lookup~lookup~CC-125~0~0~D001
 ACTION_CASES
@@ -133,6 +138,14 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "wrong lookup result fails the supported lookup row"
   else
     fail "wrong lookup result did not fail the supported lookup row"
+  fi
+
+  diagnostic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/action-diagnostic-key/decisions" '    emit_error action-unknown "action=$action hint=search--issue"' '    emit_error action-invalid "action=$action hint=search--issue"' 1)"
+  failures="$(evaluate_action_rows "$diagnostic_mutant" control issue-action)"
+  if [[ "$failures" == *'|issue-action|'* ]]; then
+    pass "a changed action key fails its row"
+  else
+    fail "a changed action key did not fail its row"
   fi
 
   action_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-action-table/decider/tests/decider-issue-action-hint.test.sh" ACTION_CASES)"

--- a/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -114,7 +114,7 @@ record_row() {
 
 evaluate_next_id_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name repo_name environment expected_status
-  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected guard
+  local stdout_rule expected_stdout stderr_rule repo actual_stdout actual_stderr actual expected guard first_line
   local executed_rows=0
   table_failures=""
   while IFS='~' read -r name repo_name environment expected_status stdout_rule expected_stdout stderr_rule; do
@@ -129,6 +129,7 @@ evaluate_next_id_rows() {
       ignore) actual_stdout=ignored; expected_stdout=ignored ;;
       *) fail "unknown stdout rule: $stdout_rule"; continue ;;
     esac
+    first_line="${err%%$'\n'*}"
     case "$stderr_rule" in
       empty)
         actual_stderr="$err"
@@ -140,14 +141,15 @@ evaluate_next_id_rows() {
         ;;
       bad-id-prefix)
         actual_stderr=0,0
-        [[ "$err" == *ADR-current* ]] && actual_stderr=1,0
-        [[ "$err" == *ADR-current* && "$err" == *DECISION_ID_PREFIX* ]] && actual_stderr=1,1
+        [[ "$first_line" == *"error=id-suffix-missing"* ]] && actual_stderr=1,0
+        [[ "$first_line" == *"error=id-suffix-missing"* && "$first_line" == *"value=ADR-current"* ]] && actual_stderr=1,1
         expected=1,1
         ;;
       width)
-        actual_stderr=0
-        [[ "$err" == *DECISION_ID_WIDTH* ]] && actual_stderr=1
-        expected=1
+        actual_stderr=0,0
+        [[ "$first_line" == *"error=id-width-invalid"* ]] && actual_stderr=1,0
+        [[ "$first_line" == *"error=id-width-invalid"* && "$first_line" == *"value=zero"* ]] && actual_stderr=1,1
+        expected=1,1
         ;;
       *) fail "unknown stderr rule: $stderr_rule"; continue ;;
     esac
@@ -191,6 +193,14 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "wrong next ID fails the inferred scheme row"
   else
     fail "wrong next ID did not fail the inferred scheme row"
+  fi
+
+  diagnostic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/id-diagnostic-key/decisions" '        emit_error id-suffix-missing "value=$last_id"' '        emit_error id-suffix-invalid "value=$last_id"' 1)"
+  failures="$(evaluate_next_id_rows "$diagnostic_mutant" control unparseable-last-id)"
+  if [[ "$failures" == *'|unparseable-last-id|'* ]]; then
+    pass "a changed ID diagnostic key fails its row"
+  else
+    fail "a changed ID diagnostic key did not fail its row"
   fi
 
   next_id_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-next-id-table/decider/tests/decider-next-id-scheme.test.sh" NEXT_ID_CASES)"

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -35,6 +35,15 @@ cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
 | 2026-01-10 | D001 | PROJ-100 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
 EOF
 
+NO_INDEX_DIR="$TMP_ROOT/no-index-project"
+mkdir -p "$NO_INDEX_DIR/docs/decisions"
+
+NO_JQ_BIN="$TMP_ROOT/no-jq-bin"
+mkdir -p "$NO_JQ_BIN"
+ln -s "$(command -v git)" "$NO_JQ_BIN/git"
+ln -s "$(command -v dirname)" "$NO_JQ_BIN/dirname"
+BASH_BIN="$(command -v bash)"
+
 NOT_A_DIR="$TMP_ROOT/not-a-dir"
 touch "$NOT_A_DIR"
 
@@ -51,6 +60,12 @@ run_decisions() {
       ;;
     existing)
       out=$( (cd "$HAS_DIR" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    missing-index)
+      out=$( (cd "$NO_INDEX_DIR" && env -u DECISIONS_DIR DECISIONS_DIR=docs/decisions "$script" "$@") 2>"$ERR_FILE")
+      ;;
+    missing-dependency)
+      out=$( (cd "$HAS_DIR" && env -u DECISIONS_DIR PATH="$NO_JQ_BIN" DECISIONS_DIR=docs/decisions "$BASH_BIN" "$script" "$@") 2>"$ERR_FILE")
       ;;
     configured-file)
       out=$( (cd "$NO_DIR" && env -u DECISIONS_DIR DECISIONS_DIR="$NOT_A_DIR" "$script" "$@") 2>"$ERR_FILE")
@@ -93,10 +108,16 @@ evaluate_directory_rows() {
     fi
     executed_rows=$((executed_rows + 1))
     case "$action" in
+      dependency) run_decisions "$script" "$state" list ;;
       issue) run_decisions "$script" "$state" search --issue "$argument" ;;
+      issue-missing) run_decisions "$script" "$state" search --issue ;;
       keyword) run_decisions "$script" "$state" search "$argument" ;;
+      limit-missing) run_decisions "$script" "$state" search "$argument" --limit ;;
+      limit-invalid) run_decisions "$script" "$state" search "$argument" --limit nope ;;
+      search-empty) run_decisions "$script" "$state" search --limit 1 ;;
       list|next-id|help) run_decisions "$script" "$state" "$action" ;;
       get) run_decisions "$script" "$state" get "$argument" ;;
+      get-missing) run_decisions "$script" "$state" get ;;
       *) fail "unknown directory-row action: $action"; continue ;;
     esac
 
@@ -128,10 +149,8 @@ evaluate_directory_rows() {
     [[ "$needle_two" == '<not-a-dir>' ]] && needle_two="path=$NOT_A_DIR"
     case "$stderr_rule" in
       key-value)
-        actual_stderr=0,0
-        [[ "$first_line" == *"$needle_one"* ]] && actual_stderr=1,0
-        [[ "$first_line" == *"$needle_one"* && "$first_line" == *"$needle_two"* ]] && actual_stderr=1,1
-        expected=1,1
+        actual_stderr="$first_line"
+        expected="$needle_one $needle_two"
         ;;
       empty)
         actual_stderr="$err"
@@ -158,6 +177,14 @@ existing-keyword-miss~existing~keyword~zzz nonexistent term~0~exact~[]~empty~~
 existing-issue-miss~existing~issue~PROJ-999~0~exact~[]~empty~~
 existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
 existing-next-id~existing~next-id~~0~exact~D002~ignore~~
+missing-jq~missing-dependency~dependency~~1~ignore~~key-value~error=dependency-missing~command=jq
+missing-index~missing-index~list~~1~ignore~~key-value~error=index-missing~path=docs/decisions/INDEX.md
+missing-search-input~existing~search-empty~~1~ignore~~key-value~error=search-input-missing~value=query-or-issue
+missing-decision~existing~get~D999~1~ignore~~key-value~error=decision-not-found~id=D999
+missing-issue-value~existing~issue-missing~~1~ignore~~key-value~error=argument-value-missing~option=--issue
+missing-limit-value~existing~limit-missing~redis~1~ignore~~key-value~error=argument-value-missing~option=--limit
+invalid-limit-value~existing~limit-invalid~redis~1~ignore~~key-value~error=limit-invalid~value=nope
+missing-get-value~existing~get-missing~~1~ignore~~key-value~error=argument-value-missing~action=get
 configured-file-search~configured-file~issue~PROJ-557~1~exact~~key-value~error=decisions-dir-type~<not-a-dir>
 configured-file-next-id~configured-file~next-id~~1~ignore~~key-value~error=decisions-dir-type~<not-a-dir>
 DIRECTORY_CASES

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -83,7 +83,7 @@ record_row() {
 
 evaluate_directory_rows() {
   local script="$1" mode="$2" only_row="${3:-}" name state action argument expected_status
-  local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr
+  local stdout_rule expected_stdout stderr_rule needle_one needle_two actual_stdout actual_stderr first_line
   local projected projection_rc actual expected guard
   local executed_rows=0
   table_failures=""
@@ -124,16 +124,13 @@ evaluate_directory_rows() {
       *) fail "unknown stdout rule: $stdout_rule"; continue ;;
     esac
 
+    first_line="${err%%$'\n'*}"
+    [[ "$needle_two" == '<not-a-dir>' ]] && needle_two="path=$NOT_A_DIR"
     case "$stderr_rule" in
-      contains)
-        actual_stderr=0
-        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1
-        expected=1
-        ;;
-      both)
+      key-value)
         actual_stderr=0,0
-        [[ "$err" == *"$needle_one"* ]] && actual_stderr=1,0
-        [[ "$err" == *"$needle_one"* && "$err" == *"$needle_two"* ]] && actual_stderr=1,1
+        [[ "$first_line" == *"$needle_one"* ]] && actual_stderr=1,0
+        [[ "$first_line" == *"$needle_one"* && "$first_line" == *"$needle_two"* ]] && actual_stderr=1,1
         expected=1,1
         ;;
       empty)
@@ -150,19 +147,19 @@ evaluate_directory_rows() {
     actual="$rc~$actual_stdout~$actual_stderr"
     record_row "$mode" "$name" "$actual" "$expected_status~$expected_stdout~$expected"
   done <<'DIRECTORY_CASES'
-configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~both~docs/decisions~not present
-configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~contains~not present~
-configured-absent-list~configured-absent~list~~0~exact~[]~contains~not present~
-configured-absent-next-id~configured-absent~next-id~~1~ignore~~contains~does not exist~
-configured-absent-get~configured-absent~get~D001~1~ignore~~contains~does not exist~
-undiscovered-issue~undiscovered~issue~PROJ-557~0~exact~[]~contains~no decisions directory found~
+configured-absent-issue~configured-absent~issue~PROJ-557~0~exact~[]~key-value~notice=decisions-dir-absent~path=docs/decisions
+configured-absent-keyword~configured-absent~keyword~ffi error handling~0~exact~[]~key-value~notice=decisions-dir-absent~path=docs/decisions
+configured-absent-list~configured-absent~list~~0~exact~[]~key-value~notice=decisions-dir-absent~path=docs/decisions
+configured-absent-next-id~configured-absent~next-id~~1~ignore~~key-value~error=decisions-dir-absent~path=docs/decisions
+configured-absent-get~configured-absent~get~D001~1~ignore~~key-value~error=decisions-dir-absent~path=docs/decisions
+undiscovered-issue~undiscovered~issue~PROJ-557~0~exact~[]~key-value~notice=decisions-dir-absent~path=auto
 help-without-directory~undiscovered~help~~0~contains~Decision Lookup Tool~ignore~~
 existing-keyword-miss~existing~keyword~zzz nonexistent term~0~exact~[]~empty~~
 existing-issue-miss~existing~issue~PROJ-999~0~exact~[]~empty~~
 existing-keyword-hit~existing~keyword~redis~0~ids~["D001"]~ignore~~
 existing-next-id~existing~next-id~~0~exact~D002~ignore~~
-configured-file-search~configured-file~issue~PROJ-557~1~exact~~contains~is not a directory~
-configured-file-next-id~configured-file~next-id~~1~ignore~~contains~is not a directory~
+configured-file-search~configured-file~issue~PROJ-557~1~exact~~key-value~error=decisions-dir-type~<not-a-dir>
+configured-file-next-id~configured-file~next-id~~1~ignore~~key-value~error=decisions-dir-type~<not-a-dir>
 DIRECTORY_CASES
   if [[ "$executed_rows" -eq 0 ]]; then
     guard="directory table executed no rows"
@@ -205,6 +202,14 @@ if [[ -z "${DECIDER_TABLE_CONTROL_RUN:-}" ]]; then
     pass "absent keyword-search failure fails its row"
   else
     fail "absent keyword-search failure did not fail its row"
+  fi
+
+  diagnostic_mutant="$(decider_mutate_script "$DECISIONS" "$TMP_ROOT/diagnostic-key/decisions" '    emit_notice decisions-dir-absent "path=$DECISIONS_DIR"' '    emit_notice decisions-dir-missing "path=$DECISIONS_DIR"' 1)"
+  failures="$(evaluate_directory_rows "$diagnostic_mutant" control configured-absent-issue)"
+  if [[ "$failures" == *'|configured-absent-issue|'* ]]; then
+    pass "a changed diagnostic key fails its row"
+  else
+    fail "a changed diagnostic key did not fail its row"
   fi
 
   directory_table_mutant="$(decider_empty_test_table "${BASH_SOURCE[0]}" "$TMP_ROOT/empty-directory-table/decider/tests/decider-search-missing-dir.test.sh" DIRECTORY_CASES)"

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -111,9 +111,13 @@ evaluate_directory_rows() {
       dependency) run_decisions "$script" "$state" list ;;
       issue) run_decisions "$script" "$state" search --issue "$argument" ;;
       issue-missing) run_decisions "$script" "$state" search --issue ;;
+      issue-empty) run_decisions "$script" "$state" search --issue= ;;
+      issue-regex-invalid) run_decisions "$script" "$state" search --issue "$argument" ;;
       keyword) run_decisions "$script" "$state" search "$argument" ;;
       limit-missing) run_decisions "$script" "$state" search "$argument" --limit ;;
+      limit-empty) run_decisions "$script" "$state" search "$argument" --limit= ;;
       limit-invalid) run_decisions "$script" "$state" search "$argument" --limit nope ;;
+      query-regex-invalid) run_decisions "$script" "$state" search "$argument" ;;
       search-empty) run_decisions "$script" "$state" search --limit 1 ;;
       list|next-id|help) run_decisions "$script" "$state" "$action" ;;
       get) run_decisions "$script" "$state" get "$argument" ;;
@@ -182,8 +186,12 @@ missing-index~missing-index~list~~1~ignore~~key-value~error=index-missing~path=d
 missing-search-input~existing~search-empty~~1~ignore~~key-value~error=search-input-missing~value=query-or-issue
 missing-decision~existing~get~D999~1~ignore~~key-value~error=decision-not-found~id=D999
 missing-issue-value~existing~issue-missing~~1~ignore~~key-value~error=argument-value-missing~option=--issue
+empty-issue-value~existing~issue-empty~~1~ignore~~key-value~error=argument-value-missing~option=--issue
 missing-limit-value~existing~limit-missing~redis~1~ignore~~key-value~error=argument-value-missing~option=--limit
+empty-limit-value~existing~limit-empty~redis~1~ignore~~key-value~error=argument-value-missing~option=--limit
 invalid-limit-value~existing~limit-invalid~redis~1~ignore~~key-value~error=limit-invalid~value=nope
+invalid-query-regex~existing~query-regex-invalid~(~1~ignore~~key-value~error=regex-invalid~value=(
+invalid-issue-regex~existing~issue-regex-invalid~[~1~ignore~~key-value~error=regex-invalid~value=[
 missing-get-value~existing~get-missing~~1~ignore~~key-value~error=argument-value-missing~action=get
 configured-file-search~configured-file~issue~PROJ-557~1~exact~~key-value~error=decisions-dir-type~<not-a-dir>
 configured-file-next-id~configured-file~next-id~~1~ignore~~key-value~error=decisions-dir-type~<not-a-dir>


### PR DESCRIPTION
## Summary

- Add stable key/value first lines to every Decider refusal and notice.
- Keep English explanations on later lines.
- Replace English test pins with key, value, and exit-status assertions.
- Preserve source and tracked-render copies in the same change.

## Changed files

- `scripts/decisions`
- `tests/decider-index-parse.test.sh`
- `tests/decider-issue-action-hint.test.sh`
- `tests/decider-next-id-scheme.test.sh`
- `tests/decider-search-missing-dir.test.sh`
- The matching `.agents/skills/decider` renders.

## Compliant files left unchanged

- `SKILL.md`, `README.md`, and `kendex.settings.toml.example`
- `schemas/decision-format.md`
- `templates/decision-entry.md` and `templates/index-row.md`
- `workflows/create-decision.md` and `workflows/update-decision.md`
- `tests/decider-search-body.test.sh` and `tests/lib/mutate-script.sh`
- `scripts/lib/kendex-env.sh`. The orch package owns its canonical change and all vendored copies.
- The matching tracked renders.

## Validation

- All five Decider package suites pass on `98122d0bf6e644eacfd7a3e3dbf75eedb92821ba`.
- Each changed test surface has a must-fail control.
- `env -u TMPDIR tools/guard --full` passes on that head.

Linear: KEN-1241
