### PR TITLE
fix(KEN-1241): stabilize Harness-CI stderr notices

### DIFF
--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -41,6 +41,7 @@ base=""
 head="HEAD"
 repo="."
 output="${GITHUB_OUTPUT:-}"
+changed=""
 
 usage() {
   cat <<'USAGE'
@@ -66,6 +67,14 @@ die() { # FIELDS MESSAGE — a wiring error, never a verdict
   printf 'wiring-error: %s\n' "$1" >&2
   echo "harness-only: $2" >&2
   exit 2
+}
+
+report_changed_paths() {
+  local changed_path
+  while IFS= read -r changed_path; do
+    [ -n "$changed_path" ] || continue
+    printf 'changed-path: path=%q\n' "$changed_path" >&2
+  done <<<"${changed:-}"
 }
 
 # `shift 2` past the end of "$@" returns non-zero and shifts nothing. Every
@@ -121,6 +130,7 @@ verdict() { # true|false [FIELDS REASON]
     printf 'fallback: %s\n' "$2" >&2
     echo "harness-only: $3; running every lane" >&2
   fi
+  report_changed_paths
   printf 'harness_only=%s\n' "$1"
   exit 0
 }
@@ -161,12 +171,12 @@ done
 
 if [ "$range_style" = merge_base ]; then
   range="$base...$head"
-  changed="$(git_repo diff --name-only --no-renames "$range")" ||
+  changed="$(git_repo diff --name-only --no-renames "$range" 2>/dev/null)" ||
     verdict false \
       "cause=unreadable-diff range=$(stable_value "$range")" \
       "the diff '$range' is unreadable"
 else
-  changed="$(git_repo diff --name-only --no-renames "$base" "$head")" ||
+  changed="$(git_repo diff --name-only --no-renames "$base" "$head" 2>/dev/null)" ||
     verdict false \
       "cause=unreadable-diff base=$(stable_value "$base") head=$(stable_value "$head")" \
       "the diff '$base' '$head' is unreadable"
@@ -178,8 +188,6 @@ fi
   verdict false \
     "cause=empty-diff base=$(stable_value "$base") head=$(stable_value "$head")" \
     "the diff between '$base' and '$head' is empty"
-
-printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 
 # Read the writer's exact output paths at both selected endpoints. A missing
 # inventory runs product checks, including the commit that first installs it.

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -111,14 +111,15 @@ done
 # it and fail the real write — so a verdict printed first would already be on
 # stdout when the append died, and exit 2 is documented to carry no verdict.
 verdict() { # true|false [FIELDS REASON]
+  if [ -n "$output" ]; then
+    if ! { printf 'harness_only=%s\n' "$1" >>"$output"; } 2>/dev/null; then
+      die "cause=output-write-failed" \
+        "could not append the verdict to '$output'"
+    fi
+  fi
   if [ "$#" -gt 1 ]; then
     printf 'fallback: %s\n' "$2" >&2
     echo "harness-only: $3; running every lane" >&2
-  fi
-  if [ -n "$output" ]; then
-    printf 'harness_only=%s\n' "$1" >>"$output" ||
-      die "cause=output-write-failed" \
-        "could not append the verdict to '$output'"
   fi
   printf 'harness_only=%s\n' "$1"
   exit 0

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -18,8 +18,9 @@
 #   --output  append the verdict line to this file. Default $GITHUB_OUTPUT.
 #
 # stdout carries the verdict line and nothing else: harness_only=true|false.
-# The changed paths and the reason behind a false go to stderr, where the job
-# log shows them.
+# A stderr refusal starts with `wiring-error: cause=...`. A false-verdict
+# notice starts with `fallback: cause=...`. The English explanation follows
+# that stable key/value line in the job log.
 #
 # Exit 0 on any verdict. Exit 2 on a WIRING error — an unknown flag, a missing
 # --event, a flag where a value belongs, an unwritable --output. Those are
@@ -57,8 +58,13 @@ Prints harness_only=true|false on stdout. Exit 2 on a wiring error.
 USAGE
 }
 
-die() { # MESSAGE — a wiring error, never a verdict
-  echo "harness-only: $1" >&2
+stable_value() { # VALUE
+  printf '%q' "$1"
+}
+
+die() { # FIELDS MESSAGE — a wiring error, never a verdict
+  printf 'wiring-error: %s\n' "$1" >&2
+  echo "harness-only: $2" >&2
   exit 2
 }
 
@@ -71,9 +77,13 @@ die() { # MESSAGE — a wiring error, never a verdict
 # a verdict for a call that named no event at all. No option here takes a value
 # that starts with a dash; a path that does is reachable as `./-name`.
 need_value() { # FLAG REMAINING NEXT
-  [ "$2" -ge 2 ] || die "$1 needs a value"
+  [ "$2" -ge 2 ] || die \
+    "cause=missing-value option=$(stable_value "$1")" \
+    "$1 needs a value"
   case "$3" in
-    -?*) die "$1 needs a value, got the flag '$3'" ;;
+    -?*) die \
+      "cause=flag-used-as-value option=$(stable_value "$1") value=$(stable_value "$3")" \
+      "$1 needs a value, got the flag '$3'" ;;
   esac
 }
 
@@ -85,25 +95,30 @@ while [ "$#" -gt 0 ]; do
     --repo) need_value "$1" "$#" "${2:-}"; repo="$2"; shift 2 ;;
     --output) need_value "$1" "$#" "${2:-}"; output="$2"; shift 2 ;;
     -h | --help) usage; exit 0 ;;
