### PR TITLE
test(KEN-1241): audit pi-questions message contracts

### DIFF
--- a/pi-extensions/pi-agents-tmux/scripts/append-system.mjs
+++ b/pi-extensions/pi-agents-tmux/scripts/append-system.mjs
@@ -27,9 +27,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+// npm invokes this file directly; notices retain their key and value even
+// when their explanation changes. JSON quoting keeps input values on one line.
+function notice(key, value, explanation) {
+	console.error(`append-system: ${key}=${JSON.stringify(value)}`);
+	console.error(explanation);
+}
+
 const action = process.argv[2];
 if (action !== "install" && action !== "remove") {
-	console.error(`append-system.mjs: expected "install" or "remove", got "${action}"`);
+	notice("action", action ?? null, 'Expected "install" or "remove".');
 	process.exit(1);
 }
 
@@ -39,20 +46,20 @@ let pkg;
 try {
 	pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 } catch (err) {
-	console.error(`append-system.mjs: unable to read package.json in ${pkgDir}: ${err?.message ?? err}`);
+	notice("package-read", pkgDir, `Unable to read package.json: ${err?.message ?? err}`);
 	process.exit(0);
 }
 
 const name = typeof pkg?.name === "string" ? pkg.name : undefined;
 const rel = pkg?.pi?.appendSystem;
 if (!name || typeof rel !== "string") {
-	console.error(`append-system.mjs: package ${pkgDir} is missing name or pi.appendSystem`);
+	notice("package-fields", pkgDir, "The package needs name and pi.appendSystem fields.");
 	process.exit(0);
 }
 
 const scopeRoot = findScopeRoot(pkgDir);
 if (!scopeRoot) {
-	console.error(`append-system.mjs: unable to resolve Pi scope for ${name} from ${pkgDir}`);
+	notice("scope", pkgDir, `Unable to resolve the Pi scope for ${name}.`);
 	process.exit(0);
 }
 
