### PR TITLE
test(KEN-1241): audit pi-prompt-stash notices

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -520,6 +520,13 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
           npm test
 
+      # Prompt stash mocks its Pi TUI value imports, so its suite needs no
+      # package install.
+      - name: pi-prompt-stash suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-prompt-stash
+        run: npm test
+
       # pi-session-bridge imports nothing from Pi outside type positions, the
       # same case as pi-hooks above, so its suite runs with no install.
       - name: pi-session-bridge suite

--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -146,43 +146,11 @@ function suiteCounts() {
 	return packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
 }
 
-// Every package without a matching test file must be declared here because the
-// wiring gate has no test entry point to inspect. The reader accepts `tests/`,
-// `test/`, or `__tests__/` at any depth. It counts files, not test cases, so a
-// directory that contains only fixtures counts as covered.
-//
-// pi-prompt-stash: the stash behaviour — filterItems, previewText, loadItems,
-// saveItems, stashPrompt, safeFileName — sits unexported inside
-// `extensions/prompt-stash.ts`, which exports only its default entry point, so
-// a suite cannot reach it behind the editor shortcut and the pi-tui popup. The
-// two leaf modules beside it are importable and simply uncovered:
-// `extensions/settings.ts` is byte-identical to the copies pi-questions and
-// pi-task-panel vendor, and no suite in this tree imports any of the three —
-// pi-codex-minimal-tools/tests/settings.test.ts covers its own `src/settings.ts`,
-// a different file that happens to export a same-named recordProjectTrust.
-// The gate cannot determine when this reason expires: direction three below
-// fires only once the package gains tests, not when it becomes testable, so
-// exporting one of those functions tomorrow leaves the entry standing. It is
-// reviewed on this comment, not held by the gate.
-const NO_SUITE = ["pi-prompt-stash"];
-
-// Each direction the declaration can drift from the tree stays separate
-// because the remedies differ: add a suite, drop a stale entry, or correct a
-// name absent from the tree. Collapsing the last two makes a renamed or deleted
-// package report as one that gained tests, a
-// claim about a directory that is not there; `crates/core/src/pi_ext/renames.rs`
-// records prompt-stash -> pi-prompt-stash, so this repo has walked that path.
-// Taking the per-package suite counts as an argument is what lets the control
-// below run this exact reader over a mutated tree instead of asserting against
-// a second literal.
-function suiteDeclarationDrift(counts) {
-	const known = counts.map(([dir]) => dir);
-	const bare = counts.filter(([, files]) => files === 0).map(([dir]) => dir);
-	return [
-		...bare.filter((dir) => !NO_SUITE.includes(dir)).map((dir) => `${dir}: carries no test file and is not declared in NO_SUITE`),
-		...NO_SUITE.filter((dir) => !known.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but is not a package directory — the entry is stale`),
-		...NO_SUITE.filter((dir) => known.includes(dir) && !bare.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
-	];
+// Every package must carry a matching file under `tests/`, `test/`, or
+// `__tests__/`. Taking the counts as an argument lets the control below run
+// this reader over a mutated tree instead of asserting against another list.
+function packagesWithoutSuites(counts) {
+	return counts.filter(([, files]) => files === 0).map(([dir]) => `${dir}: carries no test file`);
 }
 
 // Packages whose declared CI entry point no enabled step invokes. Taking the
@@ -214,9 +182,9 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	assert.ok(bearing.length > 0, "no package carries test files — the suite-file walker is broken");
 
 	assert.deepEqual(
-		suiteDeclarationDrift(counts),
+		packagesWithoutSuites(counts),
 		[],
-		"a Pi package carries no test file without NO_SUITE declaring it, or a NO_SUITE entry is stale",
+		"a Pi package carries no test file",
 	);
 
 	assert.deepEqual(
@@ -253,28 +221,16 @@ test("a step conditioned on a shard the matrix does not run is reported, not acc
 	assert.deepEqual(unrunPackages(typo), ["pi-claude-bridge: no step on a shard the matrix runs invokes `npm run test:ci`"]);
 });
 
-// Must-fail control for the declaration above: with every package in the tree
-// either covered or declared, the drift reader returns the same empty list a
-// reader that had stopped looking would, so each direction it reports is
-// mutated here.
-test("a package with no test file is reported unless NO_SUITE declares it", () => {
+// Must-fail control for the reader above: with every package covered, a reader
+// that stopped looking would return the same empty list as the correct reader.
+test("a package with no test file is reported", () => {
 	const counts = suiteCounts();
-	assert.deepEqual(suiteDeclarationDrift(counts), [], "precondition: the real tree matches NO_SUITE");
+	assert.deepEqual(packagesWithoutSuites(counts), [], "precondition: every real package carries a suite");
 
-	const stripped = counts.find(([dir, files]) => files > 0 && !NO_SUITE.includes(dir));
+	const stripped = counts.find(([, files]) => files > 0);
 	assert.ok(stripped, "no covered package to strip — this control no longer mutates the tree it reads");
 	assert.deepEqual(
-		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, dir === stripped[0] ? 0 : files])),
-		[`${stripped[0]}: carries no test file and is not declared in NO_SUITE`],
-	);
-
-	assert.ok(NO_SUITE.length > 0, "NO_SUITE is empty — the two declaration directions below mutate nothing");
-	assert.deepEqual(
-		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, NO_SUITE.includes(dir) ? 1 : files])),
-		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
-	);
-	assert.deepEqual(
-		suiteDeclarationDrift(counts.filter(([dir]) => !NO_SUITE.includes(dir))),
-		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but is not a package directory — the entry is stale`),
+		packagesWithoutSuites(counts.map(([dir, files]) => [dir, dir === stripped[0] ? 0 : files])),
+		[`${stripped[0]}: carries no test file`],
 	);
 });