-    *) die "unknown argument '$1'" ;;
+    *) die "cause=unknown-argument argument=$(stable_value "$1")" \
+      "unknown argument '$1'" ;;
   esac
 done
 
-[ -n "$event" ] || die "--event is required"
-[ -n "$head" ] || die "--head cannot be empty"
+[ -n "$event" ] || die "cause=missing-event option=--event" \
+  "--event is required"
+[ -n "$head" ] || die "cause=empty-value option=--head" \
+  "--head cannot be empty"
 
 
 # The output FILE is written before stdout, never after. A zero-length probe
 # proves only that the file opens — /dev/full and a full filesystem both accept
 # it and fail the real write — so a verdict printed first would already be on
 # stdout when the append died, and exit 2 is documented to carry no verdict.
-verdict() { # true|false [REASON]
+verdict() { # true|false [FIELDS REASON]
   if [ "$#" -gt 1 ]; then
-    echo "harness-only: $2; running every lane" >&2
+    printf 'fallback: %s\n' "$2" >&2
+    echo "harness-only: $3; running every lane" >&2
   fi
   if [ -n "$output" ]; then
     printf 'harness_only=%s\n' "$1" >>"$output" ||
-      die "could not append the verdict to '$output'"
+      die "cause=output-write-failed" \
+        "could not append the verdict to '$output'"
   fi
   printf 'harness_only=%s\n' "$1"
   exit 0
@@ -127,60 +142,85 @@ git_repo() { git -C "$repo" -c core.quotePath=false "$@"; }
 case "$event" in
   pull_request) range_style=merge_base ;;
   merge_group | push) range_style=endpoints ;;
-  *) verdict false "no diff endpoints are defined for event '$event'" ;;
+  *) verdict false \
+    "cause=unsupported-event event=$(stable_value "$event")" \
+    "no diff endpoints are defined for event '$event'" ;;
 esac
 
-[ -n "$base" ] || verdict false "no base endpoint was given for event '$event'"
+[ -n "$base" ] || verdict false \
+  "cause=missing-base event=$(stable_value "$event")" \
+  "no base endpoint was given for event '$event'"
 
 for endpoint in "$base" "$head"; do
   git_repo cat-file -e "${endpoint}^{commit}" 2>/dev/null ||