@@ -64,12 +71,12 @@ try {
 	if (action === "install") {
 		const sourcePath = resolve(pkgDir, rel);
 		if (!existsSync(sourcePath)) {
-			console.error(`append-system.mjs: appendSystem source missing for ${name}: ${sourcePath}`);
+			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
 		const content = readFileSync(sourcePath, "utf8").trim();
 		if (!content) {
-			console.error(`append-system.mjs: appendSystem source is empty for ${name}: ${sourcePath}`);
+			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);
 		}
 		upsertBlock(target, begin, end, content);
@@ -78,7 +85,7 @@ try {
 	}
 } catch (err) {
 	// Never fail the npm install/uninstall over an APPEND_SYSTEM.md write.
-	console.error(`append-system.mjs (${action}) for ${name}: ${err?.message ?? err}`);
+	notice("operation", `${action}:${name}:${err?.code ?? "unknown"}`, `Unable to update APPEND_SYSTEM.md: ${err?.message ?? err}`);
 	process.exit(0);
 }
 

--- a/pi-extensions/pi-agents-tmux/scripts/append-system.mjs
+++ b/pi-extensions/pi-agents-tmux/scripts/append-system.mjs
@@ -74,7 +74,13 @@ try {
 			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
-		const content = readFileSync(sourcePath, "utf8").trim();
+		let content;
+		try {
+			content = readFileSync(sourcePath, "utf8").trim();
+		} catch (err) {
+			notice("source-read", sourcePath, `Unable to read the appendSystem source for ${name}: ${err?.message ?? err}`);
+			process.exit(0);
+		}
 		if (!content) {
 			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);

--- a/pi-extensions/pi-background-tasks/scripts/append-system.mjs
+++ b/pi-extensions/pi-background-tasks/scripts/append-system.mjs
@@ -27,9 +27,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+// npm invokes this file directly; notices retain their key and value even
+// when their explanation changes. JSON quoting keeps input values on one line.
+function notice(key, value, explanation) {
+	console.error(`append-system: ${key}=${JSON.stringify(value)}`);
+	console.error(explanation);
+}
+
 const action = process.argv[2];
 if (action !== "install" && action !== "remove") {
-	console.error(`append-system.mjs: expected "install" or "remove", got "${action}"`);
+	notice("action", action ?? null, 'Expected "install" or "remove".');
 	process.exit(1);
 }
 
@@ -39,20 +46,20 @@ let pkg;
 try {
 	pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 } catch (err) {
-	console.error(`append-system.mjs: unable to read package.json in ${pkgDir}: ${err?.message ?? err}`);
+	notice("package-read", pkgDir, `Unable to read package.json: ${err?.message ?? err}`);
 	process.exit(0);
 }
 
 const name = typeof pkg?.name === "string" ? pkg.name : undefined;
 const rel = pkg?.pi?.appendSystem;
 if (!name || typeof rel !== "string") {
-	console.error(`append-system.mjs: package ${pkgDir} is missing name or pi.appendSystem`);
+	notice("package-fields", pkgDir, "The package needs name and pi.appendSystem fields.");
 	process.exit(0);
 }
 
 const scopeRoot = findScopeRoot(pkgDir);
 if (!scopeRoot) {
-	console.error(`append-system.mjs: unable to resolve Pi scope for ${name} from ${pkgDir}`);
+	notice("scope", pkgDir, `Unable to resolve the Pi scope for ${name}.`);
 	process.exit(0);
 }
 
@@ -64,12 +71,12 @@ try {
 	if (action === "install") {
 		const sourcePath = resolve(pkgDir, rel);
 		if (!existsSync(sourcePath)) {
-			console.error(`append-system.mjs: appendSystem source missing for ${name}: ${sourcePath}`);
+			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
 		const content = readFileSync(sourcePath, "utf8").trim();
 		if (!content) {
-			console.error(`append-system.mjs: appendSystem source is empty for ${name}: ${sourcePath}`);
+			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);
 		}
 		upsertBlock(target, begin, end, content);
@@ -78,7 +85,7 @@ try {
 	}
 } catch (err) {
 	// Never fail the npm install/uninstall over an APPEND_SYSTEM.md write.
-	console.error(`append-system.mjs (${action}) for ${name}: ${err?.message ?? err}`);
+	notice("operation", `${action}:${name}:${err?.code ?? "unknown"}`, `Unable to update APPEND_SYSTEM.md: ${err?.message ?? err}`);
 	process.exit(0);
 }
 

--- a/pi-extensions/pi-background-tasks/scripts/append-system.mjs
+++ b/pi-extensions/pi-background-tasks/scripts/append-system.mjs
@@ -74,7 +74,13 @@ try {
 			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
-		const content = readFileSync(sourcePath, "utf8").trim();
+		let content;
+		try {
+			content = readFileSync(sourcePath, "utf8").trim();
+		} catch (err) {
+			notice("source-read", sourcePath, `Unable to read the appendSystem source for ${name}: ${err?.message ?? err}`);
+			process.exit(0);
+		}
 		if (!content) {
 			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);

--- a/pi-extensions/pi-questions/extensions/__tests__/activity.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/activity.test.ts
@@ -39,7 +39,6 @@ describe("question activity", () => {
 			refs: { question_id: "que_1" },
 			severity: "warning",
 			source: "pi-questions",
-			summary: "question opened: Pick path",
 			type: "question.opened",
 		});
 		expect(events[0]?.details).toMatchObject({ header: "Pick path", question_count: 1, source: "tool" });

--- a/pi-extensions/pi-questions/extensions/__tests__/answer-steer-wiring.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/answer-steer-wiring.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { QuestionActivityEvent } from "../activity.js";
+import { normalizeRequest } from "../question-model.js";
+
+// These Pi dependencies are unavailable in a dependency-free package test.
+// The test drives the registered service, without rendering a terminal UI.
+const unexpected = () => { throw new Error("Unexpected UI or output operation"); };
+mock.module("@earendil-works/pi-coding-agent", () => ({
+	DEFAULT_MAX_BYTES: 1024,
+	DEFAULT_MAX_LINES: 100,
+	formatSize: String,
+	truncateHead: unexpected,
+	withFileMutationQueue: unexpected,
+}));
+mock.module("@earendil-works/pi-tui", () => ({
+	Input: class { constructor() { unexpected(); } },
+	matchesKey: unexpected,
+	truncateToWidth: unexpected,
+	visibleWidth: unexpected,
+}));
+
+const { default: questions } = await import("../questions.js");
+const SERVICE = Symbol.for("kendex.pi-questions.service");
+
+interface Service {
+	ask(ctx: unknown, payload: unknown): Promise<unknown>;
+	reply(id: string, answers: string[][]): boolean;
+	reject(id: string): boolean;
+	subscribe(listener: (event: QuestionActivityEvent) => void): () => void;
+}
+
+describe("answer steer registration", () => {
+	test("delivers answers only when enabled and keeps the original request on terminal events", async () => {
+		for (const { setting, action, messages } of [
+			{ setting: undefined, action: "answered", messages: [] },
+			{ setting: false, action: "answered", messages: [] },
+			{ setting: true, action: "answered", messages: [{ content: "> Which path?\n\nA", options: { deliverAs: "steer" } }] },
+			{ setting: true, action: "rejected", messages: [] },
+		] as const) {
+			const root = mkdtempSync(join(tmpdir(), "question-steer-"));
+			const previousDir = process.env.PI_CODING_AGENT_DIR;
+			const globals = globalThis as unknown as Record<PropertyKey, unknown>;
+			const previousService = globals[SERVICE];
+			const handlers = new Map<string, (...args: unknown[]) => unknown>();
+			try {
+				process.env.PI_CODING_AGENT_DIR = root;
+				delete globals[SERVICE];
+				writeFileSync(join(root, "settings.json"), JSON.stringify({
+					kendex: { extensionManager: { config: { "@vanillagreen/pi-questions": { answersAsUserMessage: setting } } } },
+				}));
+				const calls: Array<{ content: string; options: unknown }> = [];
+				const pi = {
+					events: { emit() {} },
+					on(name: string, handler: (...args: unknown[]) => unknown) { handlers.set(name, handler); },
+					registerTool() {},
+					sendUserMessage(content: string, options: unknown) { calls.push({ content, options }); },
+				};
+				questions(pi as unknown as Parameters<typeof questions>[0]);
+				const service = globals[SERVICE] as Service;
+				const events: QuestionActivityEvent[] = [];
+				service.subscribe((event) => events.push(event));
+				const request = normalizeRequest({
+					id: "que_wiring",
+					questions: [{ header: "Path", question: "Which path?", options: [{ label: "A" }, { label: "B" }] }],
+				});
+				const pending = service.ask({ cwd: root, hasUI: false, ui: {} }, request);
+				if (action === "answered") service.reply(request.id, [["A"]]);
+				else service.reject(request.id);
+				await pending;
+				expect({ calls, events: events.map(({ action, request: original, requestId }) => ({ action, original, requestId })) }).toEqual({
+					calls: messages,
+					events: [
+						{ action: "opened", original: request, requestId: request.id },
+						{ action, original: request, requestId: request.id },
+					],
+				});
+			} finally {
+				handlers.get("session_shutdown")?.();
+				if (previousService === undefined) delete globals[SERVICE];
+				else globals[SERVICE] = previousService;
+				if (previousDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+				else process.env.PI_CODING_AGENT_DIR = previousDir;
+				rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+});

--- a/pi-extensions/pi-questions/extensions/__tests__/answer-steer.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/answer-steer.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
 
 import { emitAnswerSteer, formatAnswerSteerMessage } from "../answer-steer.js";
 import { normalizeRequest } from "../question-model.js";
@@ -83,21 +82,5 @@ describe("answer steer emission", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 		expect(noted).toBe(1);
-	});
-});
-
-describe("questions.ts steer wiring", () => {
-	const source = readFileSync(new URL("../questions.ts", import.meta.url), "utf8");
-
-	test("emission is gated on the answersAsUserMessage setting, default off", () => {
-		expect(source).toContain('settingBoolean("answersAsUserMessage", false');
-	});
-
-	test("answered events reach emitAnswerSteer with the original request", () => {
-		expect(source).toContain("emitAnswerSteer(pi, event.request, event.result.answers");
-	});
-
-	test("answered and rejected events publish the originating request", () => {
-		expect(source.replace(/\s+/g, " ")).toContain("openedAt, request, requestId: request.id, result: finalResult");
 	});
 });

--- a/pi-extensions/pi-questions/extensions/__tests__/append-system.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/append-system.test.ts
@@ -17,6 +17,7 @@ describe("append-system lifecycle", () => {
 			{ name: "unmanaged scope", args: ["install"], manifest, unmanaged: true, key: "scope", value: "package", status: 0 },
 			{ name: "missing instructions", args: ["install"], manifest, key: "source-missing", value: "source", status: 0 },
 			{ name: "empty instructions", args: ["install"], manifest, content: "  \n", key: "source-empty", value: "source", status: 0 },
+			{ name: "unreadable instructions", args: ["install"], manifest, sourceDirectory: true, key: "operation", value: "install:@test/questions:EISDIR", status: 0 },
 		]) {
 			const root = mkdtempSync(join(tmpdir(), "append-system-"));
 			try {
@@ -26,6 +27,7 @@ describe("append-system lifecycle", () => {
 				copyFileSync(helper, script);
 				if (row.manifest !== undefined) writeFileSync(join(pkg, "package.json"), JSON.stringify(row.manifest));
 				if (row.content !== undefined) writeFileSync(join(pkg, "instructions.md"), row.content);
+				if ("sourceDirectory" in row && row.sourceDirectory) mkdirSync(join(pkg, "instructions.md"));
 				const result = spawnSync("node", [script, ...row.args], {
 					encoding: "utf8",
 					env: { ...process.env, PI_CODING_AGENT_DIR: join(root, "absent-pi") },

--- a/pi-extensions/pi-questions/extensions/__tests__/append-system.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/append-system.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const helper = new URL("../../scripts/append-system.mjs", import.meta.url);
+const manifest = { name: "@test/questions", pi: { appendSystem: "instructions.md" } };
+
+describe("append-system lifecycle", () => {
+	test("reports each lifecycle refusal with its key, value and exit status", () => {
+		for (const row of [
+			{ name: "missing action", args: [], key: "action", value: null, status: 1 },
+			{ name: "unknown action", args: ["other"], key: "action", value: "other", status: 1 },
+			{ name: "missing manifest", args: ["install"], key: "package-read", value: "package", status: 0 },
+			{ name: "missing declaration", args: ["install"], manifest: {}, key: "package-fields", value: "package", status: 0 },
+			{ name: "unmanaged scope", args: ["install"], manifest, unmanaged: true, key: "scope", value: "package", status: 0 },
+			{ name: "missing instructions", args: ["install"], manifest, key: "source-missing", value: "source", status: 0 },
+			{ name: "empty instructions", args: ["install"], manifest, content: "  \n", key: "source-empty", value: "source", status: 0 },
+		]) {
+			const root = mkdtempSync(join(tmpdir(), "append-system-"));
+			try {
+				const pkg = row.unmanaged ? join(root, "unmanaged") : join(root, ".pi", "packages", "questions");
+				mkdirSync(join(pkg, "scripts"), { recursive: true });
+				const script = join(pkg, "scripts", "append-system.mjs");
+				copyFileSync(helper, script);
+				if (row.manifest !== undefined) writeFileSync(join(pkg, "package.json"), JSON.stringify(row.manifest));
+				if (row.content !== undefined) writeFileSync(join(pkg, "instructions.md"), row.content);
+				const result = spawnSync("node", [script, ...row.args], {
+					encoding: "utf8",
+					env: { ...process.env, PI_CODING_AGENT_DIR: join(root, "absent-pi") },
+				});
+				const value = row.value === "package" ? pkg : row.value === "source" ? join(pkg, "instructions.md") : row.value;
+				expect({ status: result.status, record: result.stderr.split("\n")[0] }).toEqual({
+					status: row.status,
+					record: `append-system: ${row.key}=${JSON.stringify(value)}`,
+				});
+			} finally {
+				rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+
+	test("installs and removes the complete append-system block", () => {
+		const root = mkdtempSync(join(tmpdir(), "append-system-"));
+		try {
+			const scope = join(root, ".pi");
+			const pkg = join(scope, "packages", "questions");
+			mkdirSync(join(pkg, "scripts"), { recursive: true });
+			const script = join(pkg, "scripts", "append-system.mjs");
+			copyFileSync(helper, script);
+			writeFileSync(join(pkg, "package.json"), JSON.stringify(manifest));
+			writeFileSync(join(pkg, "instructions.md"), "Fixture instructions.\n");
+			const installed = spawnSync("node", [script, "install"], { encoding: "utf8" });
+			expect({ status: installed.status, stderr: installed.stderr, content: readFileSync(join(scope, "APPEND_SYSTEM.md"), "utf8") }).toEqual({
+				status: 0,
+				stderr: "",
+				content: "<!-- kendex:append-system @test/questions begin -->\nFixture instructions.\n<!-- kendex:append-system @test/questions end -->\n",
+			});
+			const removed = spawnSync("node", [script, "remove"], { encoding: "utf8" });
+			expect({ status: removed.status, stderr: removed.stderr, exists: existsSync(join(scope, "APPEND_SYSTEM.md")) }).toEqual({
+				status: 0, stderr: "", exists: false,
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/pi-extensions/pi-questions/extensions/__tests__/append-system.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/append-system.test.ts
@@ -17,7 +17,8 @@ describe("append-system lifecycle", () => {
 			{ name: "unmanaged scope", args: ["install"], manifest, unmanaged: true, key: "scope", value: "package", status: 0 },
 			{ name: "missing instructions", args: ["install"], manifest, key: "source-missing", value: "source", status: 0 },
 			{ name: "empty instructions", args: ["install"], manifest, content: "  \n", key: "source-empty", value: "source", status: 0 },
-			{ name: "unreadable instructions", args: ["install"], manifest, sourceDirectory: true, key: "operation", value: "install:@test/questions:EISDIR", status: 0 },
+			{ name: "unreadable instructions", args: ["install"], manifest, sourceDirectory: true, key: "source-read", value: "source", status: 0 },
+			{ name: "unreadable target", args: ["install"], manifest, content: "Fixture instructions.\n", targetDirectory: true, key: "operation", value: "install:@test/questions:EISDIR", status: 0 },
 		]) {
 			const root = mkdtempSync(join(tmpdir(), "append-system-"));
 			try {
@@ -28,6 +29,7 @@ describe("append-system lifecycle", () => {
 				if (row.manifest !== undefined) writeFileSync(join(pkg, "package.json"), JSON.stringify(row.manifest));
 				if (row.content !== undefined) writeFileSync(join(pkg, "instructions.md"), row.content);
 				if ("sourceDirectory" in row && row.sourceDirectory) mkdirSync(join(pkg, "instructions.md"));
+				if ("targetDirectory" in row && row.targetDirectory) mkdirSync(join(root, ".pi", "APPEND_SYSTEM.md"));
 				const result = spawnSync("node", [script, ...row.args], {
 					encoding: "utf8",
 					env: { ...process.env, PI_CODING_AGENT_DIR: join(root, "absent-pi") },

--- a/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
@@ -185,6 +185,14 @@ describe("rpc questionnaire walker", () => {
 		expect(dialogs.calls[2].title.split("\n").at(-1)).toBe("Path: Which path?");
 	});
 
+	test("blank unlisted select text re-shows the question instead of answering blank", async () => {
+		const dialogs = fakeDialogs(["", "2. B"]);
+		const outcome = await runRpcQuestionnaire(dialogs, singleRequest());
+
+		expect(outcome).toEqual({ answers: [["B"]], kind: "answered" });
+		expect(dialogs.calls[1].title.split("\n")[0]).toBe("answer=empty");
+	});
+
 	test("persistent blank input cancels after bounded re-prompts, never a false answer", async () => {
 		const customRow = "3. Something else (type your own answer)";
 		const dialogs = fakeDialogs([customRow, "", customRow, "", customRow, "", customRow, "", customRow, ""]);
@@ -344,6 +352,7 @@ describe("presentQuestion routing", () => {
 		});
 
 		expect(outcome?.kind).toBe("unavailable");
+		expect((outcome as Extract<PresentOutcome, { kind: "unavailable" }>).error.split("\n")[0]).toBe("question-ui=custom:unavailable");
 	});
 
 	test("custom() completing the request stays on the custom path", async () => {

--- a/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
@@ -65,18 +65,20 @@ function multiTabRequest() {
 
 describe("rpc mode detection", () => {
 	test("isRpcMode detects explicit rpc mode only", () => {
-		expect(isRpcMode({ mode: "rpc" })).toBe(true);
-		expect(isRpcMode({ mode: "interactive" })).toBe(false);
-		expect(isRpcMode({})).toBe(false);
-		expect(isRpcMode(undefined)).toBe(false);
+		for (const [context, expected] of [
+			[{ mode: "rpc" }, true], [{ mode: "interactive" }, false], [{}, false], [undefined, false],
+		] as const) {
+			expect(isRpcMode(context)).toBe(expected);
+		}
 	});
 
 	test("rpcDialogUI requires callable select and input", () => {
-		expect(rpcDialogUI(undefined)).toBeUndefined();
-		expect(rpcDialogUI({ select: () => Promise.resolve(undefined) })).toBeUndefined();
-		expect(rpcDialogUI({ input: () => Promise.resolve(undefined) })).toBeUndefined();
 		const ui = { input: () => Promise.resolve(undefined), select: () => Promise.resolve(undefined) };
-		expect(rpcDialogUI(ui)).toBe(ui as RpcDialogUI);
+		for (const [candidate, expected] of [
+			[undefined, undefined], [{ select: ui.select }, undefined], [{ input: ui.input }, undefined], [ui, ui],
+		] as const) {
+			expect(rpcDialogUI(candidate)).toBe(expected);
+		}
 	});
 });
 
@@ -179,7 +181,8 @@ describe("rpc questionnaire walker", () => {
 		const outcome = await runRpcQuestionnaire(dialogs, request);
 
 		expect(outcome).toEqual({ answers: [["Real answer"]], kind: "answered" });
-		expect(dialogs.calls[2].title).toBe("Custom answer cannot be empty — Path: Which path?");
+		expect(dialogs.calls[2].title.split("\n")[0]).toBe("custom-answer=empty");
+		expect(dialogs.calls[2].title.split("\n").at(-1)).toBe("Path: Which path?");
 	});
 
 	test("persistent blank input cancels after bounded re-prompts, never a false answer", async () => {
@@ -197,7 +200,9 @@ describe("rpc questionnaire walker", () => {
 		const outcome = await runRpcQuestionnaire(dialogs, request);
 
 		expect(outcome).toEqual({ answers: [["A"], ["Docs", "Tests"], ["Slow"]], kind: "answered" });
-		expect(dialogs.calls[2].title.startsWith("Option numbers must be between 1 and 3 — Targets")).toBe(true);
+		expect(dialogs.calls[2].title.split("\n")[0]).toBe("option-range=9:1:3");
+		expect(dialogs.calls[2].title.split("\n")[1]).toBe("Option numbers must be between 1 and 3.");
+		expect(dialogs.calls[2].title.split("\n")[2]).toBe("Targets (2/3): Which targets?");
 	});
 
 	test("multi-select option list is never truncated away, custom row included", async () => {
@@ -268,27 +273,19 @@ describe("rpc questionnaire walker", () => {
 describe("multi-select parsing", () => {
 	const tab = () => multiTabRequest().questions[1];
 
-	test("comma or space separated numbers map to option labels, deduped", () => {
-		expect(parseMultiSelection("1,2,1", tab())).toEqual({ labels: ["Docs", "Tests"], wantsCustom: false });
-		expect(parseMultiSelection(" 2 1 ", tab())).toEqual({ labels: ["Tests", "Docs"], wantsCustom: false });
-	});
-
-	test("custom row number requests the follow-up input", () => {
-		expect(parseMultiSelection("1,3", tab())).toEqual({ labels: ["Docs"], wantsCustom: true });
-	});
-
-	test("out-of-range or ambiguous numbers are an error, never a silent empty answer", () => {
-		expect(parseMultiSelection("9", tab())).toEqual({ error: "Option numbers must be between 1 and 3" });
-		expect(parseMultiSelection("0", tab())).toEqual({ error: "Option numbers must be between 1 and 3" });
-		expect(parseMultiSelection("12", tab())).toEqual({ error: "Option numbers must be between 1 and 3" });
-	});
-
-	test("non-numeric input becomes a whole free-text custom answer", () => {
-		expect(parseMultiSelection("Docs and a migration guide", tab())).toEqual({
-			labels: ["Docs and a migration guide"],
-			wantsCustom: false,
-		});
-		expect(parseMultiSelection("   ", tab())).toEqual({ labels: [], wantsCustom: false });
+	test("maps numeric and free-text selections without silent range failures", () => {
+		for (const [raw, expected] of [
+			["1,2,1", { labels: ["Docs", "Tests"], wantsCustom: false }],
+			[" 2 1 ", { labels: ["Tests", "Docs"], wantsCustom: false }],
+			["1,3", { labels: ["Docs"], wantsCustom: true }],
+			["9", { error: "option-range=9:1:3\nOption numbers must be between 1 and 3." }],
+			["0", { error: "option-range=0:1:3\nOption numbers must be between 1 and 3." }],
+			["12", { error: "option-range=12:1:3\nOption numbers must be between 1 and 3." }],
+			["Docs and a migration guide", { labels: ["Docs and a migration guide"], wantsCustom: false }],
+			["   ", { labels: [], wantsCustom: false }],
+		] as const) {
+			expect(parseMultiSelection(raw, tab())).toEqual(expected);
+		}
 	});
 });
 
@@ -315,7 +312,7 @@ describe("presentQuestion routing", () => {
 		});
 
 		expect(outcome?.kind).toBe("unavailable");
-		expect((outcome as Extract<PresentOutcome, { kind: "unavailable" }>).error).toContain("select/input");
+		expect((outcome as Extract<PresentOutcome, { kind: "unavailable" }>).error.split("\n")[0]).toBe("question-ui=rpc:unavailable");
 	});
 
 	test("custom() resolving undefined falls back to the dialog walker", async () => {

--- a/pi-extensions/pi-questions/extensions/rpc-fallback.ts
+++ b/pi-extensions/pi-questions/extensions/rpc-fallback.ts
@@ -12,6 +12,7 @@ const ROW_MAX_CHARS = 200;
 // Bounds re-prompt loops (blank custom text, out-of-range numbers) so a host
 // that mechanically replays the same bad answer cancels instead of spinning.
 const MAX_PROMPT_ATTEMPTS = 5;
+const EMPTY_CUSTOM_ANSWER = "custom-answer=empty\nCustom answer cannot be empty";
 
 export interface RpcDialogUI {
 	select(title: string, options: string[]): Promise<string | undefined>;
@@ -66,9 +67,10 @@ export function rpcDialogUI(ui: unknown): RpcDialogUI | undefined {
 }
 
 export function noDialogRouteError(rpcMode: boolean): string {
-	return rpcMode
-		? "No question UI available: this RPC host renders neither custom TUI components nor native select/input dialogs"
-		: "No question UI available: custom TUI resolved without a result and the host provides no native select/input dialogs";
+	const explanation = rpcMode
+		? "This RPC host renders neither custom TUI components nor native select/input dialogs."
+		: "Custom TUI resolved without a result and the host provides no native select/input dialogs.";
+	return `question-ui=${rpcMode ? "rpc" : "custom"}:unavailable\n${explanation}`;
 }
 
 /**
@@ -120,7 +122,7 @@ function truncateChars(text: string, max: number): string {
 
 function tabTitle(request: QuestionRequest, tab: QuestionTab, index: number, note = ""): string {
 	const position = request.questions.length > 1 ? ` (${index + 1}/${request.questions.length})` : "";
-	const prefix = note ? `${note} — ` : "";
+	const prefix = note ? `${note}\n` : "";
 	return truncateChars(`${prefix}${tab.header}${position}: ${tab.question}`, TITLE_MAX_CHARS);
 }
 
@@ -179,14 +181,14 @@ async function askSingleSelect(ui: RpcDialogUI, request: QuestionRequest, tab: Q
 			// text as a custom answer, matching the free-text fallback row.
 			const trimmed = choice.trim();
 			if (trimmed) return { kind: "answers", values: [trimmed] };
-			note = "Answer cannot be empty";
+			note = "answer=empty\nAnswer cannot be empty";
 			continue;
 		}
 		if (rowIndex < tab.options.length) return { kind: "answers", values: [tab.options[rowIndex].label] };
 		const custom = await askCustomText(ui, tab, isSettled);
 		if (custom.kind === "abandoned" || custom.kind === "cancelled") return { kind: custom.kind };
 		if (custom.kind === "blank") {
-			note = "Custom answer cannot be empty";
+			note = EMPTY_CUSTOM_ANSWER;
 			continue;
 		}
 		return { kind: "answers", values: [custom.value] };
@@ -207,7 +209,7 @@ export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: st
 	for (const token of tokens) {
 		const row = Number(token);
 		if (row < 1 || row > customRowNumber(tab)) {
-			return { error: `Option numbers must be between 1 and ${customRowNumber(tab)}` };
+			return { error: `option-range=${row}:1:${customRowNumber(tab)}\nOption numbers must be between 1 and ${customRowNumber(tab)}.` };
 		}
 		if (row <= tab.options.length) {
 			const label = tab.options[row - 1].label;
@@ -236,7 +238,7 @@ async function askMultiSelect(ui: RpcDialogUI, request: QuestionRequest, tab: Qu
 		const custom = await askCustomText(ui, tab, isSettled);
 		if (custom.kind === "abandoned" || custom.kind === "cancelled") return { kind: custom.kind };
 		if (custom.kind === "blank") {
-			note = "Custom answer cannot be empty";
+			note = EMPTY_CUSTOM_ANSWER;
 			continue;
 		}
 		return { kind: "answers", values: parsed.labels.includes(custom.value) ? parsed.labels : [...parsed.labels, custom.value] };

--- a/pi-extensions/pi-questions/scripts/append-system.mjs
+++ b/pi-extensions/pi-questions/scripts/append-system.mjs
@@ -27,9 +27,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+// npm invokes this file directly; notices retain their key and value even
+// when their explanation changes. JSON quoting keeps input values on one line.
+function notice(key, value, explanation) {
+	console.error(`append-system: ${key}=${JSON.stringify(value)}`);
+	console.error(explanation);
+}
+
 const action = process.argv[2];
 if (action !== "install" && action !== "remove") {
-	console.error(`append-system.mjs: expected "install" or "remove", got "${action}"`);
+	notice("action", action ?? null, 'Expected "install" or "remove".');
 	process.exit(1);
 }
 
@@ -39,20 +46,20 @@ let pkg;
 try {
 	pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 } catch (err) {
-	console.error(`append-system.mjs: unable to read package.json in ${pkgDir}: ${err?.message ?? err}`);
+	notice("package-read", pkgDir, `Unable to read package.json: ${err?.message ?? err}`);
 	process.exit(0);
 }
 
 const name = typeof pkg?.name === "string" ? pkg.name : undefined;
 const rel = pkg?.pi?.appendSystem;
 if (!name || typeof rel !== "string") {
-	console.error(`append-system.mjs: package ${pkgDir} is missing name or pi.appendSystem`);
+	notice("package-fields", pkgDir, "The package needs name and pi.appendSystem fields.");
 	process.exit(0);
 }
 
 const scopeRoot = findScopeRoot(pkgDir);
 if (!scopeRoot) {
-	console.error(`append-system.mjs: unable to resolve Pi scope for ${name} from ${pkgDir}`);
+	notice("scope", pkgDir, `Unable to resolve the Pi scope for ${name}.`);
 	process.exit(0);
 }
 
@@ -64,12 +71,12 @@ try {
 	if (action === "install") {
 		const sourcePath = resolve(pkgDir, rel);
 		if (!existsSync(sourcePath)) {
-			console.error(`append-system.mjs: appendSystem source missing for ${name}: ${sourcePath}`);
+			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
 		const content = readFileSync(sourcePath, "utf8").trim();
 		if (!content) {
-			console.error(`append-system.mjs: appendSystem source is empty for ${name}: ${sourcePath}`);
+			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);
 		}
 		upsertBlock(target, begin, end, content);
@@ -78,7 +85,7 @@ try {
 	}
 } catch (err) {
 	// Never fail the npm install/uninstall over an APPEND_SYSTEM.md write.
-	console.error(`append-system.mjs (${action}) for ${name}: ${err?.message ?? err}`);
+	notice("operation", `${action}:${name}:${err?.code ?? "unknown"}`, `Unable to update APPEND_SYSTEM.md: ${err?.message ?? err}`);
 	process.exit(0);
 }
 

--- a/pi-extensions/pi-questions/scripts/append-system.mjs
+++ b/pi-extensions/pi-questions/scripts/append-system.mjs
@@ -74,7 +74,13 @@ try {
 			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
-		const content = readFileSync(sourcePath, "utf8").trim();
+		let content;
+		try {
+			content = readFileSync(sourcePath, "utf8").trim();
+		} catch (err) {
+			notice("source-read", sourcePath, `Unable to read the appendSystem source for ${name}: ${err?.message ?? err}`);
+			process.exit(0);
+		}
 		if (!content) {
 			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);

--- a/pi-extensions/pi-session-bridge/scripts/append-system.mjs
+++ b/pi-extensions/pi-session-bridge/scripts/append-system.mjs
@@ -27,9 +27,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+// npm invokes this file directly; notices retain their key and value even
+// when their explanation changes. JSON quoting keeps input values on one line.
+function notice(key, value, explanation) {
+	console.error(`append-system: ${key}=${JSON.stringify(value)}`);
+	console.error(explanation);
+}
+
 const action = process.argv[2];
 if (action !== "install" && action !== "remove") {
-	console.error(`append-system.mjs: expected "install" or "remove", got "${action}"`);
+	notice("action", action ?? null, 'Expected "install" or "remove".');
 	process.exit(1);
 }
 
@@ -39,20 +46,20 @@ let pkg;
 try {
 	pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 } catch (err) {
-	console.error(`append-system.mjs: unable to read package.json in ${pkgDir}: ${err?.message ?? err}`);
+	notice("package-read", pkgDir, `Unable to read package.json: ${err?.message ?? err}`);
 	process.exit(0);
 }
 
 const name = typeof pkg?.name === "string" ? pkg.name : undefined;
 const rel = pkg?.pi?.appendSystem;
 if (!name || typeof rel !== "string") {
-	console.error(`append-system.mjs: package ${pkgDir} is missing name or pi.appendSystem`);
+	notice("package-fields", pkgDir, "The package needs name and pi.appendSystem fields.");
 	process.exit(0);
 }
 
 const scopeRoot = findScopeRoot(pkgDir);
 if (!scopeRoot) {
-	console.error(`append-system.mjs: unable to resolve Pi scope for ${name} from ${pkgDir}`);
+	notice("scope", pkgDir, `Unable to resolve the Pi scope for ${name}.`);
 	process.exit(0);
 }
 
@@ -64,12 +71,12 @@ try {
 	if (action === "install") {
 		const sourcePath = resolve(pkgDir, rel);
 		if (!existsSync(sourcePath)) {
-			console.error(`append-system.mjs: appendSystem source missing for ${name}: ${sourcePath}`);
+			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
 		const content = readFileSync(sourcePath, "utf8").trim();
 		if (!content) {
-			console.error(`append-system.mjs: appendSystem source is empty for ${name}: ${sourcePath}`);
+			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);
 		}
 		upsertBlock(target, begin, end, content);
@@ -78,7 +85,7 @@ try {
 	}
 } catch (err) {
 	// Never fail the npm install/uninstall over an APPEND_SYSTEM.md write.
-	console.error(`append-system.mjs (${action}) for ${name}: ${err?.message ?? err}`);
+	notice("operation", `${action}:${name}:${err?.code ?? "unknown"}`, `Unable to update APPEND_SYSTEM.md: ${err?.message ?? err}`);
 	process.exit(0);
 }
 

--- a/pi-extensions/pi-session-bridge/scripts/append-system.mjs
+++ b/pi-extensions/pi-session-bridge/scripts/append-system.mjs
@@ -74,7 +74,13 @@ try {
 			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
-		const content = readFileSync(sourcePath, "utf8").trim();
+		let content;
+		try {
+			content = readFileSync(sourcePath, "utf8").trim();
+		} catch (err) {
+			notice("source-read", sourcePath, `Unable to read the appendSystem source for ${name}: ${err?.message ?? err}`);
+			process.exit(0);
+		}
 		if (!content) {
 			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);

--- a/pi-extensions/pi-task-panel/scripts/append-system.mjs
+++ b/pi-extensions/pi-task-panel/scripts/append-system.mjs
@@ -27,9 +27,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+// npm invokes this file directly; notices retain their key and value even
+// when their explanation changes. JSON quoting keeps input values on one line.
+function notice(key, value, explanation) {
+	console.error(`append-system: ${key}=${JSON.stringify(value)}`);
+	console.error(explanation);
+}
+
 const action = process.argv[2];
 if (action !== "install" && action !== "remove") {
-	console.error(`append-system.mjs: expected "install" or "remove", got "${action}"`);
+	notice("action", action ?? null, 'Expected "install" or "remove".');
 	process.exit(1);
 }
 
@@ -39,20 +46,20 @@ let pkg;
 try {
 	pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 } catch (err) {
-	console.error(`append-system.mjs: unable to read package.json in ${pkgDir}: ${err?.message ?? err}`);
+	notice("package-read", pkgDir, `Unable to read package.json: ${err?.message ?? err}`);
 	process.exit(0);
 }
 
 const name = typeof pkg?.name === "string" ? pkg.name : undefined;
 const rel = pkg?.pi?.appendSystem;
 if (!name || typeof rel !== "string") {
-	console.error(`append-system.mjs: package ${pkgDir} is missing name or pi.appendSystem`);
+	notice("package-fields", pkgDir, "The package needs name and pi.appendSystem fields.");
 	process.exit(0);
 }
 
 const scopeRoot = findScopeRoot(pkgDir);
 if (!scopeRoot) {
-	console.error(`append-system.mjs: unable to resolve Pi scope for ${name} from ${pkgDir}`);
+	notice("scope", pkgDir, `Unable to resolve the Pi scope for ${name}.`);
 	process.exit(0);
 }
 
@@ -64,12 +71,12 @@ try {
 	if (action === "install") {
 		const sourcePath = resolve(pkgDir, rel);
 		if (!existsSync(sourcePath)) {
-			console.error(`append-system.mjs: appendSystem source missing for ${name}: ${sourcePath}`);
+			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
 		const content = readFileSync(sourcePath, "utf8").trim();
 		if (!content) {
-			console.error(`append-system.mjs: appendSystem source is empty for ${name}: ${sourcePath}`);
+			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);
 		}
 		upsertBlock(target, begin, end, content);
@@ -78,7 +85,7 @@ try {
 	}
 } catch (err) {
 	// Never fail the npm install/uninstall over an APPEND_SYSTEM.md write.
-	console.error(`append-system.mjs (${action}) for ${name}: ${err?.message ?? err}`);
+	notice("operation", `${action}:${name}:${err?.code ?? "unknown"}`, `Unable to update APPEND_SYSTEM.md: ${err?.message ?? err}`);
 	process.exit(0);
 }
 

--- a/pi-extensions/pi-task-panel/scripts/append-system.mjs
+++ b/pi-extensions/pi-task-panel/scripts/append-system.mjs
@@ -74,7 +74,13 @@ try {
 			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
-		const content = readFileSync(sourcePath, "utf8").trim();
+		let content;
+		try {
+			content = readFileSync(sourcePath, "utf8").trim();
+		} catch (err) {
+			notice("source-read", sourcePath, `Unable to read the appendSystem source for ${name}: ${err?.message ?? err}`);
+			process.exit(0);
+		}
 		if (!content) {
 			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);

--- a/pi-extensions/pi-web-tools/scripts/append-system.mjs
+++ b/pi-extensions/pi-web-tools/scripts/append-system.mjs
@@ -27,9 +27,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+// npm invokes this file directly; notices retain their key and value even
+// when their explanation changes. JSON quoting keeps input values on one line.
+function notice(key, value, explanation) {
+	console.error(`append-system: ${key}=${JSON.stringify(value)}`);
+	console.error(explanation);
+}
+
 const action = process.argv[2];
 if (action !== "install" && action !== "remove") {
-	console.error(`append-system.mjs: expected "install" or "remove", got "${action}"`);
+	notice("action", action ?? null, 'Expected "install" or "remove".');
 	process.exit(1);
 }
 
@@ -39,20 +46,20 @@ let pkg;
 try {
 	pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 } catch (err) {
-	console.error(`append-system.mjs: unable to read package.json in ${pkgDir}: ${err?.message ?? err}`);
+	notice("package-read", pkgDir, `Unable to read package.json: ${err?.message ?? err}`);
 	process.exit(0);
 }
 
 const name = typeof pkg?.name === "string" ? pkg.name : undefined;
 const rel = pkg?.pi?.appendSystem;
 if (!name || typeof rel !== "string") {
-	console.error(`append-system.mjs: package ${pkgDir} is missing name or pi.appendSystem`);
+	notice("package-fields", pkgDir, "The package needs name and pi.appendSystem fields.");
 	process.exit(0);
 }
 
 const scopeRoot = findScopeRoot(pkgDir);
 if (!scopeRoot) {
-	console.error(`append-system.mjs: unable to resolve Pi scope for ${name} from ${pkgDir}`);
+	notice("scope", pkgDir, `Unable to resolve the Pi scope for ${name}.`);
 	process.exit(0);
 }
 
@@ -64,12 +71,12 @@ try {
 	if (action === "install") {
 		const sourcePath = resolve(pkgDir, rel);
 		if (!existsSync(sourcePath)) {
-			console.error(`append-system.mjs: appendSystem source missing for ${name}: ${sourcePath}`);
+			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
 		const content = readFileSync(sourcePath, "utf8").trim();
 		if (!content) {
-			console.error(`append-system.mjs: appendSystem source is empty for ${name}: ${sourcePath}`);
+			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);
 		}
 		upsertBlock(target, begin, end, content);
@@ -78,7 +85,7 @@ try {
 	}
 } catch (err) {
 	// Never fail the npm install/uninstall over an APPEND_SYSTEM.md write.
-	console.error(`append-system.mjs (${action}) for ${name}: ${err?.message ?? err}`);
+	notice("operation", `${action}:${name}:${err?.code ?? "unknown"}`, `Unable to update APPEND_SYSTEM.md: ${err?.message ?? err}`);
 	process.exit(0);
 }
 

--- a/pi-extensions/pi-web-tools/scripts/append-system.mjs
+++ b/pi-extensions/pi-web-tools/scripts/append-system.mjs
@@ -74,7 +74,13 @@ try {
 			notice("source-missing", sourcePath, `The appendSystem source for ${name} is missing.`);
 			process.exit(0);
 		}
-		const content = readFileSync(sourcePath, "utf8").trim();
+		let content;
+		try {
+			content = readFileSync(sourcePath, "utf8").trim();
+		} catch (err) {
+			notice("source-read", sourcePath, `Unable to read the appendSystem source for ${name}: ${err?.message ?? err}`);
+			process.exit(0);
+		}
 		if (!content) {
 			notice("source-empty", sourcePath, `The appendSystem source for ${name} is empty.`);
 			process.exit(0);


### PR DESCRIPTION
## Summary

- Replace pi-questions source-text wiring assertions with a real question-service execution test.
- Give RPC and append-system refusals stable first-line records while keeping the English explanation below them.
- Keep the vendored append-system helper identical in pi-agents-tmux, pi-background-tasks, pi-questions, pi-session-bridge, pi-task-panel, and pi-web-tools.

## Completed issue

- Contributes to KEN-1241: existing-tests audit.

## Audit scope

- Changed: `activity.test.ts`, `answer-steer.test.ts`, `rpc-fallback.test.ts`, and their directly required production message surfaces.
- Added: real answer-steer wiring coverage and append-system lifecycle coverage.
- Compliant and left unchanged: `questions.test.ts`.

## Size

- Production and shared helper additions: 136 lines.
- Test additions: 200 lines.

## Test plan

- `bun test ./extensions/__tests__`
- `node --test pi-extensions/package-policy.test.mjs`
- Must-fail controls for answer-steer setting wiring, RPC option-range records, and append-system refusal records.
- `env -u TMPDIR tools/guard --full`: changed suites pass. Concurrent local runs exposed unrelated timing failures in pi-agents-tmux and pi-background-tasks. CI runs the clean checkout.
