### PR TITLE
fix(KEN-1241): stabilize verification scope errors

### DIFF
--- a/.agents/skills/project-management/scripts/verification-scope
+++ b/.agents/skills/project-management/scripts/verification-scope
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Resolve repository-aware paths for tpm-audit code and deliverable checks.
+# Diagnostic protocol: each refusal starts with `error=KEY FIELD=VALUE`.
+# English guidance follows on the next line.
 set -euo pipefail
 
 usage() {
@@ -34,8 +36,11 @@ absolute worktree before any search or read.
 EOF
 }
 
-fail() {
-  echo "verification-scope: $*" >&2
+refuse() { # KEY FIELD=VALUE EXPLANATION
+  local key="$1" field="$2"
+  shift 2
+  printf 'error=%s %s\n' "$key" "$field" >&2
+  printf 'verification-scope: %s\n' "$*" >&2
   exit 1
 }
 
@@ -47,17 +52,17 @@ declare -a explicit_paths=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --worktree)
-      [[ $# -ge 2 ]] || fail "--worktree requires a path"
+      [[ $# -ge 2 ]] || refuse argument-missing option=--worktree "--worktree requires a path."
       worktree="$2"
       shift 2
       ;;
     --base-ref)
-      [[ $# -ge 2 ]] || fail "--base-ref requires a ref"
+      [[ $# -ge 2 ]] || refuse argument-missing option=--base-ref "--base-ref requires a ref."
       base_ref="$2"
       shift 2
       ;;
     --changed-file)
-      [[ $# -ge 2 ]] || fail "--changed-file requires a repository-relative path"
+      [[ $# -ge 2 ]] || refuse argument-missing option=--changed-file "--changed-file requires a repository-relative path."
       explicit_paths+=("$2")
       shift 2
       ;;
@@ -70,18 +75,18 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      fail "unknown argument: $1"
+      refuse argument-unknown "value=$1" "The argument is not supported."
       ;;
   esac
 done
 
-[[ -d "$worktree" ]] || fail "worktree does not exist: $worktree"
+[[ -d "$worktree" ]] || refuse worktree-missing "path=$worktree" "The worktree does not exist."
 repo_root="$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null)" \
-  || fail "worktree is not inside a Git repository: $worktree"
+  || refuse worktree-not-repository "path=$worktree" "The worktree is not inside a Git repository."
 repo_root="$(cd "$repo_root" && pwd -P)"
 
 if [[ -n "$base_ref" && ${#explicit_paths[@]} -gt 0 ]]; then
-  fail "use either --base-ref or --changed-file, not both"
+  refuse scope-input-conflict value=base-ref+changed-file "Use either --base-ref or --changed-file, not both."
 fi
 
 declare -a candidates=()
@@ -96,16 +101,16 @@ cleanup() {
 trap cleanup EXIT
 
 capture_git_paths() {
-  local diagnostic="$1"
-  shift
+  local operation="$1" diagnostic="$2"
+  shift 2
 
   if [[ -n "$producer_output" ]]; then
     rm -f "$producer_output"
   fi
   producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX")" \
-    || fail "could not create temporary file for Git output"
-  if ! git -C "$repo_root" "$@" >"$producer_output"; then
-    fail "$diagnostic"
+    || refuse temp-create "path=${TMPDIR:-/tmp}" "Could not create a temporary file for Git output."
+  if ! git -C "$repo_root" "$@" >"$producer_output" 2>/dev/null; then
+    refuse git-command-failed "operation=$operation" "$diagnostic"
   fi
 }
 
@@ -117,12 +122,12 @@ normalize_path() {
   if [[ "$path" == "$repo_root"/* ]]; then
     path="${path#"$repo_root"/}"
   elif [[ "$path" == /* ]]; then
-    fail "path is outside the worktree: $path"
+    refuse path-outside "path=$path" "The path is outside the worktree."
   fi
-  [[ -n "$path" ]] || fail "empty changed path"
+  [[ -n "$path" ]] || refuse path-empty value=empty "The changed path is empty."
   case "$path" in
     ..|../*|*/..|*/../*)
-      fail "path escapes the worktree: $path"
+      refuse path-escape "path=$path" "The path escapes the worktree."
       ;;
   esac
   printf '%s\n' "$path"
@@ -136,8 +141,9 @@ if [[ ${#explicit_paths[@]} -gt 0 ]]; then
 elif [[ -n "$base_ref" ]]; then
   basis="base-ref"
   git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null \
-    || fail "base ref is not a commit: $base_ref"
+    || refuse base-ref-invalid "ref=$base_ref" "The base ref is not a commit."
   capture_git_paths \
+    diff \
     "git diff failed for base ref '$base_ref'; verify the ref and that it shares history with HEAD" \
     diff --name-only -z "${base_ref}...HEAD" --
   while IFS= read -r -d '' path; do
@@ -224,7 +230,7 @@ mode="repository"
 if [[ "$force_docs_only" == true ]]; then
   for path in ${candidates[@]+"${candidates[@]}"}; do
     is_doc_path "$path" \
-      || fail "--docs-only path is not documentation: $path"
+      || refuse docs-only-nondoc "path=$path" "The --docs-only path is not documentation."
   done
   mode="docs-only"
 elif [[ ${#candidates[@]} -gt 0 ]]; then
@@ -250,6 +256,7 @@ add_source_root() {
 
 if [[ "$mode" == "repository" ]]; then
   capture_git_paths \
+    ls-files \
     "git ls-files failed while discovering tracked source roots" \
     ls-files -z
   while IFS= read -r -d '' path; do
@@ -269,7 +276,7 @@ elif [[ "$mode" == "changed" ]]; then
 fi
 
 if [[ "$mode" == "repository" && ${#source_roots[@]} -eq 0 ]]; then
-  fail "no tracked source roots found outside the vendored .agents/ render tree; pass changed paths or --docs-only for a documentation-only audit"
+  refuse source-roots-empty count=0 "No source roots were found outside the vendored .agents render tree. Pass changed paths or --docs-only for a documentation-only audit."
 fi
 
 declare -a verification_paths=()

--- a/.agents/skills/project-management/scripts/verification-scope
+++ b/.agents/skills/project-management/scripts/verification-scope
@@ -107,7 +107,7 @@ capture_git_paths() {
   if [[ -n "$producer_output" ]]; then
     rm -f "$producer_output"
   fi
-  producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX")" \
+  producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX" 2>/dev/null)" \
     || refuse temp-create "path=${TMPDIR:-/tmp}" "Could not create a temporary file for Git output."
   if ! git -C "$repo_root" "$@" >"$producer_output" 2>/dev/null; then
     refuse git-command-failed "operation=$operation" "$diagnostic"

--- a/.agents/skills/project-management/tests/verification-scope.test.sh
+++ b/.agents/skills/project-management/tests/verification-scope.test.sh
@@ -175,20 +175,21 @@ refusal_rows_executed=0
 
 record_refusal_failure() {
   local case_name="$1" description="$2" status="$3"
-  local expected_status="$4" diagnostic="$5" output="$6"
+  local expected_status="$4" expected_key="$5" expected_value="$6" output="$7"
 
   echo "FAIL: $case_name: $description" >&2
   echo "  status: $status; expected: $expected_status" >&2
-  if [[ "$diagnostic" != "-" && "$output" != *"$diagnostic"* ]]; then
-    echo "  missing diagnostic: $diagnostic" >&2
+  echo "  expected first-line fields: $expected_key $expected_value" >&2
+  if [[ "$output" != *"$expected_key"* || "$output" != *"$expected_value"* ]]; then
+    echo "  actual output: $output" >&2
   fi
   refusal_failures=$((refusal_failures + 1))
 }
 
 run_refusal_case() {
   local case_name="$1" fixture_kind="$2" invocation="$3"
-  local expected_status="$4" diagnostic="$5" description="$6"
-  local output status matches
+  local expected_status="$4" expected_key="$5" expected_value="$6" description="$7"
+  local output status matches first_line
 
   setup_fixture "$fixture_kind" "$case_name"
   case "$invocation" in
@@ -237,27 +238,27 @@ run_refusal_case() {
   esac
 
   matches=true
+  first_line="${output%%$'\n'*}"
   [[ "$status" -eq "$expected_status" ]] || matches=false
-  if [[ "$diagnostic" != "-" && "$output" != *"$diagnostic"* ]]; then
-    matches=false
-  fi
+  [[ "$first_line" == *"$expected_key"* ]] || matches=false
+  [[ "$first_line" == *"$expected_value"* ]] || matches=false
   if [[ "$matches" != true ]]; then
     record_refusal_failure "$case_name" "$description" "$status" \
-      "$expected_status" "$diagnostic" "$output"
+      "$expected_status" "$expected_key" "$expected_value" "$output"
   fi
 }
 
 while IFS='^' read -r case_name fixture_kind invocation expected_status \
-  diagnostic description; do
+  expected_key expected_value description; do
   run_refusal_case "$case_name" "$fixture_kind" "$invocation" \
-    "$expected_status" "$diagnostic" "$description"
+    "$expected_status" "$expected_key" "$expected_value" "$description"
   refusal_rows_executed=$((refusal_rows_executed + 1))
 done <<'REFUSAL_ROWS'
-forced-docs-rejects-code^workspace^forced-docs-code^1^-^forced docs mode did not reject source code with the exact refusal status
-outside-worktree-path^workspace^outside-worktree^1^-^resolver did not reject an outside path with the exact refusal status
-repository-without-source^documentation^repository-without-source^1^no tracked source roots found^repository fallback did not return its exact status and source-scope diagnostic
-disconnected-base-history^disconnected-history^disconnected-base^1^git diff failed for base ref^base-ref mode did not return its exact status and disconnected-history diagnostic
-ls-files-producer-failure^corrupt-index^corrupt-index^1^git ls-files failed^repository discovery did not return its exact status and producer diagnostic
+forced-docs-rejects-code^workspace^forced-docs-code^1^error=docs-only-nondoc^path=crate-a/src/lib.rs^forced docs mode did not reject source code with the exact refusal status
+outside-worktree-path^workspace^outside-worktree^1^error=path-escape^path=../outside.rs^resolver did not reject an outside path with the exact refusal status
+repository-without-source^documentation^repository-without-source^1^error=source-roots-empty^count=0^repository fallback did not return its exact status and source-scope diagnostic
+disconnected-base-history^disconnected-history^disconnected-base^1^error=git-command-failed^operation=diff^base-ref mode did not return its exact status and disconnected-history diagnostic
+ls-files-producer-failure^corrupt-index^corrupt-index^1^error=git-command-failed^operation=ls-files^repository discovery did not return its exact status and producer diagnostic
 REFUSAL_ROWS
 
 [[ "$refusal_rows_executed" -gt 0 ]] \

--- a/.agents/skills/project-management/tests/verification-scope.test.sh
+++ b/.agents/skills/project-management/tests/verification-scope.test.sh
@@ -66,6 +66,9 @@ setup_fixture() {
       git -C "$case_root" init -q
       git -C "$case_root" add README.md
       ;;
+    plain)
+      printf 'not a repository\n' >"$case_root/file.txt"
+      ;;
     disconnected-history)
       mkdir -p "$case_root/src"
       printf 'fn main() {}\n' >"$case_root/src/main.rs"
@@ -192,7 +195,42 @@ run_refusal_case() {
   local output status matches first_line
 
   setup_fixture "$fixture_kind" "$case_name"
+  expected_value="${expected_value//<root>/$case_root}"
+  expected_value="${expected_value//<scratch>/$scratch}"
   case "$invocation" in
+    argument-worktree)
+      if output="$($RESOLVER --worktree 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    argument-base)
+      if output="$($RESOLVER --worktree "$case_root" --base-ref 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    argument-changed)
+      if output="$($RESOLVER --worktree "$case_root" --changed-file 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    argument-unknown)
+      if output="$($RESOLVER --unknown 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    worktree-missing)
+      if output="$($RESOLVER --worktree "$scratch/absent-worktree" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    worktree-not-repository)
+      if output="$($RESOLVER --worktree "$case_root" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    scope-conflict)
+      if output="$($RESOLVER --worktree "$case_root" --base-ref HEAD --changed-file crate-a/src/lib.rs 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    temp-create)
+      if output="$(TMPDIR="$case_root/missing-temp" $RESOLVER --worktree "$case_root" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    absolute-path)
+      if output="$($RESOLVER --worktree "$case_root" --changed-file "$scratch/outside.rs" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    empty-path)
+      if output="$($RESOLVER --worktree "$case_root" --changed-file '' 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    invalid-base)
+      if output="$($RESOLVER --worktree "$case_root" --base-ref does-not-exist 2>&1)"; then status=0; else status=$?; fi
+      ;;
     forced-docs-code)
       if output="$($RESOLVER --worktree "$case_root" --docs-only \
         --changed-file crate-a/src/lib.rs 2>&1)"; then
@@ -240,8 +278,7 @@ run_refusal_case() {
   matches=true
   first_line="${output%%$'\n'*}"
   [[ "$status" -eq "$expected_status" ]] || matches=false
-  [[ "$first_line" == *"$expected_key"* ]] || matches=false
-  [[ "$first_line" == *"$expected_value"* ]] || matches=false
+  [[ "$first_line" == "$expected_key $expected_value" ]] || matches=false
   if [[ "$matches" != true ]]; then
     record_refusal_failure "$case_name" "$description" "$status" \
       "$expected_status" "$expected_key" "$expected_value" "$output"
@@ -254,6 +291,17 @@ while IFS='^' read -r case_name fixture_kind invocation expected_status \
     "$expected_status" "$expected_key" "$expected_value" "$description"
   refusal_rows_executed=$((refusal_rows_executed + 1))
 done <<'REFUSAL_ROWS'
+missing-worktree-option^workspace^argument-worktree^1^error=argument-missing^option=--worktree^missing worktree option value did not return its exact diagnostic
+missing-base-option^workspace^argument-base^1^error=argument-missing^option=--base-ref^missing base option value did not return its exact diagnostic
+missing-changed-option^workspace^argument-changed^1^error=argument-missing^option=--changed-file^missing changed-file option value did not return its exact diagnostic
+unknown-option^workspace^argument-unknown^1^error=argument-unknown^value=--unknown^unknown option did not return its exact diagnostic
+missing-worktree^workspace^worktree-missing^1^error=worktree-missing^path=<scratch>/absent-worktree^missing worktree did not return its exact diagnostic
+non-repository-worktree^plain^worktree-not-repository^1^error=worktree-not-repository^path=<root>^plain directory did not return its exact diagnostic
+conflicting-scope-inputs^workspace^scope-conflict^1^error=scope-input-conflict^value=base-ref+changed-file^conflicting scope inputs did not return their exact diagnostic
+temporary-file-failure^workspace^temp-create^1^error=temp-create^path=<root>/missing-temp^temporary-file failure did not return its exact diagnostic first
+absolute-changed-path^workspace^absolute-path^1^error=path-outside^path=<scratch>/outside.rs^absolute outside path did not return its exact diagnostic
+empty-changed-path^workspace^empty-path^1^error=path-empty^value=empty^empty changed path did not return its exact diagnostic
+invalid-base-ref^workspace^invalid-base^1^error=base-ref-invalid^ref=does-not-exist^invalid base ref did not return its exact diagnostic
 forced-docs-rejects-code^workspace^forced-docs-code^1^error=docs-only-nondoc^path=crate-a/src/lib.rs^forced docs mode did not reject source code with the exact refusal status
 outside-worktree-path^workspace^outside-worktree^1^error=path-escape^path=../outside.rs^resolver did not reject an outside path with the exact refusal status
 repository-without-source^documentation^repository-without-source^1^error=source-roots-empty^count=0^repository fallback did not return its exact status and source-scope diagnostic

--- a/skills/project-management/scripts/verification-scope
+++ b/skills/project-management/scripts/verification-scope
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Resolve repository-aware paths for tpm-audit code and deliverable checks.
+# Diagnostic protocol: each refusal starts with `error=KEY FIELD=VALUE`.
+# English guidance follows on the next line.
 set -euo pipefail
 
 usage() {
@@ -34,8 +36,11 @@ absolute worktree before any search or read.
 EOF
 }
 
-fail() {
-  echo "verification-scope: $*" >&2
+refuse() { # KEY FIELD=VALUE EXPLANATION
+  local key="$1" field="$2"
+  shift 2
+  printf 'error=%s %s\n' "$key" "$field" >&2
+  printf 'verification-scope: %s\n' "$*" >&2
   exit 1
 }
 
@@ -47,17 +52,17 @@ declare -a explicit_paths=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --worktree)
-      [[ $# -ge 2 ]] || fail "--worktree requires a path"
+      [[ $# -ge 2 ]] || refuse argument-missing option=--worktree "--worktree requires a path."
       worktree="$2"
       shift 2
       ;;
     --base-ref)
-      [[ $# -ge 2 ]] || fail "--base-ref requires a ref"
+      [[ $# -ge 2 ]] || refuse argument-missing option=--base-ref "--base-ref requires a ref."
       base_ref="$2"
       shift 2
       ;;
     --changed-file)
-      [[ $# -ge 2 ]] || fail "--changed-file requires a repository-relative path"
+      [[ $# -ge 2 ]] || refuse argument-missing option=--changed-file "--changed-file requires a repository-relative path."
       explicit_paths+=("$2")
       shift 2
       ;;
@@ -70,18 +75,18 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      fail "unknown argument: $1"
+      refuse argument-unknown "value=$1" "The argument is not supported."
       ;;
   esac
 done
 
-[[ -d "$worktree" ]] || fail "worktree does not exist: $worktree"
+[[ -d "$worktree" ]] || refuse worktree-missing "path=$worktree" "The worktree does not exist."
 repo_root="$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null)" \
-  || fail "worktree is not inside a Git repository: $worktree"
+  || refuse worktree-not-repository "path=$worktree" "The worktree is not inside a Git repository."
 repo_root="$(cd "$repo_root" && pwd -P)"
 
 if [[ -n "$base_ref" && ${#explicit_paths[@]} -gt 0 ]]; then
-  fail "use either --base-ref or --changed-file, not both"
+  refuse scope-input-conflict value=base-ref+changed-file "Use either --base-ref or --changed-file, not both."
 fi
 
 declare -a candidates=()
@@ -96,16 +101,16 @@ cleanup() {
 trap cleanup EXIT
 
 capture_git_paths() {
-  local diagnostic="$1"
-  shift
+  local operation="$1" diagnostic="$2"
+  shift 2
 
   if [[ -n "$producer_output" ]]; then
     rm -f "$producer_output"
   fi
   producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX")" \
-    || fail "could not create temporary file for Git output"
-  if ! git -C "$repo_root" "$@" >"$producer_output"; then
-    fail "$diagnostic"
+    || refuse temp-create "path=${TMPDIR:-/tmp}" "Could not create a temporary file for Git output."
+  if ! git -C "$repo_root" "$@" >"$producer_output" 2>/dev/null; then
+    refuse git-command-failed "operation=$operation" "$diagnostic"
   fi
 }
 
@@ -117,12 +122,12 @@ normalize_path() {
   if [[ "$path" == "$repo_root"/* ]]; then
     path="${path#"$repo_root"/}"
   elif [[ "$path" == /* ]]; then
-    fail "path is outside the worktree: $path"
+    refuse path-outside "path=$path" "The path is outside the worktree."
   fi
-  [[ -n "$path" ]] || fail "empty changed path"
+  [[ -n "$path" ]] || refuse path-empty value=empty "The changed path is empty."
   case "$path" in
     ..|../*|*/..|*/../*)
-      fail "path escapes the worktree: $path"
+      refuse path-escape "path=$path" "The path escapes the worktree."
       ;;
   esac
   printf '%s\n' "$path"
@@ -136,8 +141,9 @@ if [[ ${#explicit_paths[@]} -gt 0 ]]; then
 elif [[ -n "$base_ref" ]]; then
   basis="base-ref"
   git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null \
-    || fail "base ref is not a commit: $base_ref"
+    || refuse base-ref-invalid "ref=$base_ref" "The base ref is not a commit."
   capture_git_paths \
+    diff \
     "git diff failed for base ref '$base_ref'; verify the ref and that it shares history with HEAD" \
     diff --name-only -z "${base_ref}...HEAD" --
   while IFS= read -r -d '' path; do
@@ -224,7 +230,7 @@ mode="repository"
 if [[ "$force_docs_only" == true ]]; then
   for path in ${candidates[@]+"${candidates[@]}"}; do
     is_doc_path "$path" \
-      || fail "--docs-only path is not documentation: $path"
+      || refuse docs-only-nondoc "path=$path" "The --docs-only path is not documentation."
   done
   mode="docs-only"
 elif [[ ${#candidates[@]} -gt 0 ]]; then
@@ -250,6 +256,7 @@ add_source_root() {
 
 if [[ "$mode" == "repository" ]]; then
   capture_git_paths \
+    ls-files \
     "git ls-files failed while discovering tracked source roots" \
     ls-files -z
   while IFS= read -r -d '' path; do
@@ -269,7 +276,7 @@ elif [[ "$mode" == "changed" ]]; then
 fi
 
 if [[ "$mode" == "repository" && ${#source_roots[@]} -eq 0 ]]; then
-  fail "no tracked source roots found outside the vendored .agents/ render tree; pass changed paths or --docs-only for a documentation-only audit"
+  refuse source-roots-empty count=0 "No source roots were found outside the vendored .agents render tree. Pass changed paths or --docs-only for a documentation-only audit."
 fi
 
 declare -a verification_paths=()

--- a/skills/project-management/scripts/verification-scope
+++ b/skills/project-management/scripts/verification-scope
@@ -107,7 +107,7 @@ capture_git_paths() {
   if [[ -n "$producer_output" ]]; then
     rm -f "$producer_output"
   fi
-  producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX")" \
+  producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX" 2>/dev/null)" \
     || refuse temp-create "path=${TMPDIR:-/tmp}" "Could not create a temporary file for Git output."
   if ! git -C "$repo_root" "$@" >"$producer_output" 2>/dev/null; then
     refuse git-command-failed "operation=$operation" "$diagnostic"

--- a/skills/project-management/tests/verification-scope.test.sh
+++ b/skills/project-management/tests/verification-scope.test.sh
@@ -175,20 +175,21 @@ refusal_rows_executed=0
 
 record_refusal_failure() {
   local case_name="$1" description="$2" status="$3"
-  local expected_status="$4" diagnostic="$5" output="$6"
+  local expected_status="$4" expected_key="$5" expected_value="$6" output="$7"
 
   echo "FAIL: $case_name: $description" >&2
   echo "  status: $status; expected: $expected_status" >&2
-  if [[ "$diagnostic" != "-" && "$output" != *"$diagnostic"* ]]; then
-    echo "  missing diagnostic: $diagnostic" >&2
+  echo "  expected first-line fields: $expected_key $expected_value" >&2
+  if [[ "$output" != *"$expected_key"* || "$output" != *"$expected_value"* ]]; then
+    echo "  actual output: $output" >&2
   fi
   refusal_failures=$((refusal_failures + 1))
 }
 
 run_refusal_case() {
   local case_name="$1" fixture_kind="$2" invocation="$3"
-  local expected_status="$4" diagnostic="$5" description="$6"
-  local output status matches
+  local expected_status="$4" expected_key="$5" expected_value="$6" description="$7"
+  local output status matches first_line
 
   setup_fixture "$fixture_kind" "$case_name"
   case "$invocation" in
@@ -237,27 +238,27 @@ run_refusal_case() {
   esac
 
   matches=true
+  first_line="${output%%$'\n'*}"
   [[ "$status" -eq "$expected_status" ]] || matches=false
-  if [[ "$diagnostic" != "-" && "$output" != *"$diagnostic"* ]]; then
-    matches=false
-  fi
+  [[ "$first_line" == *"$expected_key"* ]] || matches=false
+  [[ "$first_line" == *"$expected_value"* ]] || matches=false
   if [[ "$matches" != true ]]; then
     record_refusal_failure "$case_name" "$description" "$status" \
-      "$expected_status" "$diagnostic" "$output"
+      "$expected_status" "$expected_key" "$expected_value" "$output"
   fi
 }
 
 while IFS='^' read -r case_name fixture_kind invocation expected_status \
-  diagnostic description; do
+  expected_key expected_value description; do
   run_refusal_case "$case_name" "$fixture_kind" "$invocation" \
-    "$expected_status" "$diagnostic" "$description"
+    "$expected_status" "$expected_key" "$expected_value" "$description"
   refusal_rows_executed=$((refusal_rows_executed + 1))
 done <<'REFUSAL_ROWS'
-forced-docs-rejects-code^workspace^forced-docs-code^1^-^forced docs mode did not reject source code with the exact refusal status
-outside-worktree-path^workspace^outside-worktree^1^-^resolver did not reject an outside path with the exact refusal status
-repository-without-source^documentation^repository-without-source^1^no tracked source roots found^repository fallback did not return its exact status and source-scope diagnostic
-disconnected-base-history^disconnected-history^disconnected-base^1^git diff failed for base ref^base-ref mode did not return its exact status and disconnected-history diagnostic
-ls-files-producer-failure^corrupt-index^corrupt-index^1^git ls-files failed^repository discovery did not return its exact status and producer diagnostic
+forced-docs-rejects-code^workspace^forced-docs-code^1^error=docs-only-nondoc^path=crate-a/src/lib.rs^forced docs mode did not reject source code with the exact refusal status
+outside-worktree-path^workspace^outside-worktree^1^error=path-escape^path=../outside.rs^resolver did not reject an outside path with the exact refusal status
+repository-without-source^documentation^repository-without-source^1^error=source-roots-empty^count=0^repository fallback did not return its exact status and source-scope diagnostic
+disconnected-base-history^disconnected-history^disconnected-base^1^error=git-command-failed^operation=diff^base-ref mode did not return its exact status and disconnected-history diagnostic
+ls-files-producer-failure^corrupt-index^corrupt-index^1^error=git-command-failed^operation=ls-files^repository discovery did not return its exact status and producer diagnostic
 REFUSAL_ROWS
 
 [[ "$refusal_rows_executed" -gt 0 ]] \

--- a/skills/project-management/tests/verification-scope.test.sh
+++ b/skills/project-management/tests/verification-scope.test.sh
@@ -66,6 +66,9 @@ setup_fixture() {
       git -C "$case_root" init -q
       git -C "$case_root" add README.md
       ;;
+    plain)
+      printf 'not a repository\n' >"$case_root/file.txt"
+      ;;
     disconnected-history)
       mkdir -p "$case_root/src"
       printf 'fn main() {}\n' >"$case_root/src/main.rs"
@@ -192,7 +195,42 @@ run_refusal_case() {
   local output status matches first_line
 
   setup_fixture "$fixture_kind" "$case_name"
+  expected_value="${expected_value//<root>/$case_root}"
+  expected_value="${expected_value//<scratch>/$scratch}"
   case "$invocation" in
+    argument-worktree)
+      if output="$($RESOLVER --worktree 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    argument-base)
+      if output="$($RESOLVER --worktree "$case_root" --base-ref 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    argument-changed)
+      if output="$($RESOLVER --worktree "$case_root" --changed-file 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    argument-unknown)
+      if output="$($RESOLVER --unknown 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    worktree-missing)
+      if output="$($RESOLVER --worktree "$scratch/absent-worktree" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    worktree-not-repository)
+      if output="$($RESOLVER --worktree "$case_root" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    scope-conflict)
+      if output="$($RESOLVER --worktree "$case_root" --base-ref HEAD --changed-file crate-a/src/lib.rs 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    temp-create)
+      if output="$(TMPDIR="$case_root/missing-temp" $RESOLVER --worktree "$case_root" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    absolute-path)
+      if output="$($RESOLVER --worktree "$case_root" --changed-file "$scratch/outside.rs" 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    empty-path)
+      if output="$($RESOLVER --worktree "$case_root" --changed-file '' 2>&1)"; then status=0; else status=$?; fi
+      ;;
+    invalid-base)
+      if output="$($RESOLVER --worktree "$case_root" --base-ref does-not-exist 2>&1)"; then status=0; else status=$?; fi
+      ;;
     forced-docs-code)
       if output="$($RESOLVER --worktree "$case_root" --docs-only \
         --changed-file crate-a/src/lib.rs 2>&1)"; then
@@ -240,8 +278,7 @@ run_refusal_case() {
   matches=true
   first_line="${output%%$'\n'*}"
   [[ "$status" -eq "$expected_status" ]] || matches=false
-  [[ "$first_line" == *"$expected_key"* ]] || matches=false
-  [[ "$first_line" == *"$expected_value"* ]] || matches=false
+  [[ "$first_line" == "$expected_key $expected_value" ]] || matches=false
   if [[ "$matches" != true ]]; then
     record_refusal_failure "$case_name" "$description" "$status" \
       "$expected_status" "$expected_key" "$expected_value" "$output"
@@ -254,6 +291,17 @@ while IFS='^' read -r case_name fixture_kind invocation expected_status \
     "$expected_status" "$expected_key" "$expected_value" "$description"
   refusal_rows_executed=$((refusal_rows_executed + 1))
 done <<'REFUSAL_ROWS'
+missing-worktree-option^workspace^argument-worktree^1^error=argument-missing^option=--worktree^missing worktree option value did not return its exact diagnostic
+missing-base-option^workspace^argument-base^1^error=argument-missing^option=--base-ref^missing base option value did not return its exact diagnostic
+missing-changed-option^workspace^argument-changed^1^error=argument-missing^option=--changed-file^missing changed-file option value did not return its exact diagnostic
+unknown-option^workspace^argument-unknown^1^error=argument-unknown^value=--unknown^unknown option did not return its exact diagnostic
+missing-worktree^workspace^worktree-missing^1^error=worktree-missing^path=<scratch>/absent-worktree^missing worktree did not return its exact diagnostic
+non-repository-worktree^plain^worktree-not-repository^1^error=worktree-not-repository^path=<root>^plain directory did not return its exact diagnostic
+conflicting-scope-inputs^workspace^scope-conflict^1^error=scope-input-conflict^value=base-ref+changed-file^conflicting scope inputs did not return their exact diagnostic
+temporary-file-failure^workspace^temp-create^1^error=temp-create^path=<root>/missing-temp^temporary-file failure did not return its exact diagnostic first
+absolute-changed-path^workspace^absolute-path^1^error=path-outside^path=<scratch>/outside.rs^absolute outside path did not return its exact diagnostic
+empty-changed-path^workspace^empty-path^1^error=path-empty^value=empty^empty changed path did not return its exact diagnostic
+invalid-base-ref^workspace^invalid-base^1^error=base-ref-invalid^ref=does-not-exist^invalid base ref did not return its exact diagnostic
 forced-docs-rejects-code^workspace^forced-docs-code^1^error=docs-only-nondoc^path=crate-a/src/lib.rs^forced docs mode did not reject source code with the exact refusal status
 outside-worktree-path^workspace^outside-worktree^1^error=path-escape^path=../outside.rs^resolver did not reject an outside path with the exact refusal status
 repository-without-source^documentation^repository-without-source^1^error=source-roots-empty^count=0^repository fallback did not return its exact status and source-scope diagnostic


### PR DESCRIPTION
## Summary

- Add stable key/value first lines to every verification-scope refusal.
- Keep English explanations on later lines.
- Replace English test pins with key, value, and exit-status assertions.
- Preserve source and tracked-render copies in the same change.

## Changed files

- `scripts/verification-scope`
- `tests/verification-scope.test.sh`
- The matching `.agents/skills/project-management` renders.

## Compliant files left unchanged

- `SKILL.md` and `README.md`
- `references/dependencies.md` and `references/labels.md`
- `schemas/audit-issues-input.md`, `schemas/audit-output.md`, `schemas/cycle-plan-output.md`, `schemas/roadmap-plan-input.md`, and `schemas/roadmap-plan-output.md`
- `templates/issue-description-template.md` and `templates/parent-issue-template.md`
- `workflows/audit-issues.md`, `workflows/cycle-plan.md`, `workflows/research-complete.md`, `workflows/research-issue.md`, `workflows/research-spike.md`, `workflows/roadmap-create.md`, `workflows/roadmap-plan.md`, `workflows/tpm-audit.md`, `workflows/tpm-cycle-plan.md`, and `workflows/tpm-roadmap-plan.md`
- The matching tracked renders.

## Validation

- The verification-scope suite passes.
- The refusal table includes must-fail controls.
- The repository commit chain passes.

Linear: KEN-1241