-    verdict false "endpoint '$endpoint' does not resolve to a commit"
+    verdict false \
+      "cause=unresolved-endpoint endpoint=$(stable_value "$endpoint")" \
+      "endpoint '$endpoint' does not resolve to a commit"
 done
 
 if [ "$range_style" = merge_base ]; then
   range="$base...$head"
   changed="$(git_repo diff --name-only --no-renames "$range")" ||
-    verdict false "the diff '$range' is unreadable"
+    verdict false \
+      "cause=unreadable-diff range=$(stable_value "$range")" \
+      "the diff '$range' is unreadable"
 else
   changed="$(git_repo diff --name-only --no-renames "$base" "$head")" ||
-    verdict false "the diff '$base' '$head' is unreadable"
+    verdict false \
+      "cause=unreadable-diff base=$(stable_value "$base") head=$(stable_value "$head")" \
+      "the diff '$base' '$head' is unreadable"
 fi
 
 # An empty list is not "nothing to run": it is also what a diff that silently
 # read nothing looks like, and neither answer is worth a waiver.
 [ -n "$changed" ] ||
-  verdict false "the diff between '$base' and '$head' is empty"
+  verdict false \
+    "cause=empty-diff base=$(stable_value "$base") head=$(stable_value "$head")" \
+    "the diff between '$base' and '$head' is empty"
 
 printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 
 # Read the writer's exact output paths at both selected endpoints. A missing
 # inventory runs product checks, including the commit that first installs it.
 if [ "$range_style" = merge_base ]; then
-  base="$(git_repo merge-base "$base" "$head")" || verdict false "merge base is unreadable"
+  base="$(git_repo merge-base "$base" "$head")" || verdict false \
+    "cause=unreadable-merge-base" "merge base is unreadable"
 fi
-base_inventory="$(git_repo show "$base:.kendex-generated.json" 2>/dev/null)" || verdict false "base generated paths are absent or unreadable"
-head_inventory="$(git_repo show "$head:.kendex-generated.json" 2>/dev/null)" || verdict false "head generated paths are absent or unreadable"
+base_inventory="$(git_repo show "$base:.kendex-generated.json" 2>/dev/null)" || verdict false \
+  "cause=unreadable-base-inventory base=$(stable_value "$base")" \
+  "base generated paths are absent or unreadable"
+head_inventory="$(git_repo show "$head:.kendex-generated.json" 2>/dev/null)" || verdict false \
+  "cause=unreadable-head-inventory head=$(stable_value "$head")" \
+  "head generated paths are absent or unreadable"
 # The array contains files, never folder prefixes. A file must be generated
 # at each endpoint where it exists, so adopting a render as source runs checks.
 for inventory in "$base_inventory" "$head_inventory"; do
   jq -e 'type == "array" and all(.[]; type == "string")' <<<"$inventory" >/dev/null 2>&1 \
-    || verdict false "generated paths are invalid"
+    || verdict false "cause=invalid-generated-paths" \
+      "generated paths are invalid"
 done
 printf '%s\n%s\n' "$base_inventory" "$head_inventory" | jq -es '
   .[0] as $base | .[1] | all(.[]; . as $path | ($base | index($path)) != null)
-' >/dev/null 2>&1 || verdict false "generated ownership gains paths and requires product checks"
+' >/dev/null 2>&1 || verdict false "cause=generated-ownership-gain" \
+  "generated ownership gains paths and requires product checks"
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   seen=false
   for endpoint in "$base" "$head"; do
-    entry="$(git_repo ls-tree "$endpoint" -- "$path")" || verdict false "file lookup failed"
+    entry="$(git_repo ls-tree "$endpoint" -- "$path")" || verdict false \
+      "cause=file-lookup-failed path=$(stable_value "$path")" \
+      "file lookup failed"
     [ -n "$entry" ] || continue
     seen=true
     inventory="$base_inventory"
     [ "$endpoint" != "$head" ] || inventory="$head_inventory"
     jq -e --arg path "$path" 'index($path) != null' <<<"$inventory" >/dev/null 2>&1 \
