### PR TITLE
test(KEN-1241): audit session bridge behavior contracts

### DIFF
--- a/pi-extensions/pi-session-bridge/extensions/__tests__/activity-broker.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/activity-broker.test.ts
@@ -86,9 +86,10 @@ describe("Pi activity broker", () => {
 			broker.publish(event({ source: "pi-agents", type: "agent.task_failed" }));
 
 			expect(warnings).toHaveLength(2);
-			expect(String(warnings[0]?.[0])).toContain("type=agent.task_completed source=pi-agents");
-			expect(String(warnings[0]?.[0])).toContain("socket closed");
-			expect(String(warnings[1]?.[0])).toContain("type=agent.task_failed source=pi-agents");
+			expect(warnings.map((warning) => String(warning[0]).split("\n")[0])).toEqual([
+				"publisher_failure=agent.task_completed source=pi-agents error=TypeError",
+				"publisher_failure=agent.task_failed source=pi-agents error=TypeError",
+			]);
 		} finally {
 			console.warn = originalWarn;
 		}

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/child-session-id.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/child-session-id.test.ts
@@ -1,74 +1,26 @@
-// A child Pi pane spawned by
-// pi-agents-tmux should advertise a UNIQUE session id derived from
-// PI_BRIDGE_PARENT_SESSION_ID + PI_BRIDGE_CHILD_ROLE so pi-bridge state
-// --session <id> matches only one instance.
+import { expect, test } from "bun:test";
+import { CHILD_ROLE_ENV, PARENT_SESSION_ENV, resolveSessionId } from "../child-session-id.js";
 
-import { describe, expect, test } from "bun:test";
+for (const row of [
+	{ name: "unset parent preserves default", defaultId: "abc-123", env: {}, pid: 42, expected: { synthesized: false, sessionId: "abc-123", parentSessionId: undefined, childRole: undefined } },
+	{ name: "parent and role synthesize child identity", defaultId: "ignored-parent-id", env: { [PARENT_SESSION_ENV]: "parent-xyz", [CHILD_ROLE_ENV]: "subagent" }, pid: 4242, expected: { synthesized: true, sessionId: "parent-xyz:c4242", parentSessionId: "parent-xyz", childRole: "subagent" } },
+	{ name: "omitted role", defaultId: undefined, env: { [PARENT_SESSION_ENV]: "p1" }, pid: 7, expected: { synthesized: true, sessionId: "p1:c7", parentSessionId: "p1", childRole: undefined } },
+	{ name: "whitespace parent", defaultId: "default", env: { [PARENT_SESSION_ENV]: "   " }, pid: 99, expected: { synthesized: false, sessionId: "default", parentSessionId: undefined, childRole: undefined } },
+	{ name: "process pid default", defaultId: undefined, env: { [PARENT_SESSION_ENV]: "parent" }, pid: undefined, expected: { synthesized: true, sessionId: `parent:c${process.pid}`, parentSessionId: "parent", childRole: undefined } },
+	{ name: "missing default identity", defaultId: undefined, env: {}, pid: undefined, expected: { synthesized: false, sessionId: undefined, parentSessionId: undefined, childRole: undefined } },
+]) {
+	test(row.name, () => expect(resolveSessionId({ defaultId: row.defaultId, env: row.env, pid: row.pid })).toEqual(row.expected));
+}
 
-import {
-	CHILD_ROLE_ENV,
-	PARENT_SESSION_ENV,
-	resolveSessionId,
-} from "../child-session-id.js";
-
-describe("resolveSessionId (kendex#60)", () => {
-	test("no PI_BRIDGE_PARENT_SESSION_ID -> returns default unchanged", () => {
-		const result = resolveSessionId({ defaultId: "abc-123", env: {} as NodeJS.ProcessEnv, pid: 42 });
-		expect(result.synthesized).toBe(false);
-		expect(result.sessionId).toBe("abc-123");
-		expect(result.parentSessionId).toBeUndefined();
-		expect(result.childRole).toBeUndefined();
-	});
-
-	test("PI_BRIDGE_PARENT_SESSION_ID set -> synthesizes <parent>:c<pid>", () => {
-		const result = resolveSessionId({
-			defaultId: "ignored-parent-id",
-			env: { [PARENT_SESSION_ENV]: "parent-xyz", [CHILD_ROLE_ENV]: "subagent" } as any,
-			pid: 4242,
-		});
-		expect(result.synthesized).toBe(true);
-		expect(result.sessionId).toBe("parent-xyz:c4242");
-		expect(result.parentSessionId).toBe("parent-xyz");
-		expect(result.childRole).toBe("subagent");
-	});
-
-	test("child role omitted -> sessionId synthesized but childRole undefined", () => {
-		const result = resolveSessionId({
-			env: { [PARENT_SESSION_ENV]: "p1" } as any,
-			pid: 7,
-		});
-		expect(result.synthesized).toBe(true);
-		expect(result.sessionId).toBe("p1:c7");
-		expect(result.parentSessionId).toBe("p1");
-		expect(result.childRole).toBeUndefined();
-	});
-
-	test("whitespace-only parent id treated as unset", () => {
-		const result = resolveSessionId({
-			defaultId: "default",
-			env: { [PARENT_SESSION_ENV]: "   " } as any,
-			pid: 99,
-		});
-		expect(result.synthesized).toBe(false);
-		expect(result.sessionId).toBe("default");
-	});
-
-	test("pid defaults to process.pid when not provided", () => {
-		const result = resolveSessionId({ env: { [PARENT_SESSION_ENV]: "parent" } as any });
-		expect(result.synthesized).toBe(true);
-		expect(result.sessionId).toBe(`parent:c${process.pid}`);
-	});
-
-	test("env defaults to process.env when not provided", () => {
-		const result = resolveSessionId({ defaultId: "fallback" });
-		// No parent env set in this test runner -> default unchanged.
-		expect(result.synthesized).toBe(false);
-		expect(result.sessionId).toBe("fallback");
-	});
-
-	test("defaultId may be undefined; no synthesis still returns undefined", () => {
-		const result = resolveSessionId({ env: {} as NodeJS.ProcessEnv });
-		expect(result.synthesized).toBe(false);
-		expect(result.sessionId).toBeUndefined();
-	});
+test("omitted env reads process environment", () => {
+	const parent = process.env[PARENT_SESSION_ENV];
+	const role = process.env[CHILD_ROLE_ENV];
+	try {
+		delete process.env[PARENT_SESSION_ENV];
+		delete process.env[CHILD_ROLE_ENV];
+		expect(resolveSessionId({ defaultId: "fallback" })).toEqual({ synthesized: false, sessionId: "fallback", parentSessionId: undefined, childRole: undefined });
+	} finally {
+		if (parent === undefined) delete process.env[PARENT_SESSION_ENV]; else process.env[PARENT_SESSION_ENV] = parent;
+		if (role === undefined) delete process.env[CHILD_ROLE_ENV]; else process.env[CHILD_ROLE_ENV] = role;
+	}
 });

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-cleanup.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-cleanup.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { cleanupStaleSpills } from "../event-history.js";
+import { dir, useHistoryFixture } from "./lib/history-fixture.ts";
+
+useHistoryFixture();
+for (const row of [
+	{ name: "own pid", filename: `${process.pid}.jsonl`, alive: false, keep: true },
+	{ name: "dead pid", filename: "9999999.jsonl", alive: false, keep: false },
+	{ name: "live pid", filename: `${process.pid + 12_345}.jsonl`, alive: true, keep: true },
+	{ name: "non-spill file", filename: "ignored.txt", alive: false, keep: true },
+]) {
+	test(`spill cleanup ${row.name}`, () => {
+		const rawDir = join(dir, "raw");
+		mkdirSync(rawDir, { recursive: true });
+		const file = join(rawDir, row.filename);
+		writeFileSync(file, "fixture\n");
+		cleanupStaleSpills(rawDir, () => row.alive);
+		expect(existsSync(file)).toBe(row.keep);
+	});
+}

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts
@@ -17,14 +17,15 @@ describe("BridgeHistory.buildResponse", () => {
 	}
 
 	for (const row of [
-		{ name: "event filter", filters: { event: "message_update" }, expected: ["message_update", "message_update", "message_update"] },
-		{ name: "since filter", filters: { since: "2026-05-21T00:00:00.003Z" }, expected: ["tool_execution_end", "message_update", "tool_execution_end"] },
+		{ name: "event filter before limit", filters: { event: "message_update" }, limit: 2, expected: ["message_update", "message_update"], indexes: [2, 4] },
+		{ name: "since filter", filters: { since: "2026-05-21T00:00:00.003Z" }, limit: 10, expected: ["tool_execution_end", "message_update", "tool_execution_end"], indexes: [3, 4, 5] },
 	]) {
-		test(`filters before limit: ${row.name}`, () => {
+		test(`history response: ${row.name}`, () => {
 			const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
 			pushSeries(history, 6);
-			const result = history.buildResponse({ limit: 10, maxBytes: 1024 * 1024, ...row.filters });
+			const result = history.buildResponse({ limit: row.limit, maxBytes: 1024 * 1024, ...row.filters });
 			expect(result.events.map((entry) => entry.event)).toEqual(row.expected);
+			expect(result.events.map((entry) => (entry.data as { idx: number }).idx)).toEqual(row.indexes);
 		});
 	}
 

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { BridgeHistory, cleanupStaleSpills, type HistoryEnvelope, type HistoryLimits } from "../event-history.js";
+import { defaultLimits, dir, makeEnvelope, spillPath, warnings, useHistoryFixture } from "./lib/history-fixture.ts";
+
+useHistoryFixture();
+
+describe("BridgeHistory.buildResponse", () => {
+	function pushSeries(history: BridgeHistory, count: number): void {
+		for (let i = 0; i < count; i++) {
+			history.push({
+				...makeEnvelope(i % 2 === 0 ? "message_update" : "tool_execution_end", 64),
+				truncated: true,
+				originalBytes: 1024,
+			}, { delta: `chunk-${i}-${"y".repeat(200)}` });
+		}
+	}
+
+	for (const row of [
+		{ name: "event filter", filters: { event: "message_update" }, expected: ["message_update", "message_update", "message_update"] },
+		{ name: "since filter", filters: { since: "2026-05-21T00:00:00.003Z" }, expected: ["tool_execution_end", "message_update", "tool_execution_end"] },
+	]) {
+		test(`filters before limit: ${row.name}`, () => {
+			const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
+			pushSeries(history, 6);
+			const result = history.buildResponse({ limit: 10, maxBytes: 1024 * 1024, ...row.filters });
+			expect(result.events.map((entry) => entry.event)).toEqual(row.expected);
+		});
+	}
+
+	test("trims compact envelopes by response budget before rehydration", () => {
+		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
+		pushSeries(history, 8);
+		const compactSizes = history.snapshot().map((envelope) => Buffer.byteLength(JSON.stringify(envelope), "utf8"));
+		const cap = compactSizes.slice(-3).reduce((sum, size) => sum + size, 0);
+		const response = history.buildResponse({ limit: 50, maxBytes: cap });
+		expect(response.events.length).toBeLessThan(8);
+		expect(response.events.at(-1)?.timestamp).toBe(history.snapshot().at(-1)?.timestamp);
+		expect(response.responseTruncated).toBe(true);
+	});
+
+	test("raw rehydration keeps compact form when rehydrated payload would exceed cap", () => {
+		const limits: HistoryLimits = { ...defaultLimits, maxRawSpillBytes: 10 * 1024 * 1024 };
+		const history = new BridgeHistory(spillPath, () => limits, () => undefined);
+		pushSeries(history, 4);
+
+		const snapshot = history.snapshot();
+		const compactTotal = snapshot.reduce((sum, env) => sum + Buffer.byteLength(JSON.stringify(env), "utf8"), 0);
+		// All 4 compact envelopes fit; leave headroom for ~2 rehydrations but not 4.
+		const budget = compactTotal + 600;
+
+		const response = history.buildResponse({ limit: 50, maxBytes: budget, raw: true });
+		expect(response.events).toHaveLength(4);
+		const hydrated = response.events.filter((e) => e.rawRestored === true);
+		expect(hydrated.length).toBeGreaterThan(0);
+		expect(hydrated.length).toBeLessThan(4);
+		expect(response.responseTruncated).toBe(true);
+		const compactStill = response.events.filter((e) => e.rawRestored !== true);
+		for (const event of compactStill) {
+			expect((event.data as Record<string, unknown>).filler).toBeDefined();
+		}
+	});
+
+	test("rehydration failures surface as per-event rawError and aggregate rawErrors", () => {
+		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
+		const envelope = { ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 };
+		history.push(envelope, { delta: "y".repeat(200) });
+		// Corrupt the sidecar so rehydration fails.
+		writeFileSync(spillPath, "not-json\n", { mode: 0o600 });
+		const response = history.buildResponse({ limit: 5, maxBytes: 1024 * 1024, raw: true });
+		expect(response.events[0]?.rawRestored).not.toBe(true);
+		expect(response.events[0]?.rawError?.split("\n")[0]).toBe("error_code=SyntaxError");
+		expect(response.rawErrors?.length).toBeGreaterThan(0);
+	});
+
+	test("rawErrors only includes events that survived the compact budget cut", () => {
+		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
+		// Push two truncated events; corrupt the sidecar so any rehydration attempt fails.
+		history.push({ ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 }, { delta: "y".repeat(200) });
+		history.push({ ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 }, { delta: "y".repeat(200) });
+		writeFileSync(spillPath, "not-json\n", { mode: 0o600 });
+
+		// maxBytes=1 forces only the newest entry into the response. The older
+		// event must NOT trigger a sidecar read or contribute to rawErrors.
+		const response = history.buildResponse({ limit: 50, maxBytes: 1, raw: true });
+		expect(response.events).toHaveLength(1);
+		expect(response.responseTruncated).toBe(true);
+		expect(response.events[0]?.event).toBe("message_update");
+		expect(response.rawErrors?.length ?? 0).toBeLessThanOrEqual(1);
+	});
+});
+

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { BridgeHistory, cleanupStaleSpills, type HistoryEnvelope, type HistoryLimits } from "../event-history.js";
-import { defaultLimits, dir, makeEnvelope, spillPath, warnings, useHistoryFixture } from "./lib/history-fixture.ts";
+import { writeFileSync } from "node:fs";
+import { BridgeHistory, type HistoryLimits } from "../event-history.js";
+import { defaultLimits, makeEnvelope, spillPath, useHistoryFixture } from "./lib/history-fixture.ts";
 
 useHistoryFixture();
 

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-history.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-history.test.ts
@@ -1,46 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-
 import { BridgeHistory, cleanupStaleSpills, type HistoryEnvelope, type HistoryLimits } from "../event-history.js";
+import { defaultLimits, dir, makeEnvelope, spillPath, warnings, useHistoryFixture } from "./lib/history-fixture.ts";
 
-const defaultLimits: HistoryLimits = {
-	historyLimit: 500,
-	maxHistoryBytes: 4 * 1024 * 1024,
-	maxRawSpillBytes: 16 * 1024 * 1024,
-	spillEnabled: true,
-};
-
-let monotonicCounter = 0;
-
-function makeEnvelope(event: string, dataBytes = 32): HistoryEnvelope {
-	const filler = "x".repeat(dataBytes);
-	const idx = monotonicCounter++;
-	const ms = String(idx % 1000).padStart(3, "0");
-	const seconds = String(Math.floor(idx / 1000) % 60).padStart(2, "0");
-	return {
-		type: "event",
-		event,
-		timestamp: `2026-05-21T00:00:${seconds}.${ms}Z`,
-		data: { filler, idx },
-	};
-}
-
-let dir = "";
-let spillPath = "";
-let warnings: Array<{ where: string; error: unknown }> = [];
-
-beforeEach(() => {
-	dir = mkdtempSync(join(tmpdir(), "bridge-history-"));
-	spillPath = join(dir, "raw", `${process.pid}.jsonl`);
-	warnings = [];
-	monotonicCounter = 0;
-});
-
-afterEach(() => {
-	rmSync(dir, { recursive: true, force: true });
-});
+useHistoryFixture();
 
 describe("BridgeHistory.push", () => {
 	test("retains envelopes in chronological order under count limit", () => {
@@ -53,7 +17,7 @@ describe("BridgeHistory.push", () => {
 		expect(history.count).toBe(5);
 	});
 
-	test("evicts oldest entries once count or byte limits are exceeded", () => {
+	test("evicts oldest entries once the count limit is exceeded", () => {
 		const limits: HistoryLimits = { ...defaultLimits, historyLimit: 3, maxHistoryBytes: 1024 };
 		const history = new BridgeHistory(spillPath, () => limits, () => undefined);
 		for (let i = 0; i < 10; i++) history.push({ ...makeEnvelope(`e${i}`, 8), data: { i } });
@@ -94,7 +58,7 @@ describe("BridgeHistory.push", () => {
 
 		expect(first.rawEventRef).toBe("1");
 		expect(first.rawError).toBeUndefined();
-		expect(second.rawError).toBeDefined();
+		expect(second.rawError?.split("\n")[0]).toBe("spill_max_bytes=320");
 		expect(warnings.some((entry) => entry.where === "spill.budget")).toBe(true);
 		expect(history.rawSpillBytes).toBeLessThanOrEqual(limits.maxRawSpillBytes);
 	});
@@ -105,9 +69,8 @@ describe("BridgeHistory.push", () => {
 		const big = { delta: "z".repeat(120) };
 		for (let i = 0; i < 12; i++) {
 			history.push({ ...makeEnvelope("message_update", 8), truncated: true, originalBytes: 200 }, big);
-			if (existsSync(spillPath)) {
-				expect(statSync(spillPath).size).toBeLessThanOrEqual(limits.maxRawSpillBytes);
-			}
+			expect(existsSync(spillPath)).toBe(true);
+			expect(statSync(spillPath).size).toBeLessThanOrEqual(limits.maxRawSpillBytes);
 		}
 		if (existsSync(spillPath)) {
 			expect(statSync(spillPath).size).toBeLessThanOrEqual(limits.maxRawSpillBytes);
@@ -134,115 +97,7 @@ describe("BridgeHistory.push", () => {
 		const history = new BridgeHistory(spillPath, () => limits, () => undefined);
 		const pushed = history.push({ ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 }, { delta: "x".repeat(200) });
 		expect(pushed.rawEventPath).toBeUndefined();
-		expect(pushed.rawError).toBe("raw spill disabled");
+		expect(pushed.rawError?.split("\n")[0]).toBe("spill_enabled=false");
 		expect(existsSync(spillPath)).toBe(false);
-	});
-});
-
-describe("BridgeHistory.buildResponse", () => {
-	function pushSeries(history: BridgeHistory, count: number): void {
-		for (let i = 0; i < count; i++) {
-			history.push({
-				...makeEnvelope(i % 2 === 0 ? "message_update" : "tool_execution_end", 64, String(i).padStart(3, "0")),
-				truncated: true,
-				originalBytes: 1024,
-			}, { delta: `chunk-${i}-${"y".repeat(200)}` });
-		}
-	}
-
-	test("applies event and since filters before slicing to the requested limit", () => {
-		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
-		pushSeries(history, 6);
-		const filtered = history.buildResponse({ limit: 10, maxBytes: 1024 * 1024, event: "message_update" });
-		expect(filtered.events.every((e) => e.event === "message_update")).toBe(true);
-		expect(filtered.events).toHaveLength(3);
-
-		const since = history.snapshot()[3]!.timestamp;
-		const sinceResponse = history.buildResponse({ limit: 10, maxBytes: 1024 * 1024, since });
-		expect(sinceResponse.events.map((e) => e.event)).toEqual(history.snapshot().slice(3).map((e) => e.event));
-	});
-
-	test("trims compact envelopes by response budget before rehydration", () => {
-		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
-		pushSeries(history, 8);
-		const compactSizes = history.snapshot().map((envelope) => Buffer.byteLength(JSON.stringify(envelope), "utf8"));
-		const cap = compactSizes.slice(-3).reduce((sum, size) => sum + size, 0);
-		const response = history.buildResponse({ limit: 50, maxBytes: cap });
-		expect(response.events.length).toBeLessThan(8);
-		expect(response.events.at(-1)?.timestamp).toBe(history.snapshot().at(-1)?.timestamp);
-		expect(response.responseTruncated).toBe(true);
-	});
-
-	test("raw rehydration keeps compact form when rehydrated payload would exceed cap", () => {
-		const limits: HistoryLimits = { ...defaultLimits, maxRawSpillBytes: 10 * 1024 * 1024 };
-		const history = new BridgeHistory(spillPath, () => limits, () => undefined);
-		pushSeries(history, 4);
-
-		const snapshot = history.snapshot();
-		const compactTotal = snapshot.reduce((sum, env) => sum + Buffer.byteLength(JSON.stringify(env), "utf8"), 0);
-		// All 4 compact envelopes fit; leave headroom for ~2 rehydrations but not 4.
-		const budget = compactTotal + 600;
-
-		const response = history.buildResponse({ limit: 50, maxBytes: budget, raw: true });
-		expect(response.events).toHaveLength(4);
-		const hydrated = response.events.filter((e) => e.rawRestored === true);
-		expect(hydrated.length).toBeGreaterThan(0);
-		expect(hydrated.length).toBeLessThan(4);
-		expect(response.responseTruncated).toBe(true);
-		const compactStill = response.events.filter((e) => e.rawRestored !== true);
-		for (const event of compactStill) {
-			expect((event.data as Record<string, unknown>).filler).toBeDefined();
-		}
-	});
-
-	test("rehydration failures surface as per-event rawError and aggregate rawErrors", () => {
-		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
-		const envelope = { ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 };
-		history.push(envelope, { delta: "y".repeat(200) });
-		// Corrupt the sidecar so rehydration fails.
-		writeFileSync(spillPath, "not-json\n", { mode: 0o600 });
-		const response = history.buildResponse({ limit: 5, maxBytes: 1024 * 1024, raw: true });
-		expect(response.events[0]?.rawRestored).not.toBe(true);
-		expect(typeof response.events[0]?.rawError).toBe("string");
-		expect(response.rawErrors?.length).toBeGreaterThan(0);
-	});
-
-	test("rawErrors only includes events that survived the compact budget cut", () => {
-		const history = new BridgeHistory(spillPath, () => defaultLimits, () => undefined);
-		// Push two truncated events; corrupt the sidecar so any rehydration attempt fails.
-		history.push({ ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 }, { delta: "y".repeat(200) });
-		history.push({ ...makeEnvelope("message_update"), truncated: true, originalBytes: 200 }, { delta: "y".repeat(200) });
-		writeFileSync(spillPath, "not-json\n", { mode: 0o600 });
-
-		// maxBytes=1 forces only the newest entry into the response. The older
-		// event must NOT trigger a sidecar read or contribute to rawErrors.
-		const response = history.buildResponse({ limit: 50, maxBytes: 1, raw: true });
-		expect(response.events).toHaveLength(1);
-		expect(response.responseTruncated).toBe(true);
-		expect(response.events[0]?.event).toBe("message_update");
-		expect(response.rawErrors?.length ?? 0).toBeLessThanOrEqual(1);
-	});
-});
-
-describe("cleanupStaleSpills", () => {
-	test("removes spill files for dead pids and keeps live and self pids", () => {
-		const liveDir = join(dir, "raw");
-		const selfPath = join(liveDir, `${process.pid}.jsonl`);
-		const livePid = process.pid + 12_345;
-		const deadPath = join(liveDir, "9999999.jsonl");
-		const livePath = join(liveDir, `${livePid}.jsonl`);
-		const notJsonl = join(liveDir, "ignored.txt");
-		const fs = require("node:fs") as typeof import("node:fs");
-		fs.mkdirSync(liveDir, { recursive: true });
-		fs.writeFileSync(selfPath, "ours\n");
-		fs.writeFileSync(deadPath, "stale\n");
-		fs.writeFileSync(livePath, "live\n");
-		fs.writeFileSync(notJsonl, "skip\n");
-
-		cleanupStaleSpills(liveDir, (pid) => pid === livePid);
-		expect(existsSync(selfPath)).toBe(true);
-		expect(existsSync(deadPath)).toBe(false);
-		expect(existsSync(livePath)).toBe(true);
-		expect(existsSync(notJsonl)).toBe(true);
 	});
 });

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-history.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-history.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { BridgeHistory, cleanupStaleSpills, type HistoryEnvelope, type HistoryLimits } from "../event-history.js";
-import { defaultLimits, dir, makeEnvelope, spillPath, warnings, useHistoryFixture } from "./lib/history-fixture.ts";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { BridgeHistory, type HistoryEnvelope, type HistoryLimits } from "../event-history.js";
+import { defaultLimits, makeEnvelope, spillPath, warnings, useHistoryFixture } from "./lib/history-fixture.ts";
 
 useHistoryFixture();
 

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts
@@ -10,32 +10,25 @@ import {
 const baseConfig = { maxEventBytes: DEFAULT_MAX_EVENT_BYTES, previewBytes: DEFAULT_PREVIEW_BYTES };
 
 describe("sanitizeBridgeEvent", () => {
-	test("message_update keeps role/contentIndex/delta length and short preview", () => {
-		const payload = { role: "assistant", contentIndex: 0, type: "text", delta: "Hello world" };
-		const result = sanitizeBridgeEvent("message_update", payload, baseConfig);
-		expect(result.truncated).toBe(true);
-		const data = result.data as Record<string, unknown>;
-		expect(data.role).toBe("assistant");
-		expect(data.type).toBe("text");
-		expect(data.contentIndex).toBe(0);
-		expect(data.deltaLength).toBe(11);
-		expect(data.deltaBytes).toBe(11);
-		expect(data.deltaPreview).toBe("Hello world");
-		expect("delta" in data).toBe(false);
-	});
-
-	test("message_update truncates very large deltas to preview window", () => {
-		const huge = "x".repeat(500_000);
-		const payload = { role: "assistant", contentIndex: 0, delta: huge };
-		const result = sanitizeBridgeEvent("message_update", payload, { ...baseConfig, previewBytes: 64 });
-		const data = result.data as Record<string, unknown>;
-		expect(data.deltaLength).toBe(500_000);
-		expect(typeof data.deltaPreview).toBe("string");
-		expect((data.deltaPreview as string).length).toBeLessThanOrEqual(64);
-		expect(result.truncated).toBe(true);
-		expect(result.raw).toEqual(payload);
-		expect(result.originalBytes).toBeGreaterThan(100_000);
-	});
+	for (const row of [
+		{ name: "short delta", delta: "Hello world", length: 11, previewBytes: DEFAULT_PREVIEW_BYTES, large: false },
+		{ name: "large delta", delta: "x".repeat(500_000), length: 500_000, previewBytes: 64, large: true },
+	]) {
+		test(`message update ${row.name}`, () => {
+			const payload = { role: "assistant", contentIndex: 0, type: "text", delta: row.delta };
+			const result = sanitizeBridgeEvent("message_update", payload, { ...baseConfig, previewBytes: row.previewBytes });
+			const data = result.data as Record<string, unknown>;
+			expect(data).toMatchObject({ role: "assistant", type: "text", contentIndex: 0, deltaLength: row.length, deltaBytes: row.length });
+			expect(typeof data.deltaPreview).toBe("string");
+			expect((data.deltaPreview as string).length).toBeLessThanOrEqual(row.previewBytes);
+			expect("delta" in data).toBe(false);
+			expect(result.truncated).toBe(true);
+			if (row.large) {
+				expect(result.raw).toEqual(payload);
+				expect(result.originalBytes).toBeGreaterThan(100_000);
+			} else expect(data.deltaPreview).toBe("Hello world");
+		});
+	}
 
 	test("tool_execution_end compacts heavy result and surfaces byte counts", () => {
 		const heavyResult = { text: "y".repeat(120_000) };
@@ -117,62 +110,54 @@ describe("sanitizeBridgeEvent", () => {
 		expect("streamingBehavior" in data).toBe(false);
 	});
 
-	test("unknown events pass through when under per-event budget", () => {
-		const payload = { ok: true, count: 3 };
-		const result = sanitizeBridgeEvent("bridge_pong", payload, baseConfig);
-		expect(result.data).toEqual(payload);
-		expect(result.truncated).toBe(false);
-		expect(result.raw).toBeUndefined();
-	});
+	for (const row of [
+		{ name: "small unknown event", event: "bridge_pong", payload: { ok: true, count: 3 }, maxEventBytes: DEFAULT_MAX_EVENT_BYTES, truncated: false },
+		{ name: "large unknown event", event: "custom_heavy_event", payload: { blob: "z".repeat(1_500_000) }, maxEventBytes: 1024, truncated: true },
+	]) {
+		test(row.name, () => {
+			const result = sanitizeBridgeEvent(row.event, row.payload, { ...baseConfig, maxEventBytes: row.maxEventBytes });
+			expect(result.truncated).toBe(row.truncated);
+			if (row.truncated) {
+				const data = result.data as Record<string, unknown>;
+				expect(data.truncated).toBe(true);
+				expect(typeof data.originalBytes).toBe("number");
+				expect(data.maxBytes).toBe(1024);
+				expect(result.raw).toEqual(row.payload);
+			} else {
+				expect(result.data).toEqual(row.payload);
+				expect(result.raw).toBeUndefined();
+			}
+		});
+	}
 
-	test("unknown events over per-event budget collapse to a descriptor", () => {
-		const blob = "z".repeat(1_500_000);
-		const payload = { blob };
-		const result = sanitizeBridgeEvent("custom_heavy_event", payload, { ...baseConfig, maxEventBytes: 1024 });
-		const data = result.data as Record<string, unknown>;
-		expect(result.truncated).toBe(true);
-		expect(data.truncated).toBe(true);
-		expect(typeof data.originalBytes).toBe("number");
-		expect(data.maxBytes).toBe(1024);
-		expect(result.raw).toEqual(payload);
-	});
-
-	test("session_info_changed compacts the renamed session to a preview", () => {
-		const payload = { type: "session_info_changed", name: "Rename the bridge registry" };
-		const result = sanitizeBridgeEvent("session_info_changed", payload, baseConfig);
-		const data = result.data as Record<string, unknown>;
-
-		expect(data.nameBytes).toBe(Buffer.byteLength(payload.name, "utf8"));
-		expect(data.nameLength).toBe(payload.name.length);
-		expect(data.namePreview).toBe(payload.name);
-		expect("nameTruncated" in data).toBe(false);
-		expect("name" in data).toBe(false);
-		expect("type" in data).toBe(false);
-		expect(result.truncated).toBe(true);
-		expect(result.raw).toEqual(payload);
-	});
-
-	test("session_info_changed truncates an oversized session name", () => {
-		const name = `named session ${"x".repeat(500)}`;
-		const payload = { name };
-		const result = sanitizeBridgeEvent("session_info_changed", payload, { ...baseConfig, previewBytes: 32 });
-		const data = result.data as Record<string, unknown>;
-
-		expect(data.nameBytes).toBe(Buffer.byteLength(name, "utf8"));
-		expect(data.nameLength).toBe(name.length);
-		expect((data.namePreview as string).length).toBeLessThanOrEqual(32);
-		expect(data.nameTruncated).toBe(true);
-		expect(result.truncated).toBe(true);
-		expect(result.raw).toEqual(payload);
-	});
-
-	test("session_info_changed emits an empty descriptor when the name is cleared", () => {
-		const payload = { type: "session_info_changed", name: undefined };
-		const result = sanitizeBridgeEvent("session_info_changed", payload, baseConfig);
-
-		expect(result.data).toEqual({});
-		expect(result.truncated).toBe(true);
-	});
+	for (const row of [
+		{ label: "ordinary name", name: "Rename the bridge registry", previewBytes: DEFAULT_PREVIEW_BYTES, truncated: false },
+		{ label: "oversized name", name: `named session ${"x".repeat(500)}`, previewBytes: 32, truncated: true },
+		{ label: "cleared name", name: undefined, previewBytes: DEFAULT_PREVIEW_BYTES, truncated: false },
+		{ label: "non-string name", name: 7, previewBytes: DEFAULT_PREVIEW_BYTES, truncated: false },
+	]) {
+		test(`session info ${row.label}`, () => {
+			const payload = { type: "session_info_changed", name: row.name };
+			const result = sanitizeBridgeEvent("session_info_changed", payload, { ...baseConfig, previewBytes: row.previewBytes });
+			const data = result.data as Record<string, unknown>;
+			expect(result.truncated).toBe(true);
+			expect("name" in data).toBe(false);
+			expect("type" in data).toBe(false);
+			if (typeof row.name === "string") {
+				expect(data.nameBytes).toBe(Buffer.byteLength(row.name, "utf8"));
+				expect(data.nameLength).toBe(row.name.length);
+				expect((data.namePreview as string).length).toBeLessThanOrEqual(row.previewBytes);
+				if (row.truncated) expect(data.nameTruncated).toBe(true);
+				else {
+					expect(data.namePreview).toBe(row.name);
+					expect("nameTruncated" in data).toBe(false);
+				}
+				expect(result.raw).toEqual(payload);
+			} else {
+				expect(data).toEqual({});
+			}
+		});
+	}
 
 	test("session_info_changed passes non-record payloads through untouched", () => {
 		for (const payload of [undefined, null, "renamed", 42, ["renamed"]]) {
@@ -183,13 +168,6 @@ describe("sanitizeBridgeEvent", () => {
 		}
 	});
 
-	test("session_info_changed ignores a non-string name", () => {
-		const result = sanitizeBridgeEvent("session_info_changed", { name: 7 }, baseConfig);
-		const data = result.data as Record<string, unknown>;
-
-		expect("namePreview" in data).toBe(false);
-		expect("nameBytes" in data).toBe(false);
-	});
 
 	test("message_update reads role/contentIndex/delta from assistantMessageEvent envelope", () => {
 		const payload = {
@@ -232,50 +210,30 @@ describe("sanitizeBridgeEvent", () => {
 		expect(result.truncated).toBe(true);
 	});
 
-	test("tool_execution_* accepts toolCallId / tool_call_id / nested toolCall", () => {
-		const camel = sanitizeBridgeEvent("tool_execution_start", { toolName: "Read", toolCallId: "tcl_1", input: { path: "/x" } }, baseConfig);
-		expect((camel.data as Record<string, unknown>).toolUseId).toBe("tcl_1");
+	for (const row of [
+		{ name: "camel id", event: "tool_execution_start", payload: { toolName: "Read", toolCallId: "tcl_1", input: { path: "/x" } }, expected: { toolUseId: "tcl_1" }, errorBytes: false },
+		{ name: "snake id", event: "tool_execution_update", payload: { tool_name: "Bash", tool_call_id: "tcl_2", output: "ok" }, expected: { toolUseId: "tcl_2" }, errorBytes: false },
+		{ name: "nested id", event: "tool_execution_end", payload: { toolCall: { name: "Edit", id: "tcl_3", status: "error", isError: true }, error: "boom" }, expected: { toolName: "Edit", toolUseId: "tcl_3", status: "error", isError: true }, errorBytes: true },
+	]) {
+		test(`tool execution ${row.name}`, () => {
+			const data = sanitizeBridgeEvent(row.event, row.payload, baseConfig).data as Record<string, unknown>;
+			expect(data).toMatchObject(row.expected);
+			if (row.errorBytes) expect(typeof data.errorBytes).toBe("number");
+		});
+	}
 
-		const snake = sanitizeBridgeEvent("tool_execution_update", { tool_name: "Bash", tool_call_id: "tcl_2", output: "ok" }, baseConfig);
-		expect((snake.data as Record<string, unknown>).toolUseId).toBe("tcl_2");
-
-		const nested = sanitizeBridgeEvent("tool_execution_end", { toolCall: { name: "Edit", id: "tcl_3", status: "error", isError: true }, error: "boom" }, baseConfig);
-		const nestedData = nested.data as Record<string, unknown>;
-		expect(nestedData.toolName).toBe("Edit");
-		expect(nestedData.toolUseId).toBe("tcl_3");
-		expect(nestedData.status).toBe("error");
-		expect(nestedData.isError).toBe(true);
-		expect(typeof nestedData.errorBytes).toBe("number");
-	});
-
-	test("agent_end accepts content array or single message variants", () => {
-		const stringContent = sanitizeBridgeEvent("agent_end", {
-			status: "ended",
-			usage: { inputTokens: 1 },
-			content: "final body " + "x".repeat(500),
-		}, baseConfig);
-		const stringData = stringContent.data as Record<string, unknown>;
-		expect(stringData.status).toBe("ended");
-		expect(typeof stringData.finalTextPreview).toBe("string");
-		expect((stringData.finalTextPreview as string).length).toBeGreaterThan(0);
-
-		const arrayContent = sanitizeBridgeEvent("agent_end", {
-			status: "ended",
-			content: [
-				{ type: "text", text: "alpha" },
-				{ type: "text", text: "omega" },
-			],
-		}, baseConfig);
-		expect((arrayContent.data as Record<string, unknown>).finalTextPreview).toBe("omega");
-
-		const singleMessage = sanitizeBridgeEvent("agent_end", {
-			status: "ended",
-			message: { role: "assistant", content: [{ type: "text", text: "from .message" }] },
-		}, baseConfig);
-		const singleData = singleMessage.data as Record<string, unknown>;
-		expect(singleData.messagesCount).toBe(1);
-		expect(singleData.finalTextPreview).toBe("from .message");
-	});
+	for (const row of [
+		{ name: "string content", payload: { status: "ended", usage: { inputTokens: 1 }, content: "final body " + "x".repeat(500) }, expected: { status: "ended" } },
+		{ name: "array content", payload: { status: "ended", content: [{ type: "text", text: "alpha" }, { type: "text", text: "omega" }] }, expected: { finalTextPreview: "omega" } },
+		{ name: "single message", payload: { status: "ended", message: { role: "assistant", content: [{ type: "text", text: "from .message" }] } }, expected: { messagesCount: 1, finalTextPreview: "from .message" } },
+	]) {
+		test(`agent end ${row.name}`, () => {
+			const data = sanitizeBridgeEvent("agent_end", row.payload, baseConfig).data as Record<string, unknown>;
+			expect(data).toMatchObject(row.expected);
+			expect(typeof data.finalTextPreview).toBe("string");
+			expect((data.finalTextPreview as string).length).toBeGreaterThan(0);
+		});
+	}
 
 	test("originalBytes reflects raw JSON length", () => {
 		const payload = { role: "assistant", contentIndex: 1, delta: "abc" };

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts
@@ -11,22 +11,24 @@ const baseConfig = { maxEventBytes: DEFAULT_MAX_EVENT_BYTES, previewBytes: DEFAU
 
 describe("sanitizeBridgeEvent", () => {
 	for (const row of [
-		{ name: "short delta", delta: "Hello world", length: 11, previewBytes: DEFAULT_PREVIEW_BYTES, large: false },
-		{ name: "large delta", delta: "x".repeat(500_000), length: 500_000, previewBytes: 64, large: true },
+		{ name: "short delta", payload: { role: "assistant", contentIndex: 0, type: "text", delta: "Hello world" }, expected: { role: "assistant", contentIndex: 0, type: "text", deltaLength: 11, deltaBytes: 11, deltaPreview: "Hello world" }, previewBytes: DEFAULT_PREVIEW_BYTES, raw: false },
+		{ name: "large delta", payload: { role: "assistant", contentIndex: 0, delta: "x".repeat(500_000) }, expected: { deltaLength: 500_000 }, previewBytes: 64, raw: true },
+		{ name: "assistant message envelope", payload: { assistantMessageEvent: { message: { id: "msg_42", role: "assistant", contentIndex: 2, type: "text", text: "z".repeat(800) } } }, expected: { role: "assistant", contentIndex: 2, messageId: "msg_42", type: "text", deltaLength: 800 }, previewBytes: DEFAULT_PREVIEW_BYTES, raw: false },
+		{ name: "message content array", payload: { message: { role: "assistant", content: [{ type: "text", text: "intro" }, { type: "text", text: "final body " + "y".repeat(400) }] } }, expected: { role: "assistant" }, previewBytes: DEFAULT_PREVIEW_BYTES, raw: false },
 	]) {
 		test(`message update ${row.name}`, () => {
-			const payload = { role: "assistant", contentIndex: 0, type: "text", delta: row.delta };
-			const result = sanitizeBridgeEvent("message_update", payload, { ...baseConfig, previewBytes: row.previewBytes });
+			const result = sanitizeBridgeEvent("message_update", row.payload, { ...baseConfig, previewBytes: row.previewBytes });
 			const data = result.data as Record<string, unknown>;
-			expect(data).toMatchObject({ role: "assistant", type: "text", contentIndex: 0, deltaLength: row.length, deltaBytes: row.length });
+			expect(data).toMatchObject(row.expected);
 			expect(typeof data.deltaPreview).toBe("string");
+			expect((data.deltaPreview as string).length).toBeGreaterThan(0);
 			expect((data.deltaPreview as string).length).toBeLessThanOrEqual(row.previewBytes);
 			expect("delta" in data).toBe(false);
 			expect(result.truncated).toBe(true);
-			if (row.large) {
-				expect(result.raw).toEqual(payload);
+			if (row.raw) {
+				expect(result.raw).toEqual(row.payload);
 				expect(result.originalBytes).toBeGreaterThan(100_000);
-			} else expect(data.deltaPreview).toBe("Hello world");
+			}
 		});
 	}
 
@@ -78,37 +80,31 @@ describe("sanitizeBridgeEvent", () => {
 		expect("messages" in data).toBe(false);
 	});
 
-	test("input events retain source and streaming behavior while compacting prompt text", () => {
-		const payload = {
-			text: "please adjust the current plan " + "x".repeat(200),
-			source: "extension",
-			streamingBehavior: "followUp",
-			images: [{ source: { type: "base64", data: "image-data" } }],
-		};
-		const result = sanitizeBridgeEvent("input", payload, { ...baseConfig, previewBytes: 48 });
-		const data = result.data as Record<string, unknown>;
-
-		expect(data.source).toBe("extension");
-		expect(data.streamingBehavior).toBe("followUp");
-		expect(data.imagesCount).toBe(1);
-		expect(data.textBytes).toBe(Buffer.byteLength(payload.text, "utf8"));
-		expect(data.textLength).toBe(payload.text.length);
-		expect((data.textPreview as string).length).toBeLessThanOrEqual(48);
-		expect(data.textTruncated).toBe(true);
-		expect("text" in data).toBe(false);
-		expect("images" in data).toBe(false);
-		expect(result.truncated).toBe(true);
-		expect(result.raw).toEqual(payload);
-	});
-
-	test("input event compaction treats idle prompts as undefined streaming behavior", () => {
-		const result = sanitizeBridgeEvent("input", { text: "idle prompt", source: "interactive" }, baseConfig);
-		const data = result.data as Record<string, unknown>;
-
-		expect(data.textPreview).toBe("idle prompt");
-		expect(data.source).toBe("interactive");
-		expect("streamingBehavior" in data).toBe(false);
-	});
+	for (const row of [
+		{ name: "streaming extension input", payload: { text: "please adjust the current plan " + "x".repeat(200), source: "extension", streamingBehavior: "followUp", images: [{ source: { type: "base64", data: "image-data" } }] }, previewBytes: 48, streamed: true },
+		{ name: "idle interactive input", payload: { text: "idle prompt", source: "interactive" }, previewBytes: DEFAULT_PREVIEW_BYTES, streamed: false },
+	]) {
+		test(row.name, () => {
+			const result = sanitizeBridgeEvent("input", row.payload, { ...baseConfig, previewBytes: row.previewBytes });
+			const data = result.data as Record<string, unknown>;
+			expect(data.source).toBe(row.payload.source);
+			if (row.streamed) {
+				expect(data.streamingBehavior).toBe("followUp");
+				expect(data.imagesCount).toBe(1);
+				expect(data.textBytes).toBe(Buffer.byteLength(row.payload.text, "utf8"));
+				expect(data.textLength).toBe(row.payload.text.length);
+				expect((data.textPreview as string).length).toBeLessThanOrEqual(48);
+				expect(data.textTruncated).toBe(true);
+				expect("text" in data).toBe(false);
+				expect("images" in data).toBe(false);
+				expect(result.truncated).toBe(true);
+				expect(result.raw).toEqual(row.payload);
+			} else {
+				expect(data.textPreview).toBe("idle prompt");
+				expect("streamingBehavior" in data).toBe(false);
+			}
+		});
+	}
 
 	for (const row of [
 		{ name: "small unknown event", event: "bridge_pong", payload: { ok: true, count: 3 }, maxEventBytes: DEFAULT_MAX_EVENT_BYTES, truncated: false },
@@ -169,46 +165,6 @@ describe("sanitizeBridgeEvent", () => {
 	});
 
 
-	test("message_update reads role/contentIndex/delta from assistantMessageEvent envelope", () => {
-		const payload = {
-			assistantMessageEvent: {
-				message: {
-					id: "msg_42",
-					role: "assistant",
-					contentIndex: 2,
-					type: "text",
-					text: "z".repeat(800),
-				},
-			},
-		};
-		const result = sanitizeBridgeEvent("message_update", payload, baseConfig);
-		const data = result.data as Record<string, unknown>;
-		expect(data.role).toBe("assistant");
-		expect(data.contentIndex).toBe(2);
-		expect(data.messageId).toBe("msg_42");
-		expect(data.type).toBe("text");
-		expect(data.deltaLength).toBe(800);
-		expect(typeof data.deltaPreview).toBe("string");
-		expect(result.truncated).toBe(true);
-	});
-
-	test("message_update falls back to message.content array text", () => {
-		const payload = {
-			message: {
-				role: "assistant",
-				content: [
-					{ type: "text", text: "intro" },
-					{ type: "text", text: "final body " + "y".repeat(400) },
-				],
-			},
-		};
-		const result = sanitizeBridgeEvent("message_update", payload, baseConfig);
-		const data = result.data as Record<string, unknown>;
-		expect(data.role).toBe("assistant");
-		expect(typeof data.deltaPreview).toBe("string");
-		expect((data.deltaPreview as string).length).toBeGreaterThan(0);
-		expect(result.truncated).toBe(true);
-	});
 
 	for (const row of [
 		{ name: "camel id", event: "tool_execution_start", payload: { toolName: "Read", toolCallId: "tcl_1", input: { path: "/x" } }, expected: { toolUseId: "tcl_1" }, errorBytes: false },

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/lib/history-fixture.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/lib/history-fixture.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HistoryEnvelope, HistoryLimits } from "../../event-history.js";
+
+export const defaultLimits: HistoryLimits = {
+	historyLimit: 500,
+	maxHistoryBytes: 4 * 1024 * 1024,
+	maxRawSpillBytes: 16 * 1024 * 1024,
+	spillEnabled: true,
+};
+
+let monotonicCounter = 0;
+
+export function makeEnvelope(event: string, dataBytes = 32): HistoryEnvelope {
+	const filler = "x".repeat(dataBytes);
+	const idx = monotonicCounter++;
+	const ms = String(idx % 1000).padStart(3, "0");
+	const seconds = String(Math.floor(idx / 1000) % 60).padStart(2, "0");
+	return {
+		type: "event",
+		event,
+		timestamp: `2026-05-21T00:00:${seconds}.${ms}Z`,
+		data: { filler, idx },
+	};
+}
+
+export let dir = "";
+export let spillPath = "";
+export let warnings: Array<{ where: string; error: unknown }> = [];
+
+export function useHistoryFixture(): void {
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "bridge-history-"));
+	spillPath = join(dir, "raw", `${process.pid}.jsonl`);
+	warnings = [];
+	monotonicCounter = 0;
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+}

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/session-info-events.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/session-info-events.test.ts
@@ -1,19 +1,65 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sessionBridge, { BRIDGE_STREAM_EVENT_NAMES, REGISTRY_REFRESH_EVENT_NAMES } from "../session-bridge.js";
+import { fakePi, fakeCtx, sendCommand, shutdownBridge, writeBridgeSettings } from "../../tests/lib/bridge-fixture.ts";
 
-import { BRIDGE_STREAM_EVENT_NAMES, REGISTRY_REFRESH_EVENT_NAMES } from "../session-bridge.js";
-
-test("session_info_changed is streamed to clients and refreshes registry metadata", () => {
-	expect(BRIDGE_STREAM_EVENT_NAMES).toContain("session_info_changed");
-	expect(REGISTRY_REFRESH_EVENT_NAMES.has("session_info_changed")).toBe(true);
-});
-
-test("every registry-refresh event is also streamed", () => {
-	const streamed = new Set<string>(BRIDGE_STREAM_EVENT_NAMES);
-	for (const eventName of REGISTRY_REFRESH_EVENT_NAMES) {
-		expect(streamed.has(eventName)).toBe(true);
-	}
-});
-
-test("streamed event names are unique", () => {
-	expect(new Set<string>(BRIDGE_STREAM_EVENT_NAMES).size).toBe(BRIDGE_STREAM_EVENT_NAMES.length);
-});
+for (const eventName of new Set(["session_info_changed", ...BRIDGE_STREAM_EVENT_NAMES, ...REGISTRY_REFRESH_EVENT_NAMES])) {
+	test(`${eventName} publishes once and updates registry when required`, async () => {
+		const root = fs.mkdtempSync(join(tmpdir(), "bridge-events-"));
+		const oldBridge = process.env.PI_BRIDGE_DIR;
+		const oldAgent = process.env.PI_CODING_AGENT_DIR;
+		const oldCwd = process.cwd();
+		const fixture = fakePi();
+		let writeSpy: ReturnType<typeof spyOn> | undefined;
+		let deadline: ReturnType<typeof setTimeout> | undefined;
+		try {
+			writeBridgeSettings(root);
+			process.chdir(root);
+			const bridgeDir = join(root, "bridge");
+			process.env.PI_BRIDGE_DIR = bridgeDir;
+			process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+			let name = "before";
+			fixture.pi.getSessionName = () => name;
+			sessionBridge(fixture.pi);
+			const ctx = fakeCtx(root);
+			await fixture.handlers.get("session_start")!({ reason: "test" }, ctx);
+			const registryPath = join(bridgeDir, "instances", `${process.pid}.json`);
+			const writes: string[] = [];
+			const writeFile = fs.promises.writeFile.bind(fs.promises);
+			let resolveWrite: () => void = () => {};
+			const written = new Promise<void>((resolve) => { resolveWrite = resolve; });
+			writeSpy = spyOn(fs.promises, "writeFile").mockImplementation(async (...args) => {
+				await writeFile(...args);
+				if (args[0] === registryPath) { writes.push(String(args[1])); resolveWrite(); }
+			});
+			name = `after-${eventName}`;
+			const handler = fixture.handlers.get(eventName);
+			expect(typeof handler).toBe("function");
+			await handler!({ name }, ctx);
+			const refresh = eventName === "session_info_changed" || REGISTRY_REFRESH_EVENT_NAMES.has(eventName);
+			if (refresh) {
+				await Promise.race([written, new Promise<never>((_resolve, reject) => {
+					deadline = setTimeout(() => reject(new Error("registry write deadline exceeded")), 2500);
+				})]);
+				clearTimeout(deadline);
+				expect(writes).toHaveLength(1);
+				expect(JSON.parse(fs.readFileSync(registryPath, "utf8"))).toMatchObject({ sessionName: name, lastReason: eventName });
+			}
+			const response = await sendCommand(join(bridgeDir, `pi-${process.pid}.sock`), { id: "events", type: "history", event: eventName, limit: 50 });
+			expect(response.success).toBe(true);
+			expect(response.data.events).toHaveLength(1);
+			expect(response.data.events[0].event).toBe(eventName);
+		} finally {
+			clearTimeout(deadline);
+			writeSpy?.mockRestore();
+			try { await shutdownBridge(fixture.handlers, root); } finally {
+				process.chdir(oldCwd);
+				if (oldBridge === undefined) delete process.env.PI_BRIDGE_DIR; else process.env.PI_BRIDGE_DIR = oldBridge;
+				if (oldAgent === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = oldAgent;
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+}

--- a/pi-extensions/pi-session-bridge/extensions/activity-broker.ts
+++ b/pi-extensions/pi-session-bridge/extensions/activity-broker.ts
@@ -168,5 +168,5 @@ function warnBridgePublisherFailure(event: PiActivityEvent, error: unknown): voi
 	if (warnedBridgePublisherFailures.has(key)) return;
 	warnedBridgePublisherFailures.add(key);
 	const message = error instanceof Error ? error.message : String(error);
-	console.warn(`[pi-session-bridge] activity bridge publisher failed type=${event.type} source=${event.source}: ${message}`);
+	console.warn(`publisher_failure=${event.type} source=${event.source} error=${errorName}\nActivity bridge publisher failed: ${message}`);
 }

--- a/pi-extensions/pi-session-bridge/extensions/diagnostics.ts
+++ b/pi-extensions/pi-session-bridge/extensions/diagnostics.ts
@@ -1,0 +1,6 @@
+export function stringifyError(error: unknown): string {
+	const code = error && typeof error === "object" && "code" in error ? String(error.code) : error instanceof Error ? error.name : typeof error;
+	const path = error && typeof error === "object" && "path" in error && typeof error.path === "string" ? ` path=${error.path}` : "";
+	const explanation = error instanceof Error ? error.message : String(error);
+	return `error_code=${code}${path}\n${explanation}`;
+}

--- a/pi-extensions/pi-session-bridge/extensions/event-history.ts
+++ b/pi-extensions/pi-session-bridge/extensions/event-history.ts
@@ -16,6 +16,7 @@
  *     compact-only data plus an explicit `rawError` marker.
  */
 
+import { stringifyError } from "./diagnostics.js";
 import { Buffer } from "node:buffer";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -69,6 +70,12 @@ interface RawSlot {
 }
 
 export type HistoryWarn = (where: string, error: unknown) => void;
+
+const messages = {
+	disabled: "spill_enabled=false\nRaw spill is disabled.",
+	budget: (bytes: number) => `spill_max_bytes=${bytes}\nRaw spill exceeds the configured limit.`,
+	refMismatch: (offset: number) => `raw_ref_offset=${offset}\nThe raw event reference does not match.`,
+};
 
 export class BridgeHistory {
 	private readonly entries: HistoryEntry[] = [];
@@ -126,7 +133,7 @@ export class BridgeHistory {
 					envelope.rawError = this.lastSpillError;
 				}
 			} else {
-				envelope.rawError = "raw spill disabled";
+				envelope.rawError = messages.disabled;
 			}
 		}
 		const bytes = Buffer.byteLength(JSON.stringify(envelope), "utf8");
@@ -245,7 +252,7 @@ export class BridgeHistory {
 			if (limits.maxRawSpillBytes > 0 && this.currentFileSize() + length > limits.maxRawSpillBytes) {
 				this.compactSidecar();
 				if (this.currentFileSize() + length > limits.maxRawSpillBytes) {
-					this.lastSpillError = `raw spill exceeds maxRawSpillBytes (${limits.maxRawSpillBytes})`;
+					this.lastSpillError = messages.budget(limits.maxRawSpillBytes);
 					this.warn("spill.budget", new Error(this.lastSpillError));
 					return undefined;
 				}
@@ -282,7 +289,7 @@ export class BridgeHistory {
 				fs.readSync(fd, buf, 0, current.length, current.offset);
 				const line = buf.toString("utf8").trimEnd();
 				const parsed = JSON.parse(line) as { ref?: unknown; data?: unknown };
-				if (parsed.ref !== slot.ref) return { ok: false, error: `raw ref mismatch at offset ${current.offset}` };
+				if (parsed.ref !== slot.ref) return { ok: false, error: messages.refMismatch(current.offset) };
 				return { ok: true, data: parsed.data };
 			} finally {
 				fs.closeSync(fd);
@@ -344,10 +351,7 @@ function clone(envelope: HistoryEnvelope): HistoryEnvelope {
 	return JSON.parse(JSON.stringify(envelope)) as HistoryEnvelope;
 }
 
-function stringifyError(error: unknown): string {
-	if (error instanceof Error) return `${error.name}: ${error.message}`;
-	return String(error);
-}
+
 
 /** Remove sidecar files belonging to dead pids. Best-effort. */
 export function cleanupStaleSpills(rawDir: string, isAlive: (pid: number) => boolean): void {

--- a/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
+++ b/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
@@ -47,7 +47,7 @@ const DEFAULT_MAX_LINE_BYTES = 1024 * 1024;
 const MAX_SKILL_EXPANSION_CACHE_SESSIONS = 100;
 
 const messages = {
-	loadedSkill: (name: string, args: string) => `skill_loaded=${name} invocation=${args}\nThe skill is already in this session's context.`,
+	loadedSkill: (name: string, args: string) => `skill_loaded=${name} invocation=${args.replace(/\s+/g, " ")}\nThe skill is already in this session's context.`,
 };
 
 /** Pi events the bridge republishes (after sanitizing) to subscribed clients. */

--- a/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
+++ b/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
@@ -12,6 +12,7 @@
  *   The bridge replies with JSONL responses and broadcasts live Pi events.
  */
 
+import { stringifyError } from "./diagnostics.js";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
@@ -44,6 +45,10 @@ const CONFIG_ID = "@vanillagreen/pi-session-bridge";
 const DEFAULT_HISTORY_LIMIT = 500;
 const DEFAULT_MAX_LINE_BYTES = 1024 * 1024;
 const MAX_SKILL_EXPANSION_CACHE_SESSIONS = 100;
+
+const messages = {
+	loadedSkill: (name: string, args: string) => `skill_loaded=${name} invocation=${args}\nThe skill is already in this session's context.`,
+};
 
 /** Pi events the bridge republishes (after sanitizing) to subscribed clients. */
 export const BRIDGE_STREAM_EVENT_NAMES = [
@@ -795,7 +800,7 @@ export function expandLoadedSlashContent(
 						expanded: true,
 						kind: "skill",
 						command: parsed.commandName,
-						text: invocation ? `Skill ${skillName} (previously loaded). Invocation: ${invocation}` : `Skill ${skillName} (previously loaded).`,
+						text: messages.loadedSkill(skillName, invocation),
 					};
 				}
 			}
@@ -1025,10 +1030,7 @@ function readPositiveInt(value: unknown, fallback: number) {
 	return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
-function stringifyError(error: unknown) {
-	if (error instanceof Error) return `${error.name}: ${error.message}`;
-	return String(error);
-}
+
 
 function toJsonable<T>(value: T): T {
 	const seen = new WeakSet<object>();

--- a/pi-extensions/pi-session-bridge/tests/cli-history.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/cli-history.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { runCli } from "./lib/cli-fixture.ts";
 import { mkdtempSync, rmSync, unlinkSync } from "node:fs";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
-const BRIDGE_BIN = resolve(__dirname, "..", "bin", "pi-bridge.js");
 
 interface CapturedCommand {
 	raw: string;
@@ -21,7 +20,10 @@ interface FakeBridge {
 async function startFakeBridge(dir: string, responder?: (cmd: Record<string, unknown>) => Record<string, unknown>): Promise<FakeBridge> {
 	const socketPath = join(dir, "fake.sock");
 	const captured: CapturedCommand[] = [];
+	const sockets = new Set<net.Socket>();
 	const server = net.createServer((socket) => {
+		sockets.add(socket);
+		socket.once("close", () => sockets.delete(socket));
 		let buffer = "";
 		socket.setEncoding("utf8");
 		socket.write(`${JSON.stringify({ type: "bridge_hello", protocol: "pi-session-bridge.v1" })}\n`);
@@ -58,6 +60,7 @@ async function startFakeBridge(dir: string, responder?: (cmd: Record<string, unk
 		captured,
 		close: () =>
 			new Promise<void>((resolveClose) => {
+				for (const socket of sockets) socket.destroy();
 				server.close(() => {
 					try { unlinkSync(socketPath); } catch { /* ignore */ }
 					resolveClose();
@@ -66,17 +69,6 @@ async function startFakeBridge(dir: string, responder?: (cmd: Record<string, unk
 	};
 }
 
-async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
-	return new Promise((resolveProcess, rejectProcess) => {
-		const child = spawn("node", [BRIDGE_BIN, ...args], { stdio: ["ignore", "pipe", "pipe"] });
-		let stdout = "";
-		let stderr = "";
-		child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
-		child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
-		child.on("error", rejectProcess);
-		child.on("close", (code) => resolveProcess({ stdout, stderr, code: code ?? -1 }));
-	});
-}
 
 let dir = "";
 let bridge: FakeBridge | undefined;
@@ -93,77 +85,19 @@ afterEach(async () => {
 	if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
-describe("pi-bridge history CLI", () => {
-	test("forwards --raw, --event, --since, --max-bytes, and limit positional", async () => {
+for (const row of [
+	{ name: "raw and filters", args: ["30", "--raw", "--event", "message_update", "--since", "2026-05-21T00:00:00.000Z", "--max-bytes", "4096"], expected: { type: "history", limit: 30, raw: true, event: "message_update", since: "2026-05-21T00:00:00.000Z", maxBytes: 4096 } },
+	{ name: "verbose alias omits limit", args: ["--verbose"], expected: { type: "history", raw: true } },
+	{ name: "default omits optional filters", args: ["10"], expected: { type: "history", limit: 10 } },
+	{ name: "non-numeric budget falls back", args: ["--max-bytes", "not-a-number"], expected: { type: "history" } },
+]) {
+	test(`history CLI ${row.name}`, async () => {
 		bridge = await startFakeBridge(dir);
-		const since = "2026-05-21T00:00:00.000Z";
-		const result = await runCli([
-			"history",
-			"--socket",
-			bridge.socketPath,
-			"30",
-			"--raw",
-			"--event",
-			"message_update",
-			"--since",
-			since,
-			"--max-bytes",
-			"4096",
-		]);
+		const result = await runCli(["history", "--socket", bridge.socketPath, ...row.args]);
 		expect(result.code).toBe(0);
 		expect(bridge.captured).toHaveLength(1);
-		const cmd = bridge.captured[0]!.parsed;
-		expect(cmd.type).toBe("history");
-		expect(cmd.limit).toBe(30);
-		expect(cmd.raw).toBe(true);
-		expect(cmd.event).toBe("message_update");
-		expect(cmd.since).toBe(since);
-		expect(cmd.maxBytes).toBe(4096);
-		expect(typeof cmd.id).toBe("string");
+		const { id, ...command } = bridge.captured[0]!.parsed;
+		expect(typeof id).toBe("string");
+		expect(command).toEqual(row.expected);
 	});
-
-	test("treats --verbose as an alias for --raw", async () => {
-		bridge = await startFakeBridge(dir);
-		const result = await runCli([
-			"history",
-			"--socket",
-			bridge.socketPath,
-			"--verbose",
-		]);
-		expect(result.code).toBe(0);
-		expect(bridge.captured).toHaveLength(1);
-		expect(bridge.captured[0]!.parsed.raw).toBe(true);
-		expect("limit" in bridge.captured[0]!.parsed).toBe(false);
-	});
-
-	test("default history call omits raw/event/since fields", async () => {
-		bridge = await startFakeBridge(dir);
-		const result = await runCli([
-			"history",
-			"--socket",
-			bridge.socketPath,
-			"10",
-		]);
-		expect(result.code).toBe(0);
-		const cmd = bridge.captured[0]!.parsed;
-		expect(cmd.type).toBe("history");
-		expect(cmd.limit).toBe(10);
-		expect("raw" in cmd).toBe(false);
-		expect("event" in cmd).toBe(false);
-		expect("since" in cmd).toBe(false);
-		expect("maxBytes" in cmd).toBe(false);
-	});
-
-	test("ignores non-numeric --max-bytes and falls back to bridge default", async () => {
-		bridge = await startFakeBridge(dir);
-		const result = await runCli([
-			"history",
-			"--socket",
-			bridge.socketPath,
-			"--max-bytes",
-			"not-a-number",
-		]);
-		expect(result.code).toBe(0);
-		expect("maxBytes" in bridge.captured[0]!.parsed).toBe(false);
-	});
-});
+}

--- a/pi-extensions/pi-session-bridge/tests/command-args.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/command-args.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { parseCommandArgs } from "../extensions/session-bridge.ts";
+
+for (const row of [
+	{ input: "one 'two words' \"three words\" four", expected: ["one", "two words", "three words", "four"] },
+	{ input: "one\ntwo 'three\nfour'\tfive", expected: ["one", "two", "three\nfour", "five"] },
+]) {
+	test(`parse command arguments ${JSON.stringify(row.input)}`, () => expect(parseCommandArgs(row.input)).toEqual(row.expected));
+}

--- a/pi-extensions/pi-session-bridge/tests/history-budgets.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/history-budgets.test.ts
@@ -1,121 +1,40 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import * as net from "node:net";
+import { afterEach, beforeEach, describe, expect, setSystemTime, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import sessionBridge from "../extensions/session-bridge.ts";
 
-type EventHandler = (event: any, ctx?: any) => unknown | Promise<unknown>;
-
-interface FakePi {
-	handlers: Map<string, EventHandler>;
-	pi: any;
-}
-
-function fakePi(): FakePi {
-	const handlers = new Map<string, EventHandler>();
-	return {
-		handlers,
-		pi: {
-			exec: async () => ({ code: 0, stdout: "" }),
-			getCommands: () => [],
-			getSessionName: () => undefined,
-			getThinkingLevel: () => undefined,
-			on: (eventName: string, handler: EventHandler) => handlers.set(eventName, handler),
-			registerCommand: () => undefined,
-			sendUserMessage: () => undefined,
-		},
-	};
-}
-
-function writeBridgeSettings(root: string, extras: Record<string, unknown> = {}): void {
-	const settingsPath = join(root, ".pi/settings.json");
-	mkdirSync(dirname(settingsPath), { recursive: true });
-	writeFileSync(settingsPath, JSON.stringify({
-		kendex: {
-			extensionManager: {
-				config: {
-					"@vanillagreen/pi-session-bridge": { enabled: true, ...extras },
-				},
-			},
-		},
-	}));
-}
-
-function fakeCtx(dir: string): any {
-	return {
-		cwd: dir,
-		hasUI: false,
-		isProjectTrusted: () => true,
-		sessionManager: { getSessionId: () => "session-test" },
-	};
-}
-
-async function shutdownBridge(handlers: Map<string, EventHandler>, dir: string): Promise<void> {
-	const shutdown = handlers.get("session_shutdown");
-	if (!shutdown) return;
-	// stop() awaits server.close() which can take a moment for FIN exchange under bun's net.
-	await Promise.race([
-		shutdown({ reason: "test" }, fakeCtx(dir)),
-		new Promise<void>((resolve) => setTimeout(resolve, 1500)),
-	]);
-}
-
-async function sendCommand(socketPath: string, payload: Record<string, unknown>): Promise<any> {
-	return new Promise<any>((resolve, reject) => {
-		const socket = net.createConnection(socketPath);
-		let buffer = "";
-		const targetId = payload.id;
-		const timeout = setTimeout(() => {
-			socket.destroy();
-			reject(new Error(`sendCommand timed out waiting for id=${String(targetId)}`));
-		}, 2500);
-		socket.setEncoding("utf8");
-		socket.on("connect", () => {
-			socket.write(`${JSON.stringify(payload)}\n`);
-		});
-		socket.on("data", (chunk) => {
-			buffer += chunk;
-			while (true) {
-				const nl = buffer.indexOf("\n");
-				if (nl === -1) break;
-				const line = buffer.slice(0, nl);
-				buffer = buffer.slice(nl + 1);
-				if (!line) continue;
-				let msg: any;
-				try { msg = JSON.parse(line); } catch { continue; }
-				if (msg.type === "response" && msg.id === targetId) {
-					clearTimeout(timeout);
-					socket.destroy();
-					resolve(msg);
-					return;
-				}
-			}
-		});
-		socket.on("error", (error) => {
-			clearTimeout(timeout);
-			reject(error);
-		});
-	});
-}
+import { fakePi, fakeCtx, sendCommand, shutdownBridge, writeBridgeSettings, type EventHandler } from "./lib/bridge-fixture.ts";
 
 let dir = "";
+let activeHandlers: Map<string, EventHandler> | undefined;
+let oldPiDir: string | undefined;
 let oldBridgeDir: string | undefined;
 let oldCwd = "";
 
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "pi-session-bridge-history-"));
 	oldBridgeDir = process.env.PI_BRIDGE_DIR;
+	oldPiDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = join(dir, "agent");
 	oldCwd = process.cwd();
 	process.env.PI_BRIDGE_DIR = join(dir, "bridge");
 });
 
 afterEach(async () => {
+	try {
+		if (activeHandlers) await shutdownBridge(activeHandlers, dir);
+	} finally {
+		activeHandlers = undefined;
+		setSystemTime();
+		if (oldPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = oldPiDir;
 	if (oldBridgeDir === undefined) delete process.env.PI_BRIDGE_DIR;
 	else process.env.PI_BRIDGE_DIR = oldBridgeDir;
 	process.chdir(oldCwd);
 	if (dir) rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 describe("history byte budgets", () => {
@@ -123,6 +42,7 @@ describe("history byte budgets", () => {
 		writeBridgeSettings(dir);
 		process.chdir(dir);
 		const { pi, handlers } = fakePi();
+		activeHandlers = handlers;
 		sessionBridge(pi);
 		await handlers.get("session_start")?.({ reason: "test" }, fakeCtx(dir));
 
@@ -162,16 +82,18 @@ describe("history byte budgets", () => {
 	});
 
 	test("history honors event and since filters", async () => {
+		setSystemTime(new Date("2026-05-20T00:00:00.000Z"));
 		writeBridgeSettings(dir);
 		process.chdir(dir);
 		const { pi, handlers } = fakePi();
+		activeHandlers = handlers;
 		sessionBridge(pi);
 		await handlers.get("session_start")?.({ reason: "test" }, fakeCtx(dir));
 
+		setSystemTime(new Date("2026-05-21T00:00:00.000Z"));
 		await handlers.get("message_update")?.({ role: "assistant", contentIndex: 0, delta: "first" }, fakeCtx(dir));
-		await new Promise((resolve) => setTimeout(resolve, 25));
-		const turnStart = new Date();
-		await new Promise((resolve) => setTimeout(resolve, 25));
+		const turnStart = new Date("2026-05-21T00:00:01.000Z");
+		setSystemTime(turnStart);
 		await handlers.get("tool_execution_end")?.({ toolName: "Read", toolUseId: "t1", status: "success", result: "result body" }, fakeCtx(dir));
 		await handlers.get("message_update")?.({ role: "assistant", contentIndex: 1, delta: "second" }, fakeCtx(dir));
 
@@ -195,6 +117,7 @@ describe("history byte budgets", () => {
 		writeBridgeSettings(dir, { maxHistoryBytes: 1_500, maxEventBytes: 65_536, eventPreviewBytes: 32 });
 		process.chdir(dir);
 		const { pi, handlers } = fakePi();
+		activeHandlers = handlers;
 		sessionBridge(pi);
 		await handlers.get("session_start")?.({ reason: "test" }, fakeCtx(dir));
 
@@ -220,6 +143,7 @@ describe("history byte budgets", () => {
 		writeBridgeSettings(dir, { maxEventBytes: 65_536, eventPreviewBytes: 16 });
 		process.chdir(dir);
 		const { pi, handlers } = fakePi();
+		activeHandlers = handlers;
 		sessionBridge(pi);
 		await handlers.get("session_start")?.({ reason: "test" }, fakeCtx(dir));
 
@@ -259,6 +183,7 @@ describe("history byte budgets", () => {
 		writeBridgeSettings(dir);
 		process.chdir(dir);
 		const { pi, handlers } = fakePi();
+		activeHandlers = handlers;
 		sessionBridge(pi);
 		await handlers.get("session_start")?.({ reason: "test" }, fakeCtx(dir));
 
@@ -273,7 +198,7 @@ describe("history byte budgets", () => {
 		expect(resp.success).toBe(true);
 		const updateEvent = (resp.data.events as Array<Record<string, unknown>>).find((entry) => entry.event === "message_update");
 		expect(updateEvent?.rawRestored).not.toBe(true);
-		expect(typeof updateEvent?.rawError).toBe("string");
+		expect((updateEvent?.rawError as string).split("\n")[0]).toBe("error_code=SyntaxError");
 		expect(Array.isArray(resp.data.rawErrors)).toBe(true);
 
 		await shutdownBridge(handlers, dir);
@@ -283,6 +208,7 @@ describe("history byte budgets", () => {
 		writeBridgeSettings(dir);
 		process.chdir(dir);
 		const { pi, handlers } = fakePi();
+		activeHandlers = handlers;
 		sessionBridge(pi);
 		await handlers.get("session_start")?.({ reason: "test" }, fakeCtx(dir));
 

--- a/pi-extensions/pi-session-bridge/tests/lib/bridge-fixture.ts
+++ b/pi-extensions/pi-session-bridge/tests/lib/bridge-fixture.ts
@@ -60,6 +60,7 @@ export function fakeCtx(dir: string): ExtensionContext {
 export async function shutdownBridge(handlers: Map<string, EventHandler>, dir: string): Promise<void> {
 	const shutdown = handlers.get("session_shutdown");
 	if (!shutdown) return;
+	handlers.delete("session_shutdown");
 	await shutdown({ reason: "test" }, fakeCtx(dir));
 }
 

--- a/pi-extensions/pi-session-bridge/tests/lib/bridge-fixture.ts
+++ b/pi-extensions/pi-session-bridge/tests/lib/bridge-fixture.ts
@@ -1,0 +1,70 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { HistoryResponse } from "../../extensions/event-history.ts";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { runCli } from "./cli-fixture.ts";
+import { dirname, join } from "node:path";
+
+export type EventHandler = (event: unknown, ctx?: unknown) => unknown | Promise<unknown>;
+
+interface FakePi {
+	handlers: Map<string, EventHandler>;
+	pi: ExtensionAPI;
+}
+
+export function fakePi(): FakePi {
+	const handlers = new Map<string, EventHandler>();
+	return {
+		handlers,
+		pi: {
+			exec: async () => ({ code: 0, stdout: "" }),
+			getCommands: () => [],
+			getSessionName: () => undefined,
+			getThinkingLevel: () => undefined,
+			on: (eventName: string, handler: EventHandler) => {
+				const previous = handlers.get(eventName);
+				handlers.set(eventName, previous ? async (event, ctx) => {
+					await previous(event, ctx);
+					return handler(event, ctx);
+				} : handler);
+			},
+			registerCommand: () => undefined,
+			sendUserMessage: () => undefined,
+		} as unknown as ExtensionAPI,
+	};
+}
+
+export function writeBridgeSettings(root: string, extras: Record<string, unknown> = {}): void {
+	const settingsPath = join(root, ".pi/settings.json");
+	mkdirSync(dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, JSON.stringify({
+		kendex: {
+			extensionManager: {
+				config: {
+					"@vanillagreen/pi-session-bridge": { enabled: true, ...extras },
+				},
+			},
+		},
+	}));
+}
+
+export function fakeCtx(dir: string): ExtensionContext {
+	return {
+		cwd: dir,
+		hasUI: false,
+		isProjectTrusted: () => true,
+		sessionManager: { getSessionId: () => "session-test" },
+	} as unknown as ExtensionContext;
+}
+
+export async function shutdownBridge(handlers: Map<string, EventHandler>, dir: string): Promise<void> {
+	const shutdown = handlers.get("session_shutdown");
+	if (!shutdown) return;
+	await shutdown({ reason: "test" }, fakeCtx(dir));
+}
+
+export async function sendCommand(socketPath: string, payload: Record<string, unknown>): Promise<{ success: boolean; data: HistoryResponse }> {
+	const result = await runCli(["request", "--socket", socketPath, JSON.stringify(payload)]);
+	assert.equal(result.code, 0, result.stderr);
+	return JSON.parse(result.stdout);
+}

--- a/pi-extensions/pi-session-bridge/tests/lib/cli-fixture.ts
+++ b/pi-extensions/pi-session-bridge/tests/lib/cli-fixture.ts
@@ -1,0 +1,30 @@
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BRIDGE_BIN = resolve(dirname(fileURLToPath(import.meta.url)), "../../bin/pi-bridge.js");
+
+export async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+	const child = spawn("node", [BRIDGE_BIN, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+	let stdout = "";
+	let stderr = "";
+	child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+	child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+	let expired = false;
+	const deadline = setTimeout(() => { expired = true; child.kill("SIGKILL"); }, 5000);
+	try {
+		const code = await new Promise<number>((resolveProcess, rejectProcess) => {
+			child.once("error", rejectProcess);
+			child.once("close", (code) => resolveProcess(code ?? -1));
+		});
+		if (expired) throw new Error("CLI deadline exceeded");
+		return { stdout, stderr, code };
+	} finally {
+		clearTimeout(deadline);
+		if (child.exitCode === null && child.signalCode === null && child.pid !== undefined) {
+			const closed = new Promise<void>((resolveClose) => child.once("close", () => resolveClose()));
+			child.kill("SIGKILL");
+			await closed;
+		}
+	}
+}

--- a/pi-extensions/pi-session-bridge/tests/lib/slash-fixture.ts
+++ b/pi-extensions/pi-session-bridge/tests/lib/slash-fixture.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadedSkillHashesBySession } from "../../extensions/session-bridge.ts";
+
+export let dir = "";
+
+let oldAgentDir: string | undefined;
+let oldBridgeDir: string | undefined;
+let oldCwd = "";
+export function p(name: string): string { return join(dir, name); }
+
+export function useSlashFixture(): void {
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "pi-session-bridge-slash-"));
+	
+	oldBridgeDir = process.env.PI_BRIDGE_DIR;
+	oldAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = join(dir, "agent");
+	oldCwd = process.cwd();
+});
+
+afterEach(() => {
+	
+	if (oldBridgeDir === undefined) delete process.env.PI_BRIDGE_DIR;
+	else process.env.PI_BRIDGE_DIR = oldBridgeDir;
+	if (oldAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = oldAgentDir;
+	process.chdir(oldCwd);
+	loadedSkillHashesBySession.clear();
+	if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+}

--- a/pi-extensions/pi-session-bridge/tests/skill-expansion-cache.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/skill-expansion-cache.test.ts
@@ -23,13 +23,13 @@ describe("skill expansion cache", () => {
 		expect(first.text).toContain(`<skill name="orch" location="${skillPath}">`);
 		expect(first.text).toContain("# Orchestration");
 
-		const second = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
+		const second = expandLoadedSlashContent("/skill:orch start\nABC-123\tready", commands, readFileSync, {
 			sessionId: "session-a",
 			skillExpansionCache: cache,
 		});
 		expect(second.expanded).toBe(true);
 		expect(second.kind).toBe("skill");
-		expect(second.text?.split("\n")[0]).toBe("skill_loaded=orch invocation=start ABC-123");
+		expect(second.text?.split("\n")[0]).toBe("skill_loaded=orch invocation=start ABC-123 ready");
 		expect(second.text).not.toContain("<skill");
 		expect(second.text).not.toContain("# Orchestration");
 

--- a/pi-extensions/pi-session-bridge/tests/skill-expansion-cache.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/skill-expansion-cache.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import sessionBridge, { expandLoadedSlashContent, loadedSkillHashesBySession, type SlashCommandInfoLike } from "../extensions/session-bridge.ts";
+import { fakePi, writeBridgeSettings } from "./lib/bridge-fixture.ts";
+import { dir, p, useSlashFixture } from "./lib/slash-fixture.ts";
+
+useSlashFixture();
+
+describe("skill expansion cache", () => {
+	test("dedups repeated skill expansion within the same session", () => {
+		const skillPath = p("skills/orch/SKILL.md");
+		mkdirSync(dirname(skillPath), { recursive: true });
+		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration\nStart work.\n");
+		const commands = [{ name: "skill:orch", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+
+		const first = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(first.expanded).toBe(true);
+		expect(first.text).toContain(`<skill name="orch" location="${skillPath}">`);
+		expect(first.text).toContain("# Orchestration");
+
+		const second = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(second.expanded).toBe(true);
+		expect(second.kind).toBe("skill");
+		expect(second.text?.split("\n")[0]).toBe("skill_loaded=orch invocation=start ABC-123");
+		expect(second.text).not.toContain("<skill");
+		expect(second.text).not.toContain("# Orchestration");
+
+		const otherSession = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
+			sessionId: "session-b",
+			skillExpansionCache: cache,
+		});
+		expect(otherSession.text).toContain(`<skill name="orch" location="${skillPath}">`);
+	});
+
+	test("evicts only the shutting-down session from the skill expansion cache", async () => {
+		writeBridgeSettings(dir);
+		process.chdir(dir);
+		process.env.PI_BRIDGE_DIR = p("bridge-dir");
+		loadedSkillHashesBySession.set("session-a", new Map([["alpha", "hash-a"]]));
+		loadedSkillHashesBySession.set("session-b", new Map([["beta", "hash-b"]]));
+
+		const { pi, handlers } = fakePi();
+		sessionBridge(pi);
+		const shutdown = handlers.get("session_shutdown");
+		expect(typeof shutdown).toBe("function");
+
+		await shutdown?.({ reason: "quit" }, { sessionManager: { getSessionId: () => "session-a" } });
+
+		expect(loadedSkillHashesBySession.has("session-a")).toBe(false);
+		expect(loadedSkillHashesBySession.get("session-b")?.get("beta")).toBe("hash-b");
+	});
+
+	test("bounds skill expansion cache to the 100 most recent sessions", () => {
+		const skillPath = p("skills/orch/SKILL.md");
+		mkdirSync(dirname(skillPath), { recursive: true });
+		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration\nStart work.\n");
+		const commands = [{ name: "skill:orch", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+
+		for (let index = 0; index < 101; index++) {
+			expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
+				sessionId: `session-${index}`,
+				skillExpansionCache: cache,
+			});
+		}
+
+		expect(cache.size).toBe(100);
+		expect(cache.has("session-0")).toBe(false);
+		expect(cache.has("session-1")).toBe(true);
+		expect(cache.has("session-100")).toBe(true);
+	});
+
+	test("re-expands skill after SKILL.md content changes", () => {
+		const skillPath = p("skills/orch/SKILL.md");
+		mkdirSync(dirname(skillPath), { recursive: true });
+		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration v1\n");
+		const commands = [{ name: "skill:orch", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+
+		const first = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(first.text).toContain("# Orchestration v1");
+
+		const deduped = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(deduped.text?.split("\n")[0]).toBe("skill_loaded=orch invocation=run");
+
+		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration v2\n");
+		const changed = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(changed.text).toContain(`<skill name="orch" location="${skillPath}">`);
+		expect(changed.text).toContain("# Orchestration v2");
+		expect(changed.text).not.toContain("# Orchestration v1");
+
+		const dedupedAgain = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(dedupedAgain.text?.split("\n")[0]).toBe("skill_loaded=orch invocation=run");
+	});
+
+	test("dedup is independent per skill within a session (pins Map<sessionId, Map<skillName, hash>>)", () => {
+		const alphaPath = p("skills/alpha/SKILL.md");
+		const betaPath = p("skills/beta/SKILL.md");
+		mkdirSync(dirname(alphaPath), { recursive: true });
+		mkdirSync(dirname(betaPath), { recursive: true });
+		writeFileSync(alphaPath, "---\nname: alpha\n---\n# Alpha Skill\nA body.\n");
+		writeFileSync(betaPath, "---\nname: beta\n---\n# Beta Skill\nB body.\n");
+		const commands = [
+			{ name: "skill:alpha", source: "skill", sourceInfo: { path: alphaPath } },
+			{ name: "skill:beta", source: "skill", sourceInfo: { path: betaPath } },
+		] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+		const options = { sessionId: "session-a", skillExpansionCache: cache };
+
+		const firstAlpha = expandLoadedSlashContent("/skill:alpha run-a", commands, readFileSync, options);
+		expect(firstAlpha.text).toContain(`<skill name="alpha" location="${alphaPath}">`);
+		expect(firstAlpha.text).toContain("# Alpha Skill");
+
+		// Skill B in the same session must still get the FULL body, not the dedup reminder.
+		const firstBeta = expandLoadedSlashContent("/skill:beta run-b", commands, readFileSync, options);
+		expect(firstBeta.text).toContain(`<skill name="beta" location="${betaPath}">`);
+		expect(firstBeta.text).toContain("# Beta Skill");
+		expect(firstBeta.text).not.toContain("skill_loaded=");
+
+		// Re-expanding each skill independently now hits the short reminder for each.
+		const secondAlpha = expandLoadedSlashContent("/skill:alpha run-a", commands, readFileSync, options);
+		expect(secondAlpha.text?.split("\n")[0]).toBe("skill_loaded=alpha invocation=run-a");
+
+		const secondBeta = expandLoadedSlashContent("/skill:beta run-b", commands, readFileSync, options);
+		expect(secondBeta.text?.split("\n")[0]).toBe("skill_loaded=beta invocation=run-b");
+	});
+});

--- a/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
@@ -1,77 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { expandLoadedSlashContent, type SlashCommandInfoLike } from "../extensions/session-bridge.ts";
+import { p, useSlashFixture } from "./lib/slash-fixture.ts";
 
-import sessionBridge, {
-	expandLoadedSlashContent,
-	loadedSkillHashesBySession,
-	parseCommandArgs,
-	pasteAndSubmitToPane,
-	resolveOwnTmuxPaneByParentChain,
-	type ExecLike,
-	type SlashCommandInfoLike,
-} from "../extensions/session-bridge.ts";
-
-type EventHandler = (event: any, ctx?: any) => unknown | Promise<unknown>;
-
-interface FakePi {
-	handlers: Map<string, EventHandler>;
-	pi: any;
-}
-
-function fakePi(): FakePi {
-	const handlers = new Map<string, EventHandler>();
-	return {
-		handlers,
-		pi: {
-			exec: async () => ({ code: 0, stdout: "" }),
-			getCommands: () => [],
-			getSessionName: () => undefined,
-			getThinkingLevel: () => undefined,
-			on: (eventName: string, handler: EventHandler) => handlers.set(eventName, handler),
-			registerCommand: () => undefined,
-			sendUserMessage: () => undefined,
-		},
-	};
-}
-
-function writeEnabledProjectSettings(root: string): void {
-	const settingsPath = join(root, ".pi/settings.json");
-	mkdirSync(dirname(settingsPath), { recursive: true });
-	writeFileSync(settingsPath, JSON.stringify({
-		kendex: {
-			extensionManager: {
-				config: {
-					"@vanillagreen/pi-session-bridge": { enabled: true },
-				},
-			},
-		},
-	}));
-}
-
-let dir = "";
-let oldTmux: string | undefined;
-let oldBridgeDir: string | undefined;
-let oldCwd = "";
-function p(name: string): string { return join(dir, name); }
-
-beforeEach(() => {
-	dir = mkdtempSync(join(tmpdir(), "pi-session-bridge-slash-"));
-	oldTmux = process.env.TMUX;
-	oldBridgeDir = process.env.PI_BRIDGE_DIR;
-	oldCwd = process.cwd();
-});
-
-afterEach(() => {
-	if (oldTmux === undefined) delete process.env.TMUX;
-	else process.env.TMUX = oldTmux;
-	if (oldBridgeDir === undefined) delete process.env.PI_BRIDGE_DIR;
-	else process.env.PI_BRIDGE_DIR = oldBridgeDir;
-	process.chdir(oldCwd);
-	loadedSkillHashesBySession.clear();
-	if (dir) rmSync(dir, { recursive: true, force: true });
-});
+useSlashFixture();
 
 describe("slash expansion", () => {
 	test("bridge dispatch matrix matches Pi editor outcomes", () => {
@@ -89,33 +22,19 @@ describe("slash expansion", () => {
 			{ name: "clear-ai", source: "prompt", sourceInfo: { path: promptPath } },
 		];
 
-		const plain = expandLoadedSlashContent("hello", commands);
-		expect(plain.expanded).toBe(false);
+		for (const row of [
+			{ input: "hello", expected: { expanded: false } },
+			{ input: "/bridge:ping ok", expected: { expanded: false } },
+			{ input: "/tasks:add foo", expected: { expanded: false } },
+			{ input: "/skill:worktree status", expected: { expanded: true, kind: "skill", text: [
+				`<skill name="worktree" location="${skillPath}">`, `References are relative to ${dirname(skillPath)}.`,
+				"", "# Worktree", "Use git worktrees.", "</skill>", "", "status",
+			].join("\n") } },
+			{ input: '/clear-ai one "two words"', expected: { expanded: true, kind: "prompt", text: "Clear one with all=one two words and rest=two words" } },
+		]) {
+			expect(expandLoadedSlashContent(row.input, commands)).toMatchObject(row.expected);
+		}
 
-		const ping = expandLoadedSlashContent("/bridge:ping ok", commands);
-		expect(ping.expanded).toBe(false); // Route 2: own tmux pane, editor executes extension command.
-
-		const tasks = expandLoadedSlashContent("/tasks:add foo", commands);
-		expect(tasks.expanded).toBe(false); // Route 2: own tmux pane, editor executes extension command.
-
-		const skill = expandLoadedSlashContent("/skill:worktree status", commands);
-		expect(skill.expanded).toBe(true);
-		expect(skill.kind).toBe("skill");
-		expect(skill.text).toBe([
-			`<skill name="worktree" location="${skillPath}">`,
-			`References are relative to ${dirname(skillPath)}.`,
-			"",
-			"# Worktree",
-			"Use git worktrees.",
-			"</skill>",
-			"",
-			"status",
-		].join("\n"));
-
-		const prompt = expandLoadedSlashContent('/clear-ai one "two words"', commands);
-		expect(prompt.expanded).toBe(true);
-		expect(prompt.kind).toBe("prompt");
-		expect(prompt.text).toBe("Clear one with all=one two words and rest=two words");
 	});
 
 	test("extension command wins name collisions, matching Pi prompt() precedence", () => {
@@ -129,201 +48,31 @@ describe("slash expansion", () => {
 		expect(result.expanded).toBe(false);
 	});
 
-	test("prompt and skill read failures are surfaced as expansion errors", () => {
-		const prompt = expandLoadedSlashContent("/missing arg", [
-			{ name: "missing", source: "prompt", sourceInfo: { path: p("prompts/missing.md") } },
-		]);
-		expect(prompt.expanded).toBe(false);
-		expect(prompt.error).toContain("ENOENT");
-		const skill = expandLoadedSlashContent("/skill:missing arg", [
-			{ name: "skill:missing", source: "skill", sourceInfo: { path: p("skills/missing/SKILL.md") } },
-		]);
-		expect(skill.expanded).toBe(false);
-		expect(skill.error).toContain("ENOENT");
-	});
+	for (const row of [
+		{ name: "missing", source: "prompt", path: "prompts/missing.md" },
+		{ name: "skill:missing", source: "skill", path: "skills/missing/SKILL.md" },
+	]) {
+		test(`${row.source} read failure`, () => {
+			const result = expandLoadedSlashContent(`/${row.name} arg`, [{ name: row.name, source: row.source, sourceInfo: { path: p(row.path) } }]);
+			expect(result.expanded).toBe(false);
+			expect(result.error?.split("\n")[0]).toBe(`error_code=ENOENT path=${p(row.path)}`);
+		});
+	}
 
 	test("prompt argument substitution matches Pi prompt-template rules", () => {
-		expect(parseCommandArgs("one 'two words' \"three words\" four")).toEqual(["one", "two words", "three words", "four"]);
-		expect(parseCommandArgs("one\ntwo 'three\nfour'\tfive")).toEqual(["one", "two", "three\nfour", "five"]);
 		const promptPath = p("template.md");
 		writeFileSync(promptPath, "---\ndescription: Demo\n---\n$1|$2|$@|$ARGUMENTS|${@:2}|${@:2:2}|${4:-fallback}|${2:-unused}|${5:-$1}|${@:-all-fallback}|${ARGUMENTS:-arguments-fallback}");
 		const commands = [{ name: "template", source: "prompt", sourceInfo: { path: promptPath } }] as SlashCommandInfoLike[];
-		const result = expandLoadedSlashContent('/template alpha "beta gamma" delta', commands);
-		expect(result.text).toBe("alpha|beta gamma|alpha beta gamma delta|alpha beta gamma delta|beta gamma delta|beta gamma delta|fallback|beta gamma|$1|alpha beta gamma delta|alpha beta gamma delta");
-		const multiline = expandLoadedSlashContent("/template\nalpha beta", commands);
-		expect(multiline.expanded).toBe(true);
-		expect(multiline.text).toBe("alpha|beta|alpha beta|alpha beta|beta|beta|fallback|beta|$1|alpha beta|alpha beta");
-		const defaults = expandLoadedSlashContent("/template", commands);
-		expect(defaults.text).toBe("||||||fallback|unused|$1|all-fallback|arguments-fallback");
-	});
-
-	test("dedups repeated skill expansion within the same session", () => {
-		const skillPath = p("skills/orch/SKILL.md");
-		mkdirSync(dirname(skillPath), { recursive: true });
-		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration\nStart work.\n");
-		const commands = [{ name: "skill:orch", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
-		const cache = new Map<string, Map<string, string>>();
-
-		const first = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
-			sessionId: "session-a",
-			skillExpansionCache: cache,
-		});
-		expect(first.expanded).toBe(true);
-		expect(first.text).toContain(`<skill name="orch" location="${skillPath}">`);
-		expect(first.text).toContain("# Orchestration");
-
-		const second = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
-			sessionId: "session-a",
-			skillExpansionCache: cache,
-		});
-		expect(second.expanded).toBe(true);
-		expect(second.kind).toBe("skill");
-		expect(second.text).toBe("Skill orch (previously loaded). Invocation: start ABC-123");
-		expect(second.text).not.toContain("<skill");
-		expect(second.text).not.toContain("# Orchestration");
-
-		const otherSession = expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
-			sessionId: "session-b",
-			skillExpansionCache: cache,
-		});
-		expect(otherSession.text).toContain(`<skill name="orch" location="${skillPath}">`);
-	});
-
-	test("evicts only the shutting-down session from the skill expansion cache", async () => {
-		writeEnabledProjectSettings(dir);
-		process.chdir(dir);
-		process.env.PI_BRIDGE_DIR = p("bridge-dir");
-		loadedSkillHashesBySession.set("session-a", new Map([["alpha", "hash-a"]]));
-		loadedSkillHashesBySession.set("session-b", new Map([["beta", "hash-b"]]));
-
-		const { pi, handlers } = fakePi();
-		sessionBridge(pi);
-		const shutdown = handlers.get("session_shutdown");
-		expect(typeof shutdown).toBe("function");
-
-		await shutdown?.({ reason: "quit" }, { sessionManager: { getSessionId: () => "session-a" } });
-
-		expect(loadedSkillHashesBySession.has("session-a")).toBe(false);
-		expect(loadedSkillHashesBySession.get("session-b")?.get("beta")).toBe("hash-b");
-	});
-
-	test("bounds skill expansion cache to the 100 most recent sessions", () => {
-		const skillPath = p("skills/orch/SKILL.md");
-		mkdirSync(dirname(skillPath), { recursive: true });
-		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration\nStart work.\n");
-		const commands = [{ name: "skill:orch", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
-		const cache = new Map<string, Map<string, string>>();
-
-		for (let index = 0; index < 101; index++) {
-			expandLoadedSlashContent("/skill:orch start ABC-123", commands, readFileSync, {
-				sessionId: `session-${index}`,
-				skillExpansionCache: cache,
-			});
+		for (const row of [
+			{ input: '/template alpha "beta gamma" delta', expected: "alpha|beta gamma|alpha beta gamma delta|alpha beta gamma delta|beta gamma delta|beta gamma delta|fallback|beta gamma|$1|alpha beta gamma delta|alpha beta gamma delta" },
+			{ input: "/template\nalpha beta", expected: "alpha|beta|alpha beta|alpha beta|beta|beta|fallback|beta|$1|alpha beta|alpha beta" },
+			{ input: "/template", expected: "||||||fallback|unused|$1|all-fallback|arguments-fallback" },
+		]) {
+			const result = expandLoadedSlashContent(row.input, commands);
+			expect(result.expanded).toBe(true);
+			expect(result.text).toBe(row.expected);
 		}
 
-		expect(cache.size).toBe(100);
-		expect(cache.has("session-0")).toBe(false);
-		expect(cache.has("session-1")).toBe(true);
-		expect(cache.has("session-100")).toBe(true);
 	});
 
-	test("re-expands skill after SKILL.md content changes", () => {
-		const skillPath = p("skills/orch/SKILL.md");
-		mkdirSync(dirname(skillPath), { recursive: true });
-		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration v1\n");
-		const commands = [{ name: "skill:orch", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
-		const cache = new Map<string, Map<string, string>>();
-
-		const first = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
-			sessionId: "session-a",
-			skillExpansionCache: cache,
-		});
-		expect(first.text).toContain("# Orchestration v1");
-
-		const deduped = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
-			sessionId: "session-a",
-			skillExpansionCache: cache,
-		});
-		expect(deduped.text).toBe("Skill orch (previously loaded). Invocation: run");
-
-		writeFileSync(skillPath, "---\nname: orch\n---\n# Orchestration v2\n");
-		const changed = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
-			sessionId: "session-a",
-			skillExpansionCache: cache,
-		});
-		expect(changed.text).toContain(`<skill name="orch" location="${skillPath}">`);
-		expect(changed.text).toContain("# Orchestration v2");
-		expect(changed.text).not.toContain("# Orchestration v1");
-
-		const dedupedAgain = expandLoadedSlashContent("/skill:orch run", commands, readFileSync, {
-			sessionId: "session-a",
-			skillExpansionCache: cache,
-		});
-		expect(dedupedAgain.text).toBe("Skill orch (previously loaded). Invocation: run");
-	});
-
-	test("dedup is independent per skill within a session (pins Map<sessionId, Map<skillName, hash>>)", () => {
-		const alphaPath = p("skills/alpha/SKILL.md");
-		const betaPath = p("skills/beta/SKILL.md");
-		mkdirSync(dirname(alphaPath), { recursive: true });
-		mkdirSync(dirname(betaPath), { recursive: true });
-		writeFileSync(alphaPath, "---\nname: alpha\n---\n# Alpha Skill\nA body.\n");
-		writeFileSync(betaPath, "---\nname: beta\n---\n# Beta Skill\nB body.\n");
-		const commands = [
-			{ name: "skill:alpha", source: "skill", sourceInfo: { path: alphaPath } },
-			{ name: "skill:beta", source: "skill", sourceInfo: { path: betaPath } },
-		] as SlashCommandInfoLike[];
-		const cache = new Map<string, Map<string, string>>();
-		const options = { sessionId: "session-a", skillExpansionCache: cache };
-
-		const firstAlpha = expandLoadedSlashContent("/skill:alpha run-a", commands, readFileSync, options);
-		expect(firstAlpha.text).toContain(`<skill name="alpha" location="${alphaPath}">`);
-		expect(firstAlpha.text).toContain("# Alpha Skill");
-
-		// Skill B in the same session must still get the FULL body, not the dedup reminder.
-		const firstBeta = expandLoadedSlashContent("/skill:beta run-b", commands, readFileSync, options);
-		expect(firstBeta.text).toContain(`<skill name="beta" location="${betaPath}">`);
-		expect(firstBeta.text).toContain("# Beta Skill");
-		expect(firstBeta.text).not.toContain("previously loaded");
-
-		// Re-expanding each skill independently now hits the short reminder for each.
-		const secondAlpha = expandLoadedSlashContent("/skill:alpha run-a", commands, readFileSync, options);
-		expect(secondAlpha.text).toBe("Skill alpha (previously loaded). Invocation: run-a");
-
-		const secondBeta = expandLoadedSlashContent("/skill:beta run-b", commands, readFileSync, options);
-		expect(secondBeta.text).toBe("Skill beta (previously loaded). Invocation: run-b");
-	});
-});
-
-describe("tmux pane dispatch", () => {
-	test("resolves own pane by parent chain, not active tmux client state", async () => {
-		process.env.TMUX = "/tmp/tmux-1000/default,123,0";
-		const calls: Array<[string, string[]]> = [];
-		const exec: ExecLike = async (command, args) => {
-			calls.push([command, args]);
-			if (command === "tmux") return { code: 0, stdout: "100 %1\n250 %2\n" };
-			const pid = args.at(-1);
-			if (pid === "303") return { code: 0, stdout: "202\n" };
-			if (pid === "202") return { code: 0, stdout: "100\n" };
-			if (pid === "100") return { code: 0, stdout: "1\n" };
-			return { code: 1, stderr: "missing pid" };
-		};
-
-		await expect(resolveOwnTmuxPaneByParentChain(exec, 303)).resolves.toBe("%1");
-		expect(calls[0]).toEqual(["tmux", ["list-panes", "-a", "-F", "#{pane_pid} #{pane_id}"]]);
-		expect(calls.some(([command, args]) => command === "tmux" && args[0] === "display-message")).toBe(false);
-	});
-
-	test("pastes slash text literally and submits Enter", async () => {
-		const calls: Array<[string, string[]]> = [];
-		const exec: ExecLike = async (command, args) => {
-			calls.push([command, args]);
-			return { code: 0, stdout: "" };
-		};
-		await pasteAndSubmitToPane(exec, "%7", "/tasks:add foo");
-		expect(calls).toEqual([
-			["tmux", ["send-keys", "-t", "%7", "-l", "/tasks:add foo"]],
-			["tmux", ["send-keys", "-t", "%7", "Enter"]],
-		]);
-	});
 });

--- a/pi-extensions/pi-session-bridge/tests/tmux-dispatch.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/tmux-dispatch.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { pasteAndSubmitToPane, resolveOwnTmuxPaneByParentChain, type ExecLike } from "../extensions/session-bridge.ts";
+
+let oldTmux: string | undefined;
+beforeEach(() => { oldTmux = process.env.TMUX; });
+afterEach(() => {
+	if (oldTmux === undefined) delete process.env.TMUX;
+	else process.env.TMUX = oldTmux;
+});
+
+describe("tmux pane dispatch", () => {
+	test("resolves own pane by parent chain, not active tmux client state", async () => {
+		process.env.TMUX = "/tmp/tmux-1000/default,123,0";
+		const calls: Array<[string, string[]]> = [];
+		const exec: ExecLike = async (command, args) => {
+			calls.push([command, args]);
+			if (command === "tmux") return { code: 0, stdout: "100 %1\n250 %2\n" };
+			const pid = args.at(-1);
+			if (pid === "303") return { code: 0, stdout: "202\n" };
+			if (pid === "202") return { code: 0, stdout: "100\n" };
+			if (pid === "100") return { code: 0, stdout: "1\n" };
+			return { code: 1, stderr: "missing pid" };
+		};
+
+		await expect(resolveOwnTmuxPaneByParentChain(exec, 303)).resolves.toBe("%1");
+		expect(calls[0]).toEqual(["tmux", ["list-panes", "-a", "-F", "#{pane_pid} #{pane_id}"]]);
+		expect(calls.some(([command, args]) => command === "tmux" && args[0] === "display-message")).toBe(false);
+	});
+
+	test("pastes slash text literally and submits Enter", async () => {
+		const calls: Array<[string, string[]]> = [];
+		const exec: ExecLike = async (command, args) => {
+			calls.push([command, args]);
+			return { code: 0, stdout: "" };
+		};
+		await pasteAndSubmitToPane(exec, "%7", "/tasks:add foo");
+		expect(calls).toEqual([
+			["tmux", ["send-keys", "-t", "%7", "-l", "/tasks:add foo"]],
+			["tmux", ["send-keys", "-t", "%7", "Enter"]],
+		]);
+	});
+});


### PR DESCRIPTION
Session-bridge tests mixed parsing, cache lifecycle, terminal dispatch, and history storage. Some tests accepted a shutdown timeout as success, used wall-clock sleeps, or checked event constants instead of emitted events. The suite now separates these contracts, tables shaped inputs, and owns its children, sockets, settings, and temporary files.

History integration tests use the shipped Node CLI through one shared child-process helper. They await actual server shutdown. Controlled publication time replaces sleeps. Registry tests execute the registered event handlers and inspect the resulting history and registry files. Duplicate registrations reach the fake Pi listeners, so the tests can detect duplicate publications.

Diagnostics used by the affected tests emit stable keys and values before English explanations. Error formatting has one owner; repeated-skill notices, spill refusals, and activity-publisher warnings have structural assertions.

Validation: affected suite passes (91 tests). One planted defect per changed surface failed its target assertion, including history shutdown, CLI flags, parsing, cache isolation, terminal dispatch, event publication, registry writes, and diagnostic keys. `env -u TMPDIR tools/guard --full` exits 0 on 8e806e9af. System temporary storage avoids the existing CLI ancestor-discovery fixture defect owned by the CLI audit lane.

Changed files:
- `pi-extensions/pi-session-bridge/extensions/__tests__/activity-broker.test.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/child-session-id.test.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/event-history-cleanup.test.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/event-history-response.test.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/event-history.test.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/lib/history-fixture.ts`
- `pi-extensions/pi-session-bridge/extensions/__tests__/session-info-events.test.ts`
- `pi-extensions/pi-session-bridge/extensions/activity-broker.ts`
- `pi-extensions/pi-session-bridge/extensions/diagnostics.ts`
- `pi-extensions/pi-session-bridge/extensions/event-history.ts`
- `pi-extensions/pi-session-bridge/extensions/session-bridge.ts`
- `pi-extensions/pi-session-bridge/tests/cli-history.test.ts`
- `pi-extensions/pi-session-bridge/tests/command-args.test.ts`
- `pi-extensions/pi-session-bridge/tests/history-budgets.test.ts`
- `pi-extensions/pi-session-bridge/tests/lib/bridge-fixture.ts`
- `pi-extensions/pi-session-bridge/tests/lib/cli-fixture.ts`
- `pi-extensions/pi-session-bridge/tests/lib/slash-fixture.ts`
- `pi-extensions/pi-session-bridge/tests/skill-expansion-cache.test.ts`
- `pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts`
- `pi-extensions/pi-session-bridge/tests/tmux-dispatch.test.ts`

Compliant test files left unchanged: none. All original package test files required changes. Declined: none.

Linear: KEN-1241.