--- a/pi-extensions/pi-prompt-stash/CHANGELOG.md
+++ b/pi-extensions/pi-prompt-stash/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Consumer-impacting changes
 
+### Unreleased
+
+- Prompt stash notices start with a stable item-count field.
+
 ### 3.0.0
 
 - **Breaking**: stash stores are no longer moved from the older locations `~/.pi/agent/kendex/prompt-stash/sessions/<id>/` and `<project>/.pi/<store file>` at session start or when the popup opens. Drafts still sitting in those locations stay there and `/prompt-stash` no longer shows them; move them into the per-session directory by hand to keep them.

--- a/pi-extensions/pi-prompt-stash/extensions/__tests__/notifications.test.ts
+++ b/pi-extensions/pi-prompt-stash/extensions/__tests__/notifications.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+mock.module("@earendil-works/pi-tui", () => ({
+	Input: class {},
+	matchesKey: () => false,
+	truncateToWidth: (text: string) => text,
+	visibleWidth: (text: string) => text.length,
+}));
+
+const { default: promptStash } = await import("../prompt-stash.js");
+
+let root = "";
+let previousAgentDir: string | undefined;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "pi-prompt-stash-test-"));
+	mkdirSync(join(root, "project", ".pi"), { recursive: true });
+	mkdirSync(join(root, "agent"));
+	previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+});
+
+afterEach(() => {
+	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	rmSync(root, { recursive: true, force: true });
+});
+
+for (const row of [
+	{ name: "empty command", editorText: "", expected: "prompt_stash_items=0" },
+	{ name: "saved shortcut", editorText: "draft", expected: "prompt_stash_items=1" },
+]) {
+	test(row.name, async () => {
+		let command: { handler: (args: string, ctx: any) => Promise<void> } | undefined;
+		let shortcut: { handler: (ctx: any) => Promise<void> } | undefined;
+		const notices: Array<{ message: string; level: string }> = [];
+		let editorText = row.editorText;
+		const pi = {
+			on() {},
+			registerCommand(_name: string, definition: typeof command) { command = definition; },
+			registerShortcut(_key: string, definition: typeof shortcut) { shortcut = definition; },
+		};
+		promptStash(pi as never);
+		const ctx = {
+			cwd: join(root, "project"),
+			hasUI: true,
+			sessionManager: {
+				getSessionFile: () => undefined,
+				getSessionId: () => "session-1",
+			},
+			ui: {
+				getEditorText: () => editorText,
+				notify: (message: string, level: string) => notices.push({ message, level }),
+				setEditorText: (value: string) => { editorText = value; },
+			},
+		};
+		if (row.editorText) await shortcut!.handler(ctx);
+		else await command!.handler("", ctx);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]!.message.split("\n")[0]).toBe(row.expected);
+		expect(notices[0]!.level).toBe("info");
+		if (row.editorText) {
+			const stored = JSON.parse(readFileSync(join(root, "agent", "kendex", "sessions", "session-1", "prompt-stash", "prompt-stash.json"), "utf8"));
+			expect(stored.items).toHaveLength(1);
+			expect(editorText).toBe("");
+		}
+	});
+}

--- a/pi-extensions/pi-prompt-stash/extensions/prompt-stash.ts
+++ b/pi-extensions/pi-prompt-stash/extensions/prompt-stash.ts
@@ -26,6 +26,11 @@ const ANSI_GREEN_FG = "\x1b[32m";
 const ANSI_YELLOW_FG = "\x1b[33m";
 const ANSI_FG_RESET = "\x1b[39m";
 
+const stashMessages = {
+	empty: "prompt_stash_items=0\nPrompt stash is empty",
+	saved: (count: number) => `prompt_stash_items=${count}\nStashed prompt (${count} total)`,
+};
+
 function ansiGreen(text: string): string { return `${ANSI_GREEN_FG}${text}${ANSI_FG_RESET}`; }
 function ansiYellow(text: string): string { return `${ANSI_YELLOW_FG}${text}${ANSI_FG_RESET}`; }
 
@@ -232,7 +237,7 @@ async function openStashPopup(ctx: ExtensionContext): Promise<void> {
 	const path = storePath(ctx);
 	let items = loadItems(path);
 	if (items.length === 0) {
-		ctx.ui.notify("Prompt stash is empty", "info");
+		ctx.ui.notify(stashMessages.empty, "info");
 		return;
 	}
 
@@ -439,7 +444,7 @@ async function toggleStash(ctx: ExtensionContext): Promise<void> {
 	if (text.trim().length > 0) {
 		const count = stashPrompt(ctx, text);
 		ctx.ui.setEditorText("");
-		ctx.ui.notify(`Stashed prompt (${count} total)`, "info");
+		ctx.ui.notify(stashMessages.saved(count), "info");
 		return;
 	}
 

--- a/pi-extensions/pi-prompt-stash/package.json
+++ b/pi-extensions/pi-prompt-stash/package.json
@@ -17,6 +17,9 @@
     ],
     "image": "https://raw.githubusercontent.com/vanillagreencom/kendex/main/pi-extensions/pi-prompt-stash/assets/stash-popup.png"
   },
+  "scripts": {
+    "test": "bun test ./extensions/__tests__"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"


### PR DESCRIPTION
Prompt Stash had no suite, and its empty and saved notices exposed English as their first line. This change gives both notices a stable item-count field, adds direct command and shortcut coverage, removes the obsolete no-suite exception, and runs the package in CI.

Validation:

- `npm test`
- `node --test pi-extensions/package-policy.test.mjs`
- `env -u TMPDIR tools/guard --full`
- Must-fail control: removing the saved-count field fails the saved shortcut row.

Compliant test files left unchanged: none. The package had no test files before this change.