-      || verdict false "a changed file is product source or its ownership is unreadable"
+      || verdict false \
+        "cause=product-source-or-unreadable-ownership path=$(stable_value "$path")" \
+        "a changed file is product source or its ownership is unreadable"
   done
-  [ "$seen" = true ] || verdict false "a changed path could not be read"
+  [ "$seen" = true ] || verdict false \
+    "cause=unreadable-changed-path path=$(stable_value "$path")" \
+    "a changed path could not be read"
 done <<<"$changed"
 verdict true

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -103,10 +103,10 @@ else
   reason_status=$?
 fi
 case "$reason" in
-  *"event 'schedule'"*"running every lane"*) reason_contract=present ;;
-  *) reason_contract="$reason" ;;
+  "fallback: cause=unsupported-event event=schedule"*) reason_contract=present ;;
+  *) reason_contract="$(printf '%s\n' "$reason" | sed -n '1p')" ;;
 esac
-assert_eq unsupported-event-report "present exit 0" \
+assert_eq unsupported-event-stable-report "present exit 0" \
   "$reason_contract exit $reason_status"
 
 git -C "$repo" rm -q .kendex-generated.json

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -14,15 +14,18 @@ head="$(git -C "$repo" rev-parse HEAD)"
 assert_verdict valid-endpoints true \
   --repo "$repo" --event push --base "$base" --head "$head"
 
-closed() { # LABEL ARGS...
-  local label="$1" out status
-  shift
-  if out="$("$HARNESS_ONLY" "$@" 2>/dev/null)"; then
+closed() { # LABEL EXPECTED-FIRST ARGS...
+  local label="$1" expected_first="$2" out status first
+  local stderr_file="$SANDBOX/closed-$1.stderr"
+  shift 2
+  if out="$("$HARNESS_ONLY" "$@" 2>"$stderr_file")"; then
     status=0
   else
     status=$?
   fi
   assert_eq "$label" "harness_only=false exit 0" "$out exit $status"
+  first="$(sed -n '1p' "$stderr_file")"
+  assert_eq "$label first-line" "$expected_first" "$first"
 }
 
 tree_base="$(git -C "$repo" rev-parse "HEAD^{tree}")"
@@ -30,6 +33,7 @@ empty="$(new_repo empty)"
 
 run_rejected_input() { # LABEL REPO EVENT BASE HEAD
   local label="$1" case_repo="$2" event="$3" case_base="$4" case_head="$5"
+  local expected=""
   local args=(--repo "$case_repo" --event "$event")
   case "$case_base" in
     '<omit>') ;;
@@ -41,7 +45,28 @@ run_rejected_input() { # LABEL REPO EVENT BASE HEAD
     '<empty>') args+=(--head "") ;;
     *) args+=(--head "$case_head") ;;
   esac
-  closed "$label" "${args[@]}"
+  case "$label" in
+    schedule | workflow-dispatch)
+      expected="fallback: cause=unsupported-event event=$event"
+      ;;
+    missing-base | empty-base)
+      expected="fallback: cause=missing-base event=push"
+      ;;
+    zero-base | unknown-base | tree-base | non-checkout | absent-checkout)
+      expected="fallback: cause=unresolved-endpoint endpoint=$case_base"
+      ;;
+    zero-head | unknown-head)
+      expected="fallback: cause=unresolved-endpoint endpoint=$case_head"
+      ;;
+    identical-endpoints)
+      expected="fallback: cause=empty-diff base=$case_base head=$case_head"
+      ;;
+    unborn-checkout)
+      expected="fallback: cause=unresolved-endpoint endpoint=HEAD"
+      ;;
+    *) echo "FAIL: unknown rejected input '$label'" >&2; exit 1 ;;
+  esac
+  closed "$label" "$expected" "${args[@]}"
 }
 
 # label | repository | event | base | head
