### PR TITLE
fix(KEN-1241): stabilize process cleanup refusals

### DIFF
--- a/.agents/skills/second-opinion/scripts/second-opinion-runtime
+++ b/.agents/skills/second-opinion/scripts/second-opinion-runtime
@@ -204,6 +204,7 @@ launch() {
   # but pointless.
   cleanup_launch() {
     if [[ -n "$LAUNCH_WORKER_PID" ]] && ! stop_process_group "$LAUNCH_WORKER_PID" 30; then
+      printf 'launch-cleanup-failed: runtime=%s\n' "$LAUNCH_RUNTIME_DIR" >&2
       echo "second-opinion-runtime: launch cleanup failed; runtime state preserved: $LAUNCH_RUNTIME_DIR" >&2
       return 1
     fi
@@ -327,6 +328,7 @@ wait_for_run() {
     now=$(date +%s)
     if [[ $now -ge $deadline ]]; then
       if ! stop_process_group "$worker_pid" 30; then
+        printf 'deadline-cleanup-failed: runtime=%s\n' "$runtime_dir" >&2
         echo "second-opinion: deadline cleanup failed; runtime state preserved: $runtime_dir" >&2
         exit 75
       fi

--- a/.agents/skills/second-opinion/scripts/second-opinion-runtime
+++ b/.agents/skills/second-opinion/scripts/second-opinion-runtime
@@ -51,6 +51,7 @@ stop_process_group() {
   process_group_alive "$leader" || return 0
   if ! kill -TERM -- "-$leader" 2>/dev/null; then
     process_group_alive "$leader" || return 0
+    printf 'could-not-send-TERM: group=%s\n' "$leader" >&2
     echo "second-opinion-runtime: could not send TERM to process group $leader" >&2
     return 1
   fi
@@ -60,6 +61,7 @@ stop_process_group() {
     if [[ $now -ge $end ]]; then
       if ! kill -KILL -- "-$leader" 2>/dev/null; then
         process_group_alive "$leader" || return 0
+        printf 'could-not-send-KILL: group=%s\n' "$leader" >&2
         echo "second-opinion-runtime: could not send KILL to process group $leader" >&2
         return 1
       fi
@@ -67,6 +69,7 @@ stop_process_group() {
       while process_group_alive "$leader"; do
         now=$(date +%s)
         if [[ $now -ge $end ]]; then
+          printf 'process-group-still-alive: group=%s signal=KILL\n' "$leader" >&2
           echo "second-opinion-runtime: process group $leader is still alive after KILL" >&2
           return 1
         fi

--- a/.agents/skills/second-opinion/tests/process-tree.test.sh
+++ b/.agents/skills/second-opinion/tests/process-tree.test.sh
@@ -406,6 +406,7 @@ rc=0
 RUNTIME_PATH="$RUNTIME" FAIL_ROOT="$TMP_ROOT" bash -c '
   source "$RUNTIME_PATH"
   stop_process_group() {
+    printf "injected-cleanup-refusal: group=%s\n" "$1" >&2
     echo "second-opinion-runtime: injected cleanup refusal" >&2
     return 1
   }
@@ -413,10 +414,11 @@ RUNTIME_PATH="$RUNTIME" FAIL_ROOT="$TMP_ROOT" bash -c '
     "$(($(date +%s) - 1))" 1
 ' > "$TMP_ROOT/cleanup-fail.stdout" 2> "$TMP_ROOT/cleanup-fail.stderr" || rc=$?
 assert_rc "$rc" 75 "deadline cleanup failure remains recoverable"
-assert_contains "$TMP_ROOT/cleanup-fail.stderr" "injected cleanup refusal" \
-  "the cleanup cause reaches the caller"
-assert_contains "$TMP_ROOT/cleanup-fail.stderr" "runtime state preserved" \
-  "the wait names the preserved recovery state"
+assert_contains "$TMP_ROOT/cleanup-fail.stderr" "injected-cleanup-refusal: group=4444" \
+  "the cleanup cause key reaches the caller"
+assert_contains "$TMP_ROOT/cleanup-fail.stderr" \
+  "deadline-cleanup-failed: runtime=$TMP_ROOT/cleanup-fail-runtime" \
+  "the wait refusal key names the preserved recovery state"
 [[ -d "$TMP_ROOT/cleanup-fail-runtime" ]] \
   || fail "cleanup failure deleted the runtime state needed to retry"
 ok "cleanup failure preserves the runtime directory"
@@ -433,6 +435,7 @@ run_launch_cleanup_failure() { # RUNTIME LABEL
       source "$RUNTIME_PATH"
       stop_process_group() {
         printf "%s\n" "$1" > "$STOP_CAPTURE"
+        printf "injected-launch-cleanup-refusal: group=%s\n" "$1" >&2
         echo "second-opinion-runtime: injected launch cleanup refusal" >&2
         return 1
       }
@@ -452,10 +455,12 @@ cleanup_captured_launch() { # LABEL
 
 rc="$(run_launch_cleanup_failure "$RUNTIME" launch-cleanup)"
 assert_rc "$rc" 1 "a publication failure with failed cleanup exits nonzero"
-assert_contains "$TMP_ROOT/launch-cleanup.stderr" "injected launch cleanup refusal" \
-  "launch cleanup reports the stop failure"
-assert_contains "$TMP_ROOT/launch-cleanup.stderr" "runtime state preserved" \
-  "launch cleanup names the preserved state"
+assert_contains "$TMP_ROOT/launch-cleanup.stderr" \
+  "injected-launch-cleanup-refusal: group=$(cat < "$TMP_ROOT/launch-cleanup.stop-pid")" \
+  "launch cleanup reports the stop failure key"
+assert_contains "$TMP_ROOT/launch-cleanup.stderr" \
+  "launch-cleanup-failed: runtime=$TMP_ROOT/launch-cleanup-runtime" \
+  "launch cleanup refusal key names the preserved state"
 [[ -d "$TMP_ROOT/launch-cleanup-runtime" ]] \
   || fail "launch cleanup failure deleted its recovery state"
 ok "launch cleanup failure preserves the runtime directory"
@@ -463,7 +468,9 @@ cleanup_captured_launch launch-cleanup || fail "launch cleanup control left its 
 
 LAUNCH_CLEANUP_MUTANT="$TMP_ROOT/launch-cleanup-mutant-runtime-script"
 awk '
-  /launch cleanup failed; runtime state preserved/ {
+  /launch-cleanup-failed:/ {
+    print
+    if (getline <= 0) exit 8
     print
     if (getline <= 0 || $0 !~ /return 1/) exit 8
     sub(/return 1/, ":")

--- a/.agents/skills/second-opinion/tests/process-tree.test.sh
+++ b/.agents/skills/second-opinion/tests/process-tree.test.sh
@@ -312,8 +312,8 @@ RUNTIME_PATH="$RUNTIME" bash -c '
   stop_process_group 4242 1
 ' > "$TMP_ROOT/term-fail.stdout" 2> "$TMP_ROOT/term-fail.stderr" || rc=$?
 assert_rc "$rc" 1 "a TERM failure is reported"
-assert_contains "$TMP_ROOT/term-fail.stderr" "could not send TERM to process group 4242" \
-  "the TERM failure names the signal and group"
+assert_contains "$TMP_ROOT/term-fail.stderr" "could-not-send-TERM: group=4242" \
+  "the TERM failure key names the signal and group"
 
 printf '100\n' > "$TMP_ROOT/kill-fail.clock"
 rc=0
@@ -332,12 +332,14 @@ RUNTIME_PATH="$RUNTIME" TEST_CLOCK="$TMP_ROOT/kill-fail.clock" bash -c '
   stop_process_group 4292 1
 ' > "$TMP_ROOT/kill-fail.stdout" 2> "$TMP_ROOT/kill-fail.stderr" || rc=$?
 assert_rc "$rc" 1 "a KILL failure after TERM is reported"
-assert_contains "$TMP_ROOT/kill-fail.stderr" "could not send KILL to process group 4292" \
-  "the KILL failure names the signal and group"
+assert_contains "$TMP_ROOT/kill-fail.stderr" "could-not-send-KILL: group=4292" \
+  "the KILL failure key names the signal and group"
 
 KILL_FAILURE_MUTANT="$TMP_ROOT/kill-failure-mutant-runtime"
 awk '
-  /could not send KILL to process group/ {
+  /could-not-send-KILL:/ {
+    print
+    if (getline <= 0) exit 8
     print
     if (getline <= 0 || $0 !~ /return 1/) exit 8
     sub(/return 1/, "return 0")
@@ -389,8 +391,8 @@ RUNTIME_PATH="$RUNTIME" TEST_CLOCK="$TMP_ROOT/final-live.clock" \
   stop_process_group 4343 1
 ' > "$TMP_ROOT/final-live.stdout" 2> "$TMP_ROOT/final-live.stderr" || rc=$?
 assert_rc "$rc" 1 "a process group still alive after KILL is reported"
-assert_contains "$TMP_ROOT/final-live.stderr" "process group 4343 is still alive after KILL" \
-  "the final-liveness failure names the group and signal"
+assert_contains "$TMP_ROOT/final-live.stderr" "process-group-still-alive: group=4343 signal=KILL" \
+  "the final-liveness failure key names the group and signal"
 [[ ! -e "$TMP_ROOT/final-live.wait-called" ]] \
   || fail "post-KILL cleanup entered wait while the group was still alive"
 ok "post-KILL cleanup stays inside its bounded liveness loop"

--- a/skills/second-opinion/scripts/second-opinion-runtime
+++ b/skills/second-opinion/scripts/second-opinion-runtime
@@ -204,6 +204,7 @@ launch() {
   # but pointless.
   cleanup_launch() {
     if [[ -n "$LAUNCH_WORKER_PID" ]] && ! stop_process_group "$LAUNCH_WORKER_PID" 30; then
+      printf 'launch-cleanup-failed: runtime=%s\n' "$LAUNCH_RUNTIME_DIR" >&2
       echo "second-opinion-runtime: launch cleanup failed; runtime state preserved: $LAUNCH_RUNTIME_DIR" >&2
       return 1
     fi
@@ -327,6 +328,7 @@ wait_for_run() {
     now=$(date +%s)
     if [[ $now -ge $deadline ]]; then
       if ! stop_process_group "$worker_pid" 30; then
+        printf 'deadline-cleanup-failed: runtime=%s\n' "$runtime_dir" >&2
         echo "second-opinion: deadline cleanup failed; runtime state preserved: $runtime_dir" >&2
         exit 75
       fi

--- a/skills/second-opinion/scripts/second-opinion-runtime
+++ b/skills/second-opinion/scripts/second-opinion-runtime
@@ -51,6 +51,7 @@ stop_process_group() {
   process_group_alive "$leader" || return 0
   if ! kill -TERM -- "-$leader" 2>/dev/null; then
     process_group_alive "$leader" || return 0
+    printf 'could-not-send-TERM: group=%s\n' "$leader" >&2
     echo "second-opinion-runtime: could not send TERM to process group $leader" >&2
     return 1
   fi
@@ -60,6 +61,7 @@ stop_process_group() {
     if [[ $now -ge $end ]]; then
       if ! kill -KILL -- "-$leader" 2>/dev/null; then
         process_group_alive "$leader" || return 0
+        printf 'could-not-send-KILL: group=%s\n' "$leader" >&2
         echo "second-opinion-runtime: could not send KILL to process group $leader" >&2
         return 1
       fi
@@ -67,6 +69,7 @@ stop_process_group() {
       while process_group_alive "$leader"; do
         now=$(date +%s)
         if [[ $now -ge $end ]]; then
+          printf 'process-group-still-alive: group=%s signal=KILL\n' "$leader" >&2
           echo "second-opinion-runtime: process group $leader is still alive after KILL" >&2
           return 1
         fi

--- a/skills/second-opinion/tests/process-tree.test.sh
+++ b/skills/second-opinion/tests/process-tree.test.sh
@@ -406,6 +406,7 @@ rc=0
 RUNTIME_PATH="$RUNTIME" FAIL_ROOT="$TMP_ROOT" bash -c '
   source "$RUNTIME_PATH"
   stop_process_group() {
+    printf "injected-cleanup-refusal: group=%s\n" "$1" >&2
     echo "second-opinion-runtime: injected cleanup refusal" >&2
     return 1
   }
@@ -413,10 +414,11 @@ RUNTIME_PATH="$RUNTIME" FAIL_ROOT="$TMP_ROOT" bash -c '
     "$(($(date +%s) - 1))" 1
 ' > "$TMP_ROOT/cleanup-fail.stdout" 2> "$TMP_ROOT/cleanup-fail.stderr" || rc=$?
 assert_rc "$rc" 75 "deadline cleanup failure remains recoverable"
-assert_contains "$TMP_ROOT/cleanup-fail.stderr" "injected cleanup refusal" \
-  "the cleanup cause reaches the caller"
-assert_contains "$TMP_ROOT/cleanup-fail.stderr" "runtime state preserved" \
-  "the wait names the preserved recovery state"
+assert_contains "$TMP_ROOT/cleanup-fail.stderr" "injected-cleanup-refusal: group=4444" \
+  "the cleanup cause key reaches the caller"
+assert_contains "$TMP_ROOT/cleanup-fail.stderr" \
+  "deadline-cleanup-failed: runtime=$TMP_ROOT/cleanup-fail-runtime" \
+  "the wait refusal key names the preserved recovery state"
 [[ -d "$TMP_ROOT/cleanup-fail-runtime" ]] \
   || fail "cleanup failure deleted the runtime state needed to retry"
 ok "cleanup failure preserves the runtime directory"
@@ -433,6 +435,7 @@ run_launch_cleanup_failure() { # RUNTIME LABEL
       source "$RUNTIME_PATH"
       stop_process_group() {
         printf "%s\n" "$1" > "$STOP_CAPTURE"
+        printf "injected-launch-cleanup-refusal: group=%s\n" "$1" >&2
         echo "second-opinion-runtime: injected launch cleanup refusal" >&2
         return 1
       }
@@ -452,10 +455,12 @@ cleanup_captured_launch() { # LABEL
 
 rc="$(run_launch_cleanup_failure "$RUNTIME" launch-cleanup)"
 assert_rc "$rc" 1 "a publication failure with failed cleanup exits nonzero"
-assert_contains "$TMP_ROOT/launch-cleanup.stderr" "injected launch cleanup refusal" \
-  "launch cleanup reports the stop failure"
-assert_contains "$TMP_ROOT/launch-cleanup.stderr" "runtime state preserved" \
-  "launch cleanup names the preserved state"
+assert_contains "$TMP_ROOT/launch-cleanup.stderr" \
+  "injected-launch-cleanup-refusal: group=$(cat < "$TMP_ROOT/launch-cleanup.stop-pid")" \
+  "launch cleanup reports the stop failure key"
+assert_contains "$TMP_ROOT/launch-cleanup.stderr" \
+  "launch-cleanup-failed: runtime=$TMP_ROOT/launch-cleanup-runtime" \
+  "launch cleanup refusal key names the preserved state"
 [[ -d "$TMP_ROOT/launch-cleanup-runtime" ]] \
   || fail "launch cleanup failure deleted its recovery state"
 ok "launch cleanup failure preserves the runtime directory"
@@ -463,7 +468,9 @@ cleanup_captured_launch launch-cleanup || fail "launch cleanup control left its 
 
 LAUNCH_CLEANUP_MUTANT="$TMP_ROOT/launch-cleanup-mutant-runtime-script"
 awk '
-  /launch cleanup failed; runtime state preserved/ {
+  /launch-cleanup-failed:/ {
+    print
+    if (getline <= 0) exit 8
     print
     if (getline <= 0 || $0 !~ /return 1/) exit 8
     sub(/return 1/, ":")

--- a/skills/second-opinion/tests/process-tree.test.sh
+++ b/skills/second-opinion/tests/process-tree.test.sh
@@ -312,8 +312,8 @@ RUNTIME_PATH="$RUNTIME" bash -c '
   stop_process_group 4242 1
 ' > "$TMP_ROOT/term-fail.stdout" 2> "$TMP_ROOT/term-fail.stderr" || rc=$?
 assert_rc "$rc" 1 "a TERM failure is reported"
-assert_contains "$TMP_ROOT/term-fail.stderr" "could not send TERM to process group 4242" \
-  "the TERM failure names the signal and group"
+assert_contains "$TMP_ROOT/term-fail.stderr" "could-not-send-TERM: group=4242" \
+  "the TERM failure key names the signal and group"
 
 printf '100\n' > "$TMP_ROOT/kill-fail.clock"
 rc=0
@@ -332,12 +332,14 @@ RUNTIME_PATH="$RUNTIME" TEST_CLOCK="$TMP_ROOT/kill-fail.clock" bash -c '
   stop_process_group 4292 1
 ' > "$TMP_ROOT/kill-fail.stdout" 2> "$TMP_ROOT/kill-fail.stderr" || rc=$?
 assert_rc "$rc" 1 "a KILL failure after TERM is reported"
-assert_contains "$TMP_ROOT/kill-fail.stderr" "could not send KILL to process group 4292" \
-  "the KILL failure names the signal and group"
+assert_contains "$TMP_ROOT/kill-fail.stderr" "could-not-send-KILL: group=4292" \
+  "the KILL failure key names the signal and group"
 
 KILL_FAILURE_MUTANT="$TMP_ROOT/kill-failure-mutant-runtime"
 awk '
-  /could not send KILL to process group/ {
+  /could-not-send-KILL:/ {
+    print
+    if (getline <= 0) exit 8
     print
     if (getline <= 0 || $0 !~ /return 1/) exit 8
     sub(/return 1/, "return 0")
@@ -389,8 +391,8 @@ RUNTIME_PATH="$RUNTIME" TEST_CLOCK="$TMP_ROOT/final-live.clock" \
   stop_process_group 4343 1
 ' > "$TMP_ROOT/final-live.stdout" 2> "$TMP_ROOT/final-live.stderr" || rc=$?
 assert_rc "$rc" 1 "a process group still alive after KILL is reported"
-assert_contains "$TMP_ROOT/final-live.stderr" "process group 4343 is still alive after KILL" \
-  "the final-liveness failure names the group and signal"
+assert_contains "$TMP_ROOT/final-live.stderr" "process-group-still-alive: group=4343 signal=KILL" \
+  "the final-liveness failure key names the group and signal"
 [[ ! -e "$TMP_ROOT/final-live.wait-called" ]] \
   || fail "post-KILL cleanup entered wait while the group was still alive"
 ok "post-KILL cleanup stays inside its bounded liveness loop"


### PR DESCRIPTION
## Summary

- Process-group stop failures now start with stable keys that name the group and signal.
- Launch and deadline cleanup failures now start with stable keys that name the preserved runtime directory.
- The test checks keys, values, and exit status. The source and tracked render change together.

## Test plan

- The TERM key assertion failed against the old mechanism and passed after the mechanism change.
- Existing KILL-send and launch-cleanup mutants still make the suite fail when the refusal behavior is removed.
- `bash skills/second-opinion/tests/process-tree.test.sh` passed.
- `env -u TMPDIR tools/guard --full` passed on `c5b46cd1e3948cb858561c58d997f5fd81515b18`.

## Compliant files left unchanged

- `skills/second-opinion/tests/artifact-home.test.sh`
- `skills/second-opinion/tests/cli-failure-gate.test.sh`
- `skills/second-opinion/tests/detached-run.test.sh`
- `skills/second-opinion/tests/harness-identity.test.sh`
- `skills/second-opinion/tests/lane-scratch-durability.test.sh`
- `skills/second-opinion/tests/option-parsing.test.sh`
- `skills/second-opinion/tests/output-clearing.test.sh`
- `skills/second-opinion/tests/response-gate.test.sh`
- `skills/second-opinion/tests/review-prompt.test.sh`
- `skills/second-opinion/tests/review-union.test.sh`
- `skills/second-opinion/tests/startup.test.sh`
- `skills/second-opinion/tests/target-selection.test.sh`
- `skills/second-opinion/tests/timeout-defaults.test.sh`

The shared `kendex-env.sh` copy remains unchanged. PR #2462 owns that source and its renders.

Refs KEN-1241.