@@ -80,6 +105,7 @@ if git -C "$orphan" merge-base "$root_a" "$root_b" >/dev/null 2>&1; then
   exit 1
 fi
 closed unrelated-histories \
+  "fallback: cause=unreadable-diff range=$root_a...$root_b" \
   --repo "$orphan" --event pull_request --base "$root_a" --head "$root_b"
 
 # Git quotes this product path. The fixture keeps the existing fail-closed
@@ -94,27 +120,49 @@ case "$listed" in
   *'"'*) : ;;
   *) echo "FAIL: git did not quote the fixture path" >&2; exit 1 ;;
 esac
+quoted_changed="$(sed -n '$p' <<<"$listed")"
+printf -v quoted_field '%q' "$quoted_changed"
 closed git-quoted-path \
+  "fallback: cause=unreadable-changed-path path=$quoted_field" \
   --repo "$quoted" --event push --base "$quoted_base"
-
-if reason="$("$HARNESS_ONLY" --repo "$repo" --event schedule --base "$base" 2>&1 >/dev/null)"; then
-  reason_status=0
-else
-  reason_status=$?
-fi
-case "$reason" in
-  "fallback: cause=unsupported-event event=schedule"*) reason_contract=present ;;
-  *) reason_contract="$(printf '%s\n' "$reason" | sed -n '1p')" ;;
-esac
-assert_eq unsupported-event-stable-report "present exit 0" \
-  "$reason_contract exit $reason_status"
 
 git -C "$repo" rm -q .kendex-generated.json
 git -C "$repo" commit -qm "missing inventory"
-closed missing-head-inventory --repo "$repo" --event push --base "$base"
+closed missing-head-inventory \
+  "fallback: cause=unreadable-head-inventory head=HEAD" \
+  --repo "$repo" --event push --base "$base"
 printf '%s\n' invalid >"$repo/.kendex-generated.json"
 git -C "$repo" add -A
 git -C "$repo" commit -qm "invalid inventory"
-closed invalid-head-inventory --repo "$repo" --event push --base "$base"
+closed invalid-head-inventory "fallback: cause=invalid-generated-paths" \
+  --repo "$repo" --event push --base "$base"
+
+product="$(new_repo product-source)"
+commit_paths "$product" baseline README.md
+product_base="$(git -C "$product" rev-parse HEAD)"
+commit_paths "$product" product src/app.rs
+closed product-source \
+  "fallback: cause=product-source-or-unreadable-ownership path=src/app.rs" \
+  --repo "$product" --event push --base "$product_base"
+
+missing_base_inventory="$(new_repo missing-base-inventory)"
+rm -- "$missing_base_inventory/.kendex-generated.json"
+commit_paths "$missing_base_inventory" baseline README.md
+missing_inventory_base="$(git -C "$missing_base_inventory" rev-parse HEAD)"
+write_inventory "$missing_base_inventory"
+commit_paths "$missing_base_inventory" render .agents/skills/orch/SKILL.md
+closed missing-base-inventory \
+  "fallback: cause=unreadable-base-inventory base=$missing_inventory_base" \
+  --repo "$missing_base_inventory" --event push --base "$missing_inventory_base"
+
+ownership="$(new_repo ownership-gain)"
+commit_paths "$ownership" baseline README.md
+ownership_base="$(git -C "$ownership" rev-parse HEAD)"
+jq '. + ["runtime/new.conf"]' "$ownership/.kendex-generated.json" \
+  >"$ownership/.kendex-generated.next.json"
+mv -- "$ownership/.kendex-generated.next.json" "$ownership/.kendex-generated.json"
+commit_paths "$ownership" "ownership gain" runtime/new.conf
+closed ownership-gain "fallback: cause=generated-ownership-gain" \
+  --repo "$ownership" --event push --base "$ownership_base"
 
 report fail-closed

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -90,6 +90,15 @@ unwritable="$SANDBOX/no-such-dir/out.txt"
 wiring output-parent-absent \
   --repo "$repo" --event push --base "$base" --output "$unwritable"
 
+fallback_write_status=0
+fallback_write_stderr="$(bounded "$HARNESS_ONLY" \
+  --repo "$repo" --event schedule --base "$base" --output "$unwritable" \
+  2>&1 >/dev/null)" || fallback_write_status=$?
+fallback_write_first="$(printf '%s\n' "$fallback_write_stderr" | sed -n '1p')"
+assert_eq fallback-output-write-first \
+  "wiring-error: cause=output-write-failed exit 2" \
+  "$fallback_write_first exit $fallback_write_status"
+
 if [ -c /dev/full ]; then
   wiring output-write-fails \
     --repo "$repo" --event push --base "$base" --output /dev/full

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -18,30 +18,52 @@ bounded() { # ARGS...
   fi
 }
 
-wiring() { # LABEL ARGS...
-  local label="$1" out status
-  shift
-  if out="$(bounded "$HARNESS_ONLY" "$@" 2>/dev/null)"; then
+wiring() { # LABEL EXPECTED-FIRST ARGS...
+  local label="$1" expected_first="$2" out status first
+  local stderr_file="$SANDBOX/wiring-$1.stderr"
+  shift 2
+  if out="$(bounded "$HARNESS_ONLY" "$@" 2>"$stderr_file")"; then
     status=0
   else
     status=$?
   fi
-  assert_eq "$label" "exit 2 stdout=''" "exit $status stdout='$out'"
+  first="$(sed -n '1p' "$stderr_file")"
+  assert_eq "$label" "$expected_first exit 2 stdout=''" \
+    "$first exit $status stdout='$out'"
 }
 
 run_argument_case() { # LABEL KIND OPTION VALUE
-  local label="$1" kind="$2" option="$3" value="$4"
+  local label="$1" kind="$2" option="$3" value="$4" expected=""
   local args=(--repo "$repo" --event push --base "$base")
   case "$kind" in
-    unknown) args+=(--nope) ;;
-    positional) args+=("$base") ;;
-    missing-event) args=(--repo "$repo" --base "$base") ;;
-    empty-value) args+=("$option" "") ;;
-    missing-value) args+=("$option") ;;
-    flag-value) args+=("$option" "$value") ;;
+    unknown)
+      args+=(--nope)
+      expected="wiring-error: cause=unknown-argument argument=--nope"
+      ;;
+    positional)
+      args+=("$base")
+      expected="wiring-error: cause=unknown-argument argument=$base"
+      ;;
+    missing-event)
+      args=(--repo "$repo" --base "$base")
+      expected="wiring-error: cause=missing-event option=--event"
+      ;;
+    empty-value)
+      args+=("$option" "")
+      expected="wiring-error: cause=empty-value option=$option"
+      [ "$option" != --event ] || expected="wiring-error: cause=missing-event option=--event"
+      ;;
+    missing-value)
+      args+=("$option")
+      expected="wiring-error: cause=missing-value option=$option"
+      ;;
+    flag-value)
+      args+=("$option" "$value")
+      expected="wiring-error: cause=flag-used-as-value option=$option value=$value"
+      ;;
     *) echo "FAIL: unknown argument case '$kind'" >&2; exit 1 ;;
   esac
-  wiring "$label" "${args[@]}"
+  wiring "$label" "$expected" "${args[@]}"
 }
 
 # label | shape | option under test | value
@@ -68,16 +90,6 @@ flag-value-output|flag-value|--output|--head
 CASES
 require_rows argument "$argument_row_count"
 
-if missing_event_stderr="$(bounded "$HARNESS_ONLY" --repo "$repo" --base "$base" 2>&1 >/dev/null)"; then
-  missing_event_status=0
-else
-  missing_event_status=$?
-fi
-missing_event_first="$(printf '%s\n' "$missing_event_stderr" | sed -n '1p')"
-assert_eq missing-event-stable-report \
-  "wiring-error: cause=missing-event option=--event exit 2" \
-  "$missing_event_first exit $missing_event_status"
-
 if verdict_dash="$(classify --repo "$repo" --event push --base "$base" --head -)"; then
   dash_status=0
 else
@@ -87,7 +99,7 @@ assert_eq lone-dash-value "harness_only=false exit 0" \
   "$verdict_dash exit $dash_status"
 
 unwritable="$SANDBOX/no-such-dir/out.txt"
-wiring output-parent-absent \
+wiring output-parent-absent "wiring-error: cause=output-write-failed" \
   --repo "$repo" --event push --base "$base" --output "$unwritable"
 
 fallback_write_status=0
@@ -100,7 +112,7 @@ assert_eq fallback-output-write-first \
   "$fallback_write_first exit $fallback_write_status"
 
 if [ -c /dev/full ]; then
-  wiring output-write-fails \
+  wiring output-write-fails "wiring-error: cause=output-write-failed" \
     --repo "$repo" --event push --base "$base" --output /dev/full
 else
   echo "  SKIP: no /dev/full, the full-device case did not run"
@@ -173,12 +185,10 @@ if paths="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>&1 >/de
 else
   paths_status=$?
 fi
-case "$paths" in
-  *"changed: .agents/skills/orch/SKILL.md"*) paths_contract=present ;;
-  *) paths_contract="$paths" ;;
-esac
-assert_eq changed-path-stderr "present exit 0" \
-  "$paths_contract exit $paths_status"
+paths_first="$(sed -n '1p' <<<"$paths")"
+assert_eq changed-path-stderr \
+  "changed-path: path=.agents/skills/orch/SKILL.md exit 0" \
+  "$paths_first exit $paths_status"
 
 if help_out="$("$HARNESS_ONLY" --help)"; then
   help_status=0

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -68,6 +68,16 @@ flag-value-output|flag-value|--output|--head
 CASES
 require_rows argument "$argument_row_count"
 
+if missing_event_stderr="$(bounded "$HARNESS_ONLY" --repo "$repo" --base "$base" 2>&1 >/dev/null)"; then
+  missing_event_status=0
+else
+  missing_event_status=$?
+fi
+missing_event_first="$(printf '%s\n' "$missing_event_stderr" | sed -n '1p')"
+assert_eq missing-event-stable-report \
+  "wiring-error: cause=missing-event option=--event exit 2" \
+  "$missing_event_first exit $missing_event_status"
+
 if verdict_dash="$(classify --repo "$repo" --event push --base "$base" --head -)"; then
   dash_status=0
 else


### PR DESCRIPTION
## Summary

- Harness-CI wiring refusals now start with `wiring-error` and stable cause fields.
- False-verdict notices now start with `fallback` and stable cause fields.
- The script header declares both stderr forms. Its parsed stdout protocol remains exactly `harness_only=true|false`.

## Test plan

- The wiring-refusal and fallback key assertions failed against the old mechanism and passed after the mechanism change.
- The output-order finding is fixed in `a7df90261460c705fdb18778f2c7236f3d068b8d`. An unwritable output now emits `wiring-error` before any fallback notice.
- The remaining formal findings are fixed in `8399d09fe73354fe85ce9db90e3484a9600c6db6`. Tests pin the reachable cause and field forms. Fallback records now precede changed-path records.
- All Harness-CI test files pass.
- `env -u TMPDIR tools/guard --full` passed on `8399d09fe73354fe85ce9db90e3484a9600c6db6`.

## Compliant files left unchanged

- `skills/harness-ci/tests/event-ranges.test.sh`
- `skills/harness-ci/tests/in-place.test.sh`
- `skills/harness-ci/tests/path-set.test.sh`
- `skills/harness-ci/tests/rename-into-render.test.sh`
- `skills/harness-ci/tests/wiring-shapes.test.sh`

Refs KEN-1241.
