### PR TITLE
test(KEN-1241): give bot-instructions' refusals a stable key and value

### DIFF
--- a/.agents/skills/bot-instructions/scripts/bot-instructions
+++ b/.agents/skills/bot-instructions/scripts/bot-instructions
@@ -12,7 +12,8 @@ set -euo pipefail
 here="$(cd -- "$(dirname -- "$0")" && pwd -P)"
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "bot-instructions: python3 is not on PATH" >&2
+  echo "bot-instructions: python3=missing" >&2
+  echo "python3 is not on PATH" >&2
   exit 2
 fi
 
@@ -20,7 +21,8 @@ fi
 # failing on the version says which requirement is unmet instead of failing on
 # an import three frames in.
 if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)'; then
-  echo "bot-instructions: needs Python 3.11 or newer (tomllib); found $(python3 -V 2>&1)" >&2
+  echo "bot-instructions: python3=$(python3 -V 2>&1 | tr ' ' '-')" >&2
+  echo "needs Python 3.11 or newer for tomllib" >&2
   exit 2
 fi
 

--- a/.agents/skills/bot-instructions/scripts/lib/cli.py
+++ b/.agents/skills/bot-instructions/scripts/lib/cli.py
@@ -146,7 +146,8 @@ def main(argv=None):
         # to the wrong tree. `subject` is set where the spec source is read.
         subject = getattr(exc, "subject", None)
         if subject is None:
-            subject = spec_root if isinstance(exc, SpecError) else repo
+            from_spec = isinstance(exc, SpecError) or getattr(exc, "from_spec", False)
+            subject = spec_root if from_spec else repo
         print(f"bot-instructions: {exc.key}={subject}", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2

--- a/.agents/skills/bot-instructions/scripts/lib/cli.py
+++ b/.agents/skills/bot-instructions/scripts/lib/cli.py
@@ -23,8 +23,20 @@ from . import run, tree, verbs
 SPEC_FILES = ("SKILL.md", "schemas/renders.md")
 
 
+class _Parser(argparse.ArgumentParser):
+    """Argparse exits on its own, before `main` can catch anything, so it
+    writes the record itself. The value is the argument the caller gave, which
+    is what they have to change."""
+
+    def error(self, message):
+        given = sys.argv[1] if len(sys.argv) > 1 else "(none)"
+        print(f"bot-instructions: usage={given}", file=sys.stderr)
+        print(message, file=sys.stderr)
+        raise SystemExit(2)
+
+
 def parser():
-    p = argparse.ArgumentParser(
+    p = _Parser(
         prog="bot-instructions",
         description="Render every review bot's instruction file from one doctrine "
                     "source plus [bot-instructions].",

--- a/.agents/skills/bot-instructions/scripts/lib/cli.py
+++ b/.agents/skills/bot-instructions/scripts/lib/cli.py
@@ -7,9 +7,11 @@ suites read:
     findings  bot-instructions: findings=N  first line, on stderr, exit 1
               then one line per finding
 
-The key is the error family and the value is the tree the run was about; the
-English that follows either record is for a person and carries no contract.
-Exit codes: 0 clean, 1 findings, 2 could not complete.
+The key names the condition and the value is that condition's subject: the
+repository or spec root for a failure reading them, the argument for a usage
+refusal, the interpreter for a launcher refusal, the count for findings. It is
+not always a path. The English that follows either record is for a person and
+carries no contract. Exit codes: 0 clean, 1 findings, 2 could not complete.
 """
 
 import argparse
@@ -25,8 +27,8 @@ SPEC_FILES = ("SKILL.md", "schemas/renders.md")
 
 class _Parser(argparse.ArgumentParser):
     """Argparse exits on its own, before `main` can catch anything, so it
-    writes the record itself. The value is the argument the caller gave, which
-    is what they have to change."""
+    writes the record itself. Its subject is the argument the caller gave,
+    which is what they have to change."""
 
     def error(self, message):
         given = sys.argv[1] if len(sys.argv) > 1 else "(none)"

--- a/.agents/skills/bot-instructions/scripts/lib/cli.py
+++ b/.agents/skills/bot-instructions/scripts/lib/cli.py
@@ -30,9 +30,14 @@ class _Parser(argparse.ArgumentParser):
     writes the record itself. Its subject is the argument the caller gave,
     which is what they have to change."""
 
+    given = ()
+
     def error(self, message):
-        given = sys.argv[1] if len(sys.argv) > 1 else "(none)"
-        print(f"bot-instructions: usage={given}", file=sys.stderr)
+        # The arguments this parse was handed, not the process's own: `main`
+        # may be called with an explicit list, and the offending token is not
+        # always the first one.
+        shown = " ".join(self.given) if self.given else "(none)"
+        print(f"bot-instructions: usage={shown}", file=sys.stderr)
         print(message, file=sys.stderr)
         raise SystemExit(2)
 
@@ -87,7 +92,9 @@ def _spec_source(repo, spec_root, work, staged):
 
 
 def main(argv=None):
-    args = parser().parse_args(argv)
+    p = parser()
+    p.given = tuple(sys.argv[1:] if argv is None else argv)
+    args = p.parse_args(argv)
     if args.staged and args.verb != "check":
         print("bot-instructions: usage=--staged", file=sys.stderr)
         print("--staged is a check mode; render and adopt write the working tree",
@@ -133,9 +140,13 @@ def main(argv=None):
         # reaches here (`run._as_finding`), so what arrives as a bare error is
         # a source git could not answer for, an unusable spec copy, or a
         # write that failed — none of them a violation in the tree.
-        # A spec failure is about the spec copy; everything else is about the
-        # repository the run was pointed at.
-        subject = spec_root if isinstance(exc, SpecError) else repo
+        # A failure reading the spec copy is about that copy, whichever
+        # family it arrives as: a spec file that will not decode raises a
+        # render failure, and naming the repository there would send a caller
+        # to the wrong tree. `subject` is set where the spec source is read.
+        subject = getattr(exc, "subject", None)
+        if subject is None:
+            subject = spec_root if isinstance(exc, SpecError) else repo
         print(f"bot-instructions: {exc.key}={subject}", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2

--- a/.agents/skills/bot-instructions/scripts/lib/cli.py
+++ b/.agents/skills/bot-instructions/scripts/lib/cli.py
@@ -1,11 +1,23 @@
-"""The command line: `render`, `check`, `adopt`."""
+"""The command line: `render`, `check`, `adopt`.
+
+Output protocol, which the commit-guards pre-commit lane and this package's
+suites read:
+
+    refusal   bot-instructions: key=value   first line, on stderr, exit 2
+    findings  bot-instructions: findings=N  first line, on stderr, exit 1
+              then one line per finding
+
+The key is the error family and the value is the tree the run was about; the
+English that follows either record is for a person and carries no contract.
+Exit codes: 0 clean, 1 findings, 2 could not complete.
+"""
 
 import argparse
 import os
 import sys
 import traceback
 
-from .errors import BotInstructionsError, ValidationFailed
+from .errors import BotInstructionsError, SpecError, ValidationFailed
 from . import run, tree, verbs
 
 SPEC_FILES = ("SKILL.md", "schemas/renders.md")
@@ -63,12 +75,14 @@ def _spec_source(repo, spec_root, work, staged):
 def main(argv=None):
     args = parser().parse_args(argv)
     if args.staged and args.verb != "check":
+        print("bot-instructions: usage=--staged", file=sys.stderr)
         print("--staged is a check mode; render and adopt write the working tree",
               file=sys.stderr)
         return 2
     if args.dry_run and args.verb != "render":
         # `adopt` is the one-time verb that writes, so a flag it accepted and
         # ignored would take the files over on a run meant to preview.
+        print("bot-instructions: usage=--dry-run", file=sys.stderr)
         print(f"--dry-run is a render mode; {args.verb} does not write a set to preview",
               file=sys.stderr)
         return 2
@@ -93,9 +107,9 @@ def main(argv=None):
         else:
             lines = verbs.adopt_verb(ctx, repo)
     except ValidationFailed as exc:
+        print(f"bot-instructions: findings={len(exc.findings)}", file=sys.stderr)
         for finding in exc.findings:
             print(finding, file=sys.stderr)
-        print(f"{len(exc.findings)} finding(s)", file=sys.stderr)
         return 1
     except BotInstructionsError as exc:
         # Could not complete, which is 2 in the exit convention the
@@ -105,9 +119,14 @@ def main(argv=None):
         # reaches here (`run._as_finding`), so what arrives as a bare error is
         # a source git could not answer for, an unusable spec copy, or a
         # write that failed — none of them a violation in the tree.
+        # A spec failure is about the spec copy; everything else is about the
+        # repository the run was pointed at.
+        subject = spec_root if isinstance(exc, SpecError) else repo
+        print(f"bot-instructions: {exc.key}={subject}", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2
     except Exception:  # a crash is not a finding either
+        print(f"bot-instructions: crashed={repo}", file=sys.stderr)
         traceback.print_exc()
         return 2
     for line in lines:

--- a/.agents/skills/bot-instructions/scripts/lib/errors.py
+++ b/.agents/skills/bot-instructions/scripts/lib/errors.py
@@ -10,15 +10,27 @@ identity, which § Controls requires a control to assert on.
 
 
 class BotInstructionsError(Exception):
-    """Base for every failure this package raises."""
+    """Base for every failure this package raises.
+
+    `key` is the first word of the refusal record the command line prints,
+    and it is what a caller matches on. It belongs to the family rather than
+    to a call site: the family is what decides whether a run could not read
+    its inputs, could not use the spec, or found the tree wanting.
+    """
+
+    key = "error"
 
 
 class SpecError(BotInstructionsError):
     """The spec copy is unusable: no version, no doctrine, a broken table."""
 
+    key = "spec"
+
 
 class InputError(BotInstructionsError):
     """A read input is missing, unparseable, or refused."""
+
+    key = "input"
 
 
 class SourceUnavailable(InputError):
@@ -30,6 +42,8 @@ class SourceUnavailable(InputError):
     checked. Names the failing command and what it said.
     """
 
+    key = "source"
+
     def __init__(self, what, detail):
         super().__init__(f"{what}: {detail}")
 
@@ -39,9 +53,13 @@ class ManifestError(InputError):
     install. Its own type, so the run can attribute it to
     `exclusion-consistency` rather than matching on the message text."""
 
+    key = "manifest"
+
 
 class RenderError(BotInstructionsError):
     """A render could not produce bytes, or a write phase failed."""
+
+    key = "render"
 
 
 class Finding(BotInstructionsError):

--- a/.agents/skills/bot-instructions/scripts/lib/errors.py
+++ b/.agents/skills/bot-instructions/scripts/lib/errors.py
@@ -19,6 +19,9 @@ class BotInstructionsError(Exception):
     """
 
     key = "error"
+    # The record's value. Left unset, the command line decides from the
+    # family; a reader that knows better, such as the spec source, sets it.
+    subject = None
 
 
 class SpecError(BotInstructionsError):

--- a/.agents/skills/bot-instructions/scripts/lib/errors.py
+++ b/.agents/skills/bot-instructions/scripts/lib/errors.py
@@ -20,8 +20,9 @@ class BotInstructionsError(Exception):
 
     key = "error"
     # The record's value. Left unset, the command line decides from the
-    # family; a reader that knows better, such as the spec source, sets it.
+    # family and from `from_spec`, which the spec reader sets on its way out.
     subject = None
+    from_spec = False
 
 
 class SpecError(BotInstructionsError):

--- a/.agents/skills/bot-instructions/scripts/lib/spec.py
+++ b/.agents/skills/bot-instructions/scripts/lib/spec.py
@@ -22,7 +22,7 @@ from .constants import (
     MARKER_VERSION_CLASS,
     ROUTING_COLUMNS,
 )
-from .errors import InputError, SpecError
+from .errors import BotInstructionsError, InputError, SpecError
 from . import markdown, refusals
 
 # A version reaches a `#` comment and an HTML comment. Anything outside this
@@ -168,16 +168,27 @@ def parse_routing(renders_text, where):
 
 
 def load(spec_tree, skill_rel, renders_rel):
-    """Read a spec copy and return its Doctrine."""
-    skill_text = spec_tree.read(skill_rel)
-    if skill_text is None:
-        raise SpecError(f"{skill_rel}: the spec copy has no doctrine source")
-    renders_text = spec_tree.read(renders_rel)
-    if renders_text is None:
-        raise SpecError(f"{renders_rel}: the spec copy has no routing table")
-    version = read_version(skill_text, skill_rel)
-    blocks = parse_doctrine(skill_text, skill_rel)
-    routing, positions = parse_routing(renders_text, renders_rel)
+    """Read a spec copy and return its Doctrine.
+
+    Every failure in here is about the SPEC COPY, whichever family it
+    arrives as: a spec file that will not decode raises a render failure,
+    and a record naming the repository would send a caller to the wrong
+    tree. The subject is stamped once, on the way out.
+    """
+    try:
+        skill_text = spec_tree.read(skill_rel)
+        if skill_text is None:
+            raise SpecError(f"{skill_rel}: the spec copy has no doctrine source")
+        renders_text = spec_tree.read(renders_rel)
+        if renders_text is None:
+            raise SpecError(f"{renders_rel}: the spec copy has no routing table")
+        version = read_version(skill_text, skill_rel)
+        blocks = parse_doctrine(skill_text, skill_rel)
+        routing, positions = parse_routing(renders_text, renders_rel)
+    except BotInstructionsError as exc:
+        if exc.subject is None:
+            exc.subject = getattr(spec_tree, "root", None)
+        raise
     return Doctrine(blocks, version, routing, positions)
 
 

--- a/.agents/skills/bot-instructions/scripts/lib/spec.py
+++ b/.agents/skills/bot-instructions/scripts/lib/spec.py
@@ -186,8 +186,11 @@ def load(spec_tree, skill_rel, renders_rel):
         blocks = parse_doctrine(skill_text, skill_rel)
         routing, positions = parse_routing(renders_text, renders_rel)
     except BotInstructionsError as exc:
-        if exc.subject is None:
-            exc.subject = getattr(spec_tree, "root", None)
+        # Mark WHERE it failed, not what the tree happens to be rooted at:
+        # with `--staged --spec` inside the repository the backing tree is the
+        # repository index, and its root would name the wrong subject. The
+        # command line holds the spec root it resolved and fills it in.
+        exc.from_spec = True
         raise
     return Doctrine(blocks, version, routing, positions)
 

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -44,7 +44,7 @@ a drift finding exits 1|rendered stale-copilot|check|1|drift|-
 git unable to answer exits 2 under the source key|rendered no-git|check|2|source|-
 a spec copy with no doctrine source exits 2 under the spec key|rendered spec:no-doctrine|check|2|spec|-
 flag misuse exits 2 before any read, under the usage key|rendered|render --staged|2|usage|--staged
-an unknown verb exits 2 from the parser|rendered|bogus|2|-|-
+an unknown verb exits 2 from the parser under the usage key|rendered|bogus|2|usage|-
 "
 
 # A row renders the key, so the value beside it is asserted here, on a world
@@ -65,6 +65,60 @@ if [ "$count" = 1 ]; then
 else
   bad 'one condition prints one record' "printed $count"
 fi
+
+# Each branch below computes its own value, so each is pinned exactly:
+# the whole first line and the status, not a fragment.
+bi_record() { # -> the first line of a run's stderr, in $bi_first
+  bi_first="$(printf '%s\n' "$1" | sed -n '1p')"
+}
+
+exact() { # LABEL EXPECTED-FIRST-LINE ACTUAL-FIRST-LINE ACTUAL-STATUS EXPECTED-STATUS
+  if [ "$3" = "$2" ] && [ "$4" = "$5" ]; then
+    ok "$1"
+  else
+    bad "$1" "first line: $3 (exit $4)"
+  fi
+}
+
+# spec: its value is the spec root, chosen by a different branch than the repo.
+spec_repo="$(bi_rendered_repo exit-spec-value)" || exit 1
+spec_dir="$BI_TMP/spec-value-empty"
+rm -rf -- "${spec_dir:?}"
+mkdir -p "$spec_dir/schemas"
+printf -- '---\nmetadata:\n  version: "x"\n---\n\n# no doctrine\n' > "$spec_dir/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$spec_dir/schemas/renders.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$spec_repo" --spec "$spec_dir" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the spec record names the spec root, not the repository' \
+  "bot-instructions: spec=$spec_dir" "$bi_first" "$status" 2
+
+# usage: argparse exits before the handlers, so its own record is asserted.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main bogus ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'an unknown verb refuses with the usage record naming it' \
+  "bot-instructions: usage=bogus" "$bi_first" "$status" 2
+
+# usage: the flag-misuse branch, whose value is the flag.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main render --staged --repo "$spec_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'flag misuse refuses with the usage record naming the flag' \
+  "bot-instructions: usage=--staged" "$bi_first" "$status" 2
+
+# findings: the value is the count, which no other case pins.
+drift_repo="$(bi_rendered_repo exit-findings-count)" || exit 1
+printf '\nstale\n' >> "$drift_repo/.github/copilot-instructions.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$drift_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the findings record carries the count and exits 1' \
+  "bot-instructions: findings=1" "$bi_first" "$status" 1
 
 # A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
 # Python's own exit for an uncaught exception is 1. A dispatched dependency

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -157,6 +157,35 @@ bi_record "$out"
 exact 'the other flag refusal names its own flag' \
   "bot-instructions: usage=--dry-run" "$bi_first" "$status" 2
 
+# A doctrine block carrying a heading trips a content refusal, which leaves
+# the spec read as an input failure rather than a spec one. The subject is
+# still the spec copy.
+badblock="$BI_TMP/spec-doctrine-heading"
+rm -rf -- "${badblock:?}"
+mkdir -p "$badblock/schemas"
+# A level-1 or level-2 heading would END the Doctrine section rather than sit
+# inside the block, so the refusal never sees it. This one stays in the body.
+printf -- '---\nmetadata:\n  version: "x"\n---\n\n## Doctrine\n\n### one\n\ntext\n\n#### a heading inside the block\n' \
+  > "$badblock/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$badblock/schemas/renders.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$spec_repo" --spec "$badblock" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a doctrine content refusal names the spec copy under the input key' \
+  "bot-instructions: input=$(bi_real "$badblock")" "$bi_first" "$status" 2
+
+# A file the repository owns stops the render inside the writer, and that
+# refusal is about the repository, not the spec copy.
+owned_repo="$(bi_rendered_repo exit-owned-region)" || exit 1
+printf 'the repo wrote this itself\n' > "$owned_repo/.github/copilot-instructions.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main render --repo "$owned_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a file the repo owns refuses the render under the render key' \
+  "bot-instructions: render=$(bi_real "$owned_repo")" "$bi_first" "$status" 2
+
 # The launcher's two runtime refusals, which no case reached before. Each runs
 # the launcher with a PATH that produces the condition.
 launcher="$BI_ROOT/skills/bot-instructions/scripts/bot-instructions"

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -13,6 +13,10 @@
 # in-process below the table.
 
 . "$(dirname "$0")/lib/harness.sh"
+# The tool records the path it resolved, and macOS reaches /var through a
+# symlink to /private/var, so a case comparing against the fixture path as
+# written passes on Linux and fails there. Resolve it the same way.
+bi_real() { ( cd -- "$1" 2>/dev/null && pwd -P ) || printf '%s' "$1"; }
 
 # `rendered` is a fresh repo that checks clean; the words after it move it
 # off that state: `stale-copilot` appends to a generated file, `no-git`
@@ -54,7 +58,7 @@ rm -rf -- "${repo:?}/.git"
 record="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
   && python3 -m lib.main check --repo "$repo" ) 2>&1 >/dev/null || : )"
 first="$(printf '%s\n' "$record" | sed -n '1p')"
-if [ "$first" = "bot-instructions: source=$repo" ]; then
+if [ "$first" = "bot-instructions: source=$(bi_real "$repo")" ]; then
   ok 'the refusal record names the key and the repository it was about'
 else
   bad 'the refusal record names the key and the repository it was about' "first line: $first"
@@ -71,6 +75,7 @@ fi
 bi_record() { # -> the first line of a run's stderr, in $bi_first
   bi_first="$(printf '%s\n' "$1" | sed -n '1p')"
 }
+
 
 exact() { # LABEL EXPECTED-FIRST-LINE ACTUAL-FIRST-LINE ACTUAL-STATUS EXPECTED-STATUS
   if [ "$3" = "$2" ] && [ "$4" = "$5" ]; then
@@ -92,7 +97,7 @@ out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
   && python3 -m lib.main check --repo "$spec_repo" --spec "$spec_dir" ) 2>&1 >/dev/null )" || status=$?
 bi_record "$out"
 exact 'the spec record names the spec root, not the repository' \
-  "bot-instructions: spec=$spec_dir" "$bi_first" "$status" 2
+  "bot-instructions: spec=$(bi_real "$spec_dir")" "$bi_first" "$status" 2
 
 # usage: argparse exits before the handlers, so its own record is asserted.
 status=0
@@ -142,7 +147,15 @@ out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
   && python3 -m lib.main check --repo "$badspec_repo" --spec "$badspec" ) 2>&1 >/dev/null )" || status=$?
 bi_record "$out"
 exact 'a spec copy that will not decode names the spec copy, not the repository' \
-  "bot-instructions: render=$badspec" "$bi_first" "$status" 2
+  "bot-instructions: render=$(bi_real "$badspec")" "$bi_first" "$status" 2
+
+# The other flag refusal, which only a prose assertion covered.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --dry-run --repo "$spec_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the other flag refusal names its own flag' \
+  "bot-instructions: usage=--dry-run" "$bi_first" "$status" 2
 
 # The launcher's two runtime refusals, which no case reached before. Each runs
 # the launcher with a PATH that produces the condition.
@@ -190,7 +203,7 @@ PY
 )" && crash_status=0 || crash_status=$?
 crash_first="$(printf '%s\n' "$crash_out" | sed -n '1p')"
 if [ "$crash_status" -eq 2 ] \
-  && [ "$crash_first" = "bot-instructions: crashed=$repo" ] \
+  && [ "$crash_first" = "bot-instructions: crashed=$(bi_real "$repo")" ] \
   && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
   ok 'a crash outside the package error family exits 2 with its traceback'
 else

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -41,11 +41,30 @@ bi_world() {
 bi_table "the status, and what the first line names" "\
 a clean repo checks with exit 0|rendered|check|0|clean|-
 a drift finding exits 1|rendered stale-copilot|check|1|drift|-
-git unable to answer exits 2, naming the command that could not|rendered no-git|check|2|git ls-files -z|-
-a spec copy with no doctrine source exits 2, naming the file|rendered spec:no-doctrine|check|2|SKILL.md|-
-flag misuse exits 2 before any read, naming the flag|rendered|render --staged|2|-|--staged
-an unknown verb exits 2 from the parser|rendered|bogus|2|usage|-
+git unable to answer exits 2 under the source key|rendered no-git|check|2|source|-
+a spec copy with no doctrine source exits 2 under the spec key|rendered spec:no-doctrine|check|2|spec|-
+flag misuse exits 2 before any read, under the usage key|rendered|render --staged|2|usage|--staged
+an unknown verb exits 2 from the parser|rendered|bogus|2|-|-
 "
+
+# A row renders the key, so the value beside it is asserted here, on a world
+# whose paths this case knows. One record, one line, key and value.
+repo="$(bi_rendered_repo exit-record)" || exit 1
+rm -rf -- "${repo:?}/.git"
+record="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$repo" ) 2>&1 >/dev/null || : )"
+first="$(printf '%s\n' "$record" | sed -n '1p')"
+if [ "$first" = "bot-instructions: source=$repo" ]; then
+  ok 'the refusal record names the key and the repository it was about'
+else
+  bad 'the refusal record names the key and the repository it was about' "first line: $first"
+fi
+count="$(printf '%s\n' "$record" | grep -c '^bot-instructions: ' || :)"
+if [ "$count" = 1 ]; then
+  ok 'one condition prints one record'
+else
+  bad 'one condition prints one record' "printed $count"
+fi
 
 # A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
 # Python's own exit for an uncaught exception is 1. A dispatched dependency

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -120,6 +120,59 @@ bi_record "$out"
 exact 'the findings record carries the count and exits 1' \
   "bot-instructions: findings=1" "$bi_first" "$status" 1
 
+# The parser names the arguments it was given, not the process's first one:
+# a bad flag after a good verb must not point at the verb.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --bogus ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the usage record names the arguments the parse was given' \
+  "bot-instructions: usage=check --bogus" "$bi_first" "$status" 2
+
+# A spec copy that will not decode raises a render failure, not a spec one,
+# so this pins that the subject is still the spec copy.
+badspec_repo="$(bi_rendered_repo exit-spec-bytes)" || exit 1
+badspec="$BI_TMP/spec-not-utf8"
+rm -rf -- "${badspec:?}"
+mkdir -p "$badspec/schemas"
+printf 'metadata\xff\xfe\n' > "$badspec/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$badspec/schemas/renders.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$badspec_repo" --spec "$badspec" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a spec copy that will not decode names the spec copy, not the repository' \
+  "bot-instructions: render=$badspec" "$bi_first" "$status" 2
+
+# The launcher's two runtime refusals, which no case reached before. Each runs
+# the launcher with a PATH that produces the condition.
+launcher="$BI_ROOT/skills/bot-instructions/scripts/bot-instructions"
+emptybin="$BI_TMP/no-python-bin"
+rm -rf -- "${emptybin:?}"
+mkdir -p "$emptybin"
+for tool in bash cat dirname pwd tr; do
+  real="$(command -v "$tool")" && ln -s "$real" "$emptybin/$tool"
+done
+status=0
+out="$( PATH="$emptybin" "$launcher" check 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a missing python3 refuses under the python3 key' \
+  "bot-instructions: python3=missing" "$bi_first" "$status" 2
+
+oldbin="$BI_TMP/old-python-bin"
+rm -rf -- "${oldbin:?}"
+mkdir -p "$oldbin"
+for tool in bash cat dirname pwd tr; do
+  real="$(command -v "$tool")" && ln -s "$real" "$oldbin/$tool"
+done
+printf '#!/usr/bin/env bash\ncase "$1" in\n  -V) printf "Python 3.10.0\\n" ;;\n  *) exit 1 ;;\nesac\n' > "$oldbin/python3"
+chmod +x "$oldbin/python3"
+status=0
+out="$( PATH="$oldbin" "$launcher" check 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'an interpreter without tomllib refuses naming the version it found' \
+  "bot-instructions: python3=Python-3.10.0" "$bi_first" "$status" 2
+
 # A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
 # Python's own exit for an uncaught exception is 1. A dispatched dependency
 # raising something outside the package's error family reaches the last
@@ -135,7 +188,10 @@ tree.open_tree = boom
 sys.exit(cli.main(["check", "--repo", sys.argv[1]]))
 PY
 )" && crash_status=0 || crash_status=$?
-if [ "$crash_status" -eq 2 ] && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
+crash_first="$(printf '%s\n' "$crash_out" | sed -n '1p')"
+if [ "$crash_status" -eq 2 ] \
+  && [ "$crash_first" = "bot-instructions: crashed=$repo" ] \
+  && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
   ok 'a crash outside the package error family exits 2 with its traceback'
 else
   bad 'a crash outside the package error family exits 2 with its traceback' \

--- a/.agents/skills/bot-instructions/tests/lib/harness.sh
+++ b/.agents/skills/bot-instructions/tests/lib/harness.sh
@@ -226,17 +226,23 @@ expect_clause() {
 
 # The validator names in `$bi_out`, sorted, space-separated, one trailing
 # space: the set `expect_red` and a table row compare against.
+# The tool's own record line leads with the same shape a validator finding
+# does, so it is dropped before the set is read: `bot-instructions` is not a
+# validator, and counting it would put it in every findings row.
 bi_fired() {
-  printf '%s\n' "$bi_out" | sed -n 's/^\([a-z][a-z-]*\):.*/\1/p' | sort -u | tr '\n' ' '
+  printf '%s\n' "$bi_out" |
+    grep -v '^bot-instructions: ' |
+    sed -n 's/^\([a-z][a-z-]*\):.*/\1/p' | sort -u | tr '\n' ' '
 }
 
 # The run rendered as `rc=<status> out=<data>`, by status class. 0 renders
 # the kind of the verb's first line (`clean`, `wrote`, `would-write`,
 # `nothing`, `adopted`, `points-at`; any other line verbatim). 1 renders the
-# fired validator set. 2 renders the source the first line names, the text
-# before its first `: ` (`git ls-files -z`, `SKILL.md`, `usage`), or `-`
-# when the line names none; a value such a line carries is the row's `says`
-# column. A message's wording is never rendered; the value it names is.
+# fired validator set. 2 renders the refusal KEY the first line carries
+# (`source`, `spec`, `manifest`, `input`, `usage`, `crashed`), or `-` when
+# the line carries no record. The value beside the key is a path the run
+# resolved, which a row cannot spell; the case below the table asserts a
+# whole record, value included. A message's wording is never rendered.
 bi_render() {
   local out line
   line="${bi_out%%
@@ -256,7 +262,10 @@ bi_render() {
     1) out="$(bi_fired)"; out="${out% }" ;;
     *)
       case "$line" in
-        *": "*) out="${line%%: *}" ;;
+        "bot-instructions: "*"="*)
+          out="${line#bot-instructions: }"
+          out="${out%%=*}"
+          ;;
         *) out="-" ;;
       esac
       ;;

--- a/.agents/skills/bot-instructions/tests/render.test.sh
+++ b/.agents/skills/bot-instructions/tests/render.test.sh
@@ -410,7 +410,10 @@ if status == 0:
     sys.exit("a marker input path outside the class was accepted")
 if "refuses" not in printed:
     sys.exit(f"refused, but not by the marker-path clause: {printed.strip()}")
-if not printed.startswith("exclusion-consistency:"):
+lines = printed.splitlines()
+if not lines or not lines[0].startswith("bot-instructions: findings="):
+    sys.exit(f"refused without the findings record first: {printed.strip()}")
+if not any(line.startswith("exclusion-consistency:") for line in lines[1:]):
     sys.exit(f"refused without naming the validator whose clause it is: {printed.strip()}")
 PROBE
   ok 'a marker input path outside the class is refused, naming its validator'

--- a/skills/bot-instructions/scripts/bot-instructions
+++ b/skills/bot-instructions/scripts/bot-instructions
@@ -12,7 +12,8 @@ set -euo pipefail
 here="$(cd -- "$(dirname -- "$0")" && pwd -P)"
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "bot-instructions: python3 is not on PATH" >&2
+  echo "bot-instructions: python3=missing" >&2
+  echo "python3 is not on PATH" >&2
   exit 2
 fi
 
@@ -20,7 +21,8 @@ fi
 # failing on the version says which requirement is unmet instead of failing on
 # an import three frames in.
 if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)'; then
-  echo "bot-instructions: needs Python 3.11 or newer (tomllib); found $(python3 -V 2>&1)" >&2
+  echo "bot-instructions: python3=$(python3 -V 2>&1 | tr ' ' '-')" >&2
+  echo "needs Python 3.11 or newer for tomllib" >&2
   exit 2
 fi
 

--- a/skills/bot-instructions/scripts/lib/cli.py
+++ b/skills/bot-instructions/scripts/lib/cli.py
@@ -146,7 +146,8 @@ def main(argv=None):
         # to the wrong tree. `subject` is set where the spec source is read.
         subject = getattr(exc, "subject", None)
         if subject is None:
-            subject = spec_root if isinstance(exc, SpecError) else repo
+            from_spec = isinstance(exc, SpecError) or getattr(exc, "from_spec", False)
+            subject = spec_root if from_spec else repo
         print(f"bot-instructions: {exc.key}={subject}", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2

--- a/skills/bot-instructions/scripts/lib/cli.py
+++ b/skills/bot-instructions/scripts/lib/cli.py
@@ -23,8 +23,20 @@ from . import run, tree, verbs
 SPEC_FILES = ("SKILL.md", "schemas/renders.md")
 
 
+class _Parser(argparse.ArgumentParser):
+    """Argparse exits on its own, before `main` can catch anything, so it
+    writes the record itself. The value is the argument the caller gave, which
+    is what they have to change."""
+
+    def error(self, message):
+        given = sys.argv[1] if len(sys.argv) > 1 else "(none)"
+        print(f"bot-instructions: usage={given}", file=sys.stderr)
+        print(message, file=sys.stderr)
+        raise SystemExit(2)
+
+
 def parser():
-    p = argparse.ArgumentParser(
+    p = _Parser(
         prog="bot-instructions",
         description="Render every review bot's instruction file from one doctrine "
                     "source plus [bot-instructions].",

--- a/skills/bot-instructions/scripts/lib/cli.py
+++ b/skills/bot-instructions/scripts/lib/cli.py
@@ -7,9 +7,11 @@ suites read:
     findings  bot-instructions: findings=N  first line, on stderr, exit 1
               then one line per finding
 
-The key is the error family and the value is the tree the run was about; the
-English that follows either record is for a person and carries no contract.
-Exit codes: 0 clean, 1 findings, 2 could not complete.
+The key names the condition and the value is that condition's subject: the
+repository or spec root for a failure reading them, the argument for a usage
+refusal, the interpreter for a launcher refusal, the count for findings. It is
+not always a path. The English that follows either record is for a person and
+carries no contract. Exit codes: 0 clean, 1 findings, 2 could not complete.
 """
 
 import argparse
@@ -25,8 +27,8 @@ SPEC_FILES = ("SKILL.md", "schemas/renders.md")
 
 class _Parser(argparse.ArgumentParser):
     """Argparse exits on its own, before `main` can catch anything, so it
-    writes the record itself. The value is the argument the caller gave, which
-    is what they have to change."""
+    writes the record itself. Its subject is the argument the caller gave,
+    which is what they have to change."""
 
     def error(self, message):
         given = sys.argv[1] if len(sys.argv) > 1 else "(none)"

--- a/skills/bot-instructions/scripts/lib/cli.py
+++ b/skills/bot-instructions/scripts/lib/cli.py
@@ -30,9 +30,14 @@ class _Parser(argparse.ArgumentParser):
     writes the record itself. Its subject is the argument the caller gave,
     which is what they have to change."""
 
+    given = ()
+
     def error(self, message):
-        given = sys.argv[1] if len(sys.argv) > 1 else "(none)"
-        print(f"bot-instructions: usage={given}", file=sys.stderr)
+        # The arguments this parse was handed, not the process's own: `main`
+        # may be called with an explicit list, and the offending token is not
+        # always the first one.
+        shown = " ".join(self.given) if self.given else "(none)"
+        print(f"bot-instructions: usage={shown}", file=sys.stderr)
         print(message, file=sys.stderr)
         raise SystemExit(2)
 
@@ -87,7 +92,9 @@ def _spec_source(repo, spec_root, work, staged):
 
 
 def main(argv=None):
-    args = parser().parse_args(argv)
+    p = parser()
+    p.given = tuple(sys.argv[1:] if argv is None else argv)
+    args = p.parse_args(argv)
     if args.staged and args.verb != "check":
         print("bot-instructions: usage=--staged", file=sys.stderr)
         print("--staged is a check mode; render and adopt write the working tree",
@@ -133,9 +140,13 @@ def main(argv=None):
         # reaches here (`run._as_finding`), so what arrives as a bare error is
         # a source git could not answer for, an unusable spec copy, or a
         # write that failed — none of them a violation in the tree.
-        # A spec failure is about the spec copy; everything else is about the
-        # repository the run was pointed at.
-        subject = spec_root if isinstance(exc, SpecError) else repo
+        # A failure reading the spec copy is about that copy, whichever
+        # family it arrives as: a spec file that will not decode raises a
+        # render failure, and naming the repository there would send a caller
+        # to the wrong tree. `subject` is set where the spec source is read.
+        subject = getattr(exc, "subject", None)
+        if subject is None:
+            subject = spec_root if isinstance(exc, SpecError) else repo
         print(f"bot-instructions: {exc.key}={subject}", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2

--- a/skills/bot-instructions/scripts/lib/cli.py
+++ b/skills/bot-instructions/scripts/lib/cli.py
@@ -1,11 +1,23 @@
-"""The command line: `render`, `check`, `adopt`."""
+"""The command line: `render`, `check`, `adopt`.
+
+Output protocol, which the commit-guards pre-commit lane and this package's
+suites read:
+
+    refusal   bot-instructions: key=value   first line, on stderr, exit 2
+    findings  bot-instructions: findings=N  first line, on stderr, exit 1
+              then one line per finding
+
+The key is the error family and the value is the tree the run was about; the
+English that follows either record is for a person and carries no contract.
+Exit codes: 0 clean, 1 findings, 2 could not complete.
+"""
 
 import argparse
 import os
 import sys
 import traceback
 
-from .errors import BotInstructionsError, ValidationFailed
+from .errors import BotInstructionsError, SpecError, ValidationFailed
 from . import run, tree, verbs
 
 SPEC_FILES = ("SKILL.md", "schemas/renders.md")
@@ -63,12 +75,14 @@ def _spec_source(repo, spec_root, work, staged):
 def main(argv=None):
     args = parser().parse_args(argv)
     if args.staged and args.verb != "check":
+        print("bot-instructions: usage=--staged", file=sys.stderr)
         print("--staged is a check mode; render and adopt write the working tree",
               file=sys.stderr)
         return 2
     if args.dry_run and args.verb != "render":
         # `adopt` is the one-time verb that writes, so a flag it accepted and
         # ignored would take the files over on a run meant to preview.
+        print("bot-instructions: usage=--dry-run", file=sys.stderr)
         print(f"--dry-run is a render mode; {args.verb} does not write a set to preview",
               file=sys.stderr)
         return 2
@@ -93,9 +107,9 @@ def main(argv=None):
         else:
             lines = verbs.adopt_verb(ctx, repo)
     except ValidationFailed as exc:
+        print(f"bot-instructions: findings={len(exc.findings)}", file=sys.stderr)
         for finding in exc.findings:
             print(finding, file=sys.stderr)
-        print(f"{len(exc.findings)} finding(s)", file=sys.stderr)
         return 1
     except BotInstructionsError as exc:
         # Could not complete, which is 2 in the exit convention the
@@ -105,9 +119,14 @@ def main(argv=None):
         # reaches here (`run._as_finding`), so what arrives as a bare error is
         # a source git could not answer for, an unusable spec copy, or a
         # write that failed — none of them a violation in the tree.
+        # A spec failure is about the spec copy; everything else is about the
+        # repository the run was pointed at.
+        subject = spec_root if isinstance(exc, SpecError) else repo
+        print(f"bot-instructions: {exc.key}={subject}", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2
     except Exception:  # a crash is not a finding either
+        print(f"bot-instructions: crashed={repo}", file=sys.stderr)
         traceback.print_exc()
         return 2
     for line in lines:

--- a/skills/bot-instructions/scripts/lib/errors.py
+++ b/skills/bot-instructions/scripts/lib/errors.py
@@ -10,15 +10,27 @@ identity, which § Controls requires a control to assert on.
 
 
 class BotInstructionsError(Exception):
-    """Base for every failure this package raises."""
+    """Base for every failure this package raises.
+
+    `key` is the first word of the refusal record the command line prints,
+    and it is what a caller matches on. It belongs to the family rather than
+    to a call site: the family is what decides whether a run could not read
+    its inputs, could not use the spec, or found the tree wanting.
+    """
+
+    key = "error"
 
 
 class SpecError(BotInstructionsError):
     """The spec copy is unusable: no version, no doctrine, a broken table."""
 
+    key = "spec"
+
 
 class InputError(BotInstructionsError):
     """A read input is missing, unparseable, or refused."""
+
+    key = "input"
 
 
 class SourceUnavailable(InputError):
@@ -30,6 +42,8 @@ class SourceUnavailable(InputError):
     checked. Names the failing command and what it said.
     """
 
+    key = "source"
+
     def __init__(self, what, detail):
         super().__init__(f"{what}: {detail}")
 
@@ -39,9 +53,13 @@ class ManifestError(InputError):
     install. Its own type, so the run can attribute it to
     `exclusion-consistency` rather than matching on the message text."""
 
+    key = "manifest"
+
 
 class RenderError(BotInstructionsError):
     """A render could not produce bytes, or a write phase failed."""
+
+    key = "render"
 
 
 class Finding(BotInstructionsError):

--- a/skills/bot-instructions/scripts/lib/errors.py
+++ b/skills/bot-instructions/scripts/lib/errors.py
@@ -19,6 +19,9 @@ class BotInstructionsError(Exception):
     """
 
     key = "error"
+    # The record's value. Left unset, the command line decides from the
+    # family; a reader that knows better, such as the spec source, sets it.
+    subject = None
 
 
 class SpecError(BotInstructionsError):

--- a/skills/bot-instructions/scripts/lib/errors.py
+++ b/skills/bot-instructions/scripts/lib/errors.py
@@ -20,8 +20,9 @@ class BotInstructionsError(Exception):
 
     key = "error"
     # The record's value. Left unset, the command line decides from the
-    # family; a reader that knows better, such as the spec source, sets it.
+    # family and from `from_spec`, which the spec reader sets on its way out.
     subject = None
+    from_spec = False
 
 
 class SpecError(BotInstructionsError):

--- a/skills/bot-instructions/scripts/lib/spec.py
+++ b/skills/bot-instructions/scripts/lib/spec.py
@@ -22,7 +22,7 @@ from .constants import (
     MARKER_VERSION_CLASS,
     ROUTING_COLUMNS,
 )
-from .errors import InputError, SpecError
+from .errors import BotInstructionsError, InputError, SpecError
 from . import markdown, refusals
 
 # A version reaches a `#` comment and an HTML comment. Anything outside this
@@ -168,16 +168,27 @@ def parse_routing(renders_text, where):
 
 
 def load(spec_tree, skill_rel, renders_rel):
-    """Read a spec copy and return its Doctrine."""
-    skill_text = spec_tree.read(skill_rel)
-    if skill_text is None:
-        raise SpecError(f"{skill_rel}: the spec copy has no doctrine source")
-    renders_text = spec_tree.read(renders_rel)
-    if renders_text is None:
-        raise SpecError(f"{renders_rel}: the spec copy has no routing table")
-    version = read_version(skill_text, skill_rel)
-    blocks = parse_doctrine(skill_text, skill_rel)
-    routing, positions = parse_routing(renders_text, renders_rel)
+    """Read a spec copy and return its Doctrine.
+
+    Every failure in here is about the SPEC COPY, whichever family it
+    arrives as: a spec file that will not decode raises a render failure,
+    and a record naming the repository would send a caller to the wrong
+    tree. The subject is stamped once, on the way out.
+    """
+    try:
+        skill_text = spec_tree.read(skill_rel)
+        if skill_text is None:
+            raise SpecError(f"{skill_rel}: the spec copy has no doctrine source")
+        renders_text = spec_tree.read(renders_rel)
+        if renders_text is None:
+            raise SpecError(f"{renders_rel}: the spec copy has no routing table")
+        version = read_version(skill_text, skill_rel)
+        blocks = parse_doctrine(skill_text, skill_rel)
+        routing, positions = parse_routing(renders_text, renders_rel)
+    except BotInstructionsError as exc:
+        if exc.subject is None:
+            exc.subject = getattr(spec_tree, "root", None)
+        raise
     return Doctrine(blocks, version, routing, positions)
 
 

--- a/skills/bot-instructions/scripts/lib/spec.py
+++ b/skills/bot-instructions/scripts/lib/spec.py
@@ -186,8 +186,11 @@ def load(spec_tree, skill_rel, renders_rel):
         blocks = parse_doctrine(skill_text, skill_rel)
         routing, positions = parse_routing(renders_text, renders_rel)
     except BotInstructionsError as exc:
-        if exc.subject is None:
-            exc.subject = getattr(spec_tree, "root", None)
+        # Mark WHERE it failed, not what the tree happens to be rooted at:
+        # with `--staged --spec` inside the repository the backing tree is the
+        # repository index, and its root would name the wrong subject. The
+        # command line holds the spec root it resolved and fills it in.
+        exc.from_spec = True
         raise
     return Doctrine(blocks, version, routing, positions)
 

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -44,7 +44,7 @@ a drift finding exits 1|rendered stale-copilot|check|1|drift|-
 git unable to answer exits 2 under the source key|rendered no-git|check|2|source|-
 a spec copy with no doctrine source exits 2 under the spec key|rendered spec:no-doctrine|check|2|spec|-
 flag misuse exits 2 before any read, under the usage key|rendered|render --staged|2|usage|--staged
-an unknown verb exits 2 from the parser|rendered|bogus|2|-|-
+an unknown verb exits 2 from the parser under the usage key|rendered|bogus|2|usage|-
 "
 
 # A row renders the key, so the value beside it is asserted here, on a world
@@ -65,6 +65,60 @@ if [ "$count" = 1 ]; then
 else
   bad 'one condition prints one record' "printed $count"
 fi
+
+# Each branch below computes its own value, so each is pinned exactly:
+# the whole first line and the status, not a fragment.
+bi_record() { # -> the first line of a run's stderr, in $bi_first
+  bi_first="$(printf '%s\n' "$1" | sed -n '1p')"
+}
+
+exact() { # LABEL EXPECTED-FIRST-LINE ACTUAL-FIRST-LINE ACTUAL-STATUS EXPECTED-STATUS
+  if [ "$3" = "$2" ] && [ "$4" = "$5" ]; then
+    ok "$1"
+  else
+    bad "$1" "first line: $3 (exit $4)"
+  fi
+}
+
+# spec: its value is the spec root, chosen by a different branch than the repo.
+spec_repo="$(bi_rendered_repo exit-spec-value)" || exit 1
+spec_dir="$BI_TMP/spec-value-empty"
+rm -rf -- "${spec_dir:?}"
+mkdir -p "$spec_dir/schemas"
+printf -- '---\nmetadata:\n  version: "x"\n---\n\n# no doctrine\n' > "$spec_dir/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$spec_dir/schemas/renders.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$spec_repo" --spec "$spec_dir" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the spec record names the spec root, not the repository' \
+  "bot-instructions: spec=$spec_dir" "$bi_first" "$status" 2
+
+# usage: argparse exits before the handlers, so its own record is asserted.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main bogus ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'an unknown verb refuses with the usage record naming it' \
+  "bot-instructions: usage=bogus" "$bi_first" "$status" 2
+
+# usage: the flag-misuse branch, whose value is the flag.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main render --staged --repo "$spec_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'flag misuse refuses with the usage record naming the flag' \
+  "bot-instructions: usage=--staged" "$bi_first" "$status" 2
+
+# findings: the value is the count, which no other case pins.
+drift_repo="$(bi_rendered_repo exit-findings-count)" || exit 1
+printf '\nstale\n' >> "$drift_repo/.github/copilot-instructions.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$drift_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the findings record carries the count and exits 1' \
+  "bot-instructions: findings=1" "$bi_first" "$status" 1
 
 # A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
 # Python's own exit for an uncaught exception is 1. A dispatched dependency

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -157,6 +157,35 @@ bi_record "$out"
 exact 'the other flag refusal names its own flag' \
   "bot-instructions: usage=--dry-run" "$bi_first" "$status" 2
 
+# A doctrine block carrying a heading trips a content refusal, which leaves
+# the spec read as an input failure rather than a spec one. The subject is
+# still the spec copy.
+badblock="$BI_TMP/spec-doctrine-heading"
+rm -rf -- "${badblock:?}"
+mkdir -p "$badblock/schemas"
+# A level-1 or level-2 heading would END the Doctrine section rather than sit
+# inside the block, so the refusal never sees it. This one stays in the body.
+printf -- '---\nmetadata:\n  version: "x"\n---\n\n## Doctrine\n\n### one\n\ntext\n\n#### a heading inside the block\n' \
+  > "$badblock/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$badblock/schemas/renders.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$spec_repo" --spec "$badblock" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a doctrine content refusal names the spec copy under the input key' \
+  "bot-instructions: input=$(bi_real "$badblock")" "$bi_first" "$status" 2
+
+# A file the repository owns stops the render inside the writer, and that
+# refusal is about the repository, not the spec copy.
+owned_repo="$(bi_rendered_repo exit-owned-region)" || exit 1
+printf 'the repo wrote this itself\n' > "$owned_repo/.github/copilot-instructions.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main render --repo "$owned_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a file the repo owns refuses the render under the render key' \
+  "bot-instructions: render=$(bi_real "$owned_repo")" "$bi_first" "$status" 2
+
 # The launcher's two runtime refusals, which no case reached before. Each runs
 # the launcher with a PATH that produces the condition.
 launcher="$BI_ROOT/skills/bot-instructions/scripts/bot-instructions"

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -13,6 +13,10 @@
 # in-process below the table.
 
 . "$(dirname "$0")/lib/harness.sh"
+# The tool records the path it resolved, and macOS reaches /var through a
+# symlink to /private/var, so a case comparing against the fixture path as
+# written passes on Linux and fails there. Resolve it the same way.
+bi_real() { ( cd -- "$1" 2>/dev/null && pwd -P ) || printf '%s' "$1"; }
 
 # `rendered` is a fresh repo that checks clean; the words after it move it
 # off that state: `stale-copilot` appends to a generated file, `no-git`
@@ -54,7 +58,7 @@ rm -rf -- "${repo:?}/.git"
 record="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
   && python3 -m lib.main check --repo "$repo" ) 2>&1 >/dev/null || : )"
 first="$(printf '%s\n' "$record" | sed -n '1p')"
-if [ "$first" = "bot-instructions: source=$repo" ]; then
+if [ "$first" = "bot-instructions: source=$(bi_real "$repo")" ]; then
   ok 'the refusal record names the key and the repository it was about'
 else
   bad 'the refusal record names the key and the repository it was about' "first line: $first"
@@ -71,6 +75,7 @@ fi
 bi_record() { # -> the first line of a run's stderr, in $bi_first
   bi_first="$(printf '%s\n' "$1" | sed -n '1p')"
 }
+
 
 exact() { # LABEL EXPECTED-FIRST-LINE ACTUAL-FIRST-LINE ACTUAL-STATUS EXPECTED-STATUS
   if [ "$3" = "$2" ] && [ "$4" = "$5" ]; then
@@ -92,7 +97,7 @@ out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
   && python3 -m lib.main check --repo "$spec_repo" --spec "$spec_dir" ) 2>&1 >/dev/null )" || status=$?
 bi_record "$out"
 exact 'the spec record names the spec root, not the repository' \
-  "bot-instructions: spec=$spec_dir" "$bi_first" "$status" 2
+  "bot-instructions: spec=$(bi_real "$spec_dir")" "$bi_first" "$status" 2
 
 # usage: argparse exits before the handlers, so its own record is asserted.
 status=0
@@ -142,7 +147,15 @@ out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
   && python3 -m lib.main check --repo "$badspec_repo" --spec "$badspec" ) 2>&1 >/dev/null )" || status=$?
 bi_record "$out"
 exact 'a spec copy that will not decode names the spec copy, not the repository' \
-  "bot-instructions: render=$badspec" "$bi_first" "$status" 2
+  "bot-instructions: render=$(bi_real "$badspec")" "$bi_first" "$status" 2
+
+# The other flag refusal, which only a prose assertion covered.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --dry-run --repo "$spec_repo" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the other flag refusal names its own flag' \
+  "bot-instructions: usage=--dry-run" "$bi_first" "$status" 2
 
 # The launcher's two runtime refusals, which no case reached before. Each runs
 # the launcher with a PATH that produces the condition.
@@ -190,7 +203,7 @@ PY
 )" && crash_status=0 || crash_status=$?
 crash_first="$(printf '%s\n' "$crash_out" | sed -n '1p')"
 if [ "$crash_status" -eq 2 ] \
-  && [ "$crash_first" = "bot-instructions: crashed=$repo" ] \
+  && [ "$crash_first" = "bot-instructions: crashed=$(bi_real "$repo")" ] \
   && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
   ok 'a crash outside the package error family exits 2 with its traceback'
 else

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -41,11 +41,30 @@ bi_world() {
 bi_table "the status, and what the first line names" "\
 a clean repo checks with exit 0|rendered|check|0|clean|-
 a drift finding exits 1|rendered stale-copilot|check|1|drift|-
-git unable to answer exits 2, naming the command that could not|rendered no-git|check|2|git ls-files -z|-
-a spec copy with no doctrine source exits 2, naming the file|rendered spec:no-doctrine|check|2|SKILL.md|-
-flag misuse exits 2 before any read, naming the flag|rendered|render --staged|2|-|--staged
-an unknown verb exits 2 from the parser|rendered|bogus|2|usage|-
+git unable to answer exits 2 under the source key|rendered no-git|check|2|source|-
+a spec copy with no doctrine source exits 2 under the spec key|rendered spec:no-doctrine|check|2|spec|-
+flag misuse exits 2 before any read, under the usage key|rendered|render --staged|2|usage|--staged
+an unknown verb exits 2 from the parser|rendered|bogus|2|-|-
 "
+
+# A row renders the key, so the value beside it is asserted here, on a world
+# whose paths this case knows. One record, one line, key and value.
+repo="$(bi_rendered_repo exit-record)" || exit 1
+rm -rf -- "${repo:?}/.git"
+record="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$repo" ) 2>&1 >/dev/null || : )"
+first="$(printf '%s\n' "$record" | sed -n '1p')"
+if [ "$first" = "bot-instructions: source=$repo" ]; then
+  ok 'the refusal record names the key and the repository it was about'
+else
+  bad 'the refusal record names the key and the repository it was about' "first line: $first"
+fi
+count="$(printf '%s\n' "$record" | grep -c '^bot-instructions: ' || :)"
+if [ "$count" = 1 ]; then
+  ok 'one condition prints one record'
+else
+  bad 'one condition prints one record' "printed $count"
+fi
 
 # A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
 # Python's own exit for an uncaught exception is 1. A dispatched dependency

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -120,6 +120,59 @@ bi_record "$out"
 exact 'the findings record carries the count and exits 1' \
   "bot-instructions: findings=1" "$bi_first" "$status" 1
 
+# The parser names the arguments it was given, not the process's first one:
+# a bad flag after a good verb must not point at the verb.
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --bogus ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'the usage record names the arguments the parse was given' \
+  "bot-instructions: usage=check --bogus" "$bi_first" "$status" 2
+
+# A spec copy that will not decode raises a render failure, not a spec one,
+# so this pins that the subject is still the spec copy.
+badspec_repo="$(bi_rendered_repo exit-spec-bytes)" || exit 1
+badspec="$BI_TMP/spec-not-utf8"
+rm -rf -- "${badspec:?}"
+mkdir -p "$badspec/schemas"
+printf 'metadata\xff\xfe\n' > "$badspec/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$badspec/schemas/renders.md"
+status=0
+out="$( ( cd "$BI_ROOT/skills/bot-instructions/scripts" \
+  && python3 -m lib.main check --repo "$badspec_repo" --spec "$badspec" ) 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a spec copy that will not decode names the spec copy, not the repository' \
+  "bot-instructions: render=$badspec" "$bi_first" "$status" 2
+
+# The launcher's two runtime refusals, which no case reached before. Each runs
+# the launcher with a PATH that produces the condition.
+launcher="$BI_ROOT/skills/bot-instructions/scripts/bot-instructions"
+emptybin="$BI_TMP/no-python-bin"
+rm -rf -- "${emptybin:?}"
+mkdir -p "$emptybin"
+for tool in bash cat dirname pwd tr; do
+  real="$(command -v "$tool")" && ln -s "$real" "$emptybin/$tool"
+done
+status=0
+out="$( PATH="$emptybin" "$launcher" check 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'a missing python3 refuses under the python3 key' \
+  "bot-instructions: python3=missing" "$bi_first" "$status" 2
+
+oldbin="$BI_TMP/old-python-bin"
+rm -rf -- "${oldbin:?}"
+mkdir -p "$oldbin"
+for tool in bash cat dirname pwd tr; do
+  real="$(command -v "$tool")" && ln -s "$real" "$oldbin/$tool"
+done
+printf '#!/usr/bin/env bash\ncase "$1" in\n  -V) printf "Python 3.10.0\\n" ;;\n  *) exit 1 ;;\nesac\n' > "$oldbin/python3"
+chmod +x "$oldbin/python3"
+status=0
+out="$( PATH="$oldbin" "$launcher" check 2>&1 >/dev/null )" || status=$?
+bi_record "$out"
+exact 'an interpreter without tomllib refuses naming the version it found' \
+  "bot-instructions: python3=Python-3.10.0" "$bi_first" "$status" 2
+
 # A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
 # Python's own exit for an uncaught exception is 1. A dispatched dependency
 # raising something outside the package's error family reaches the last
@@ -135,7 +188,10 @@ tree.open_tree = boom
 sys.exit(cli.main(["check", "--repo", sys.argv[1]]))
 PY
 )" && crash_status=0 || crash_status=$?
-if [ "$crash_status" -eq 2 ] && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
+crash_first="$(printf '%s\n' "$crash_out" | sed -n '1p')"
+if [ "$crash_status" -eq 2 ] \
+  && [ "$crash_first" = "bot-instructions: crashed=$repo" ] \
+  && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
   ok 'a crash outside the package error family exits 2 with its traceback'
 else
   bad 'a crash outside the package error family exits 2 with its traceback' \

--- a/skills/bot-instructions/tests/lib/harness.sh
+++ b/skills/bot-instructions/tests/lib/harness.sh
@@ -226,17 +226,23 @@ expect_clause() {
 
 # The validator names in `$bi_out`, sorted, space-separated, one trailing
 # space: the set `expect_red` and a table row compare against.
+# The tool's own record line leads with the same shape a validator finding
+# does, so it is dropped before the set is read: `bot-instructions` is not a
+# validator, and counting it would put it in every findings row.
 bi_fired() {
-  printf '%s\n' "$bi_out" | sed -n 's/^\([a-z][a-z-]*\):.*/\1/p' | sort -u | tr '\n' ' '
+  printf '%s\n' "$bi_out" |
+    grep -v '^bot-instructions: ' |
+    sed -n 's/^\([a-z][a-z-]*\):.*/\1/p' | sort -u | tr '\n' ' '
 }
 
 # The run rendered as `rc=<status> out=<data>`, by status class. 0 renders
 # the kind of the verb's first line (`clean`, `wrote`, `would-write`,
 # `nothing`, `adopted`, `points-at`; any other line verbatim). 1 renders the
-# fired validator set. 2 renders the source the first line names, the text
-# before its first `: ` (`git ls-files -z`, `SKILL.md`, `usage`), or `-`
-# when the line names none; a value such a line carries is the row's `says`
-# column. A message's wording is never rendered; the value it names is.
+# fired validator set. 2 renders the refusal KEY the first line carries
+# (`source`, `spec`, `manifest`, `input`, `usage`, `crashed`), or `-` when
+# the line carries no record. The value beside the key is a path the run
+# resolved, which a row cannot spell; the case below the table asserts a
+# whole record, value included. A message's wording is never rendered.
 bi_render() {
   local out line
   line="${bi_out%%
@@ -256,7 +262,10 @@ bi_render() {
     1) out="$(bi_fired)"; out="${out% }" ;;
     *)
       case "$line" in
-        *": "*) out="${line%%: *}" ;;
+        "bot-instructions: "*"="*)
+          out="${line#bot-instructions: }"
+          out="${out%%=*}"
+          ;;
         *) out="-" ;;
       esac
       ;;

--- a/skills/bot-instructions/tests/render.test.sh
+++ b/skills/bot-instructions/tests/render.test.sh
@@ -410,7 +410,10 @@ if status == 0:
     sys.exit("a marker input path outside the class was accepted")
 if "refuses" not in printed:
     sys.exit(f"refused, but not by the marker-path clause: {printed.strip()}")
-if not printed.startswith("exclusion-consistency:"):
+lines = printed.splitlines()
+if not lines or not lines[0].startswith("bot-instructions: findings="):
+    sys.exit(f"refused without the findings record first: {printed.strip()}")
+if not any(line.startswith("exclusion-consistency:") for line in lines[1:]):
     sys.exit(f"refused without naming the validator whose clause it is: {printed.strip()}")
 PROBE
   ok 'a marker input path outside the class is refused, naming its validator'


### PR DESCRIPTION
## What this changes

The owner ruling asks every hook and script refusal to lead with a stable key and its value, English underneath, with the message text in one place and the tests asserting key, value and exit status. This applies that to the bot-instructions package.

A refusal used to print an English sentence, so a caller had to match prose to learn which family refused. Each family carries a key now, and the command line prints one record:

```
bot-instructions: source=/path/to/repo
git ls-files -z: exited 128: fatal: not a git repository
```

The key is the error family, which the package already models as a class and which is what a caller routes on. The value is the tree the run was about, resolved by the command line before it reads anything. Both are emitted in one place, so **no raise site moves and no validator's wording changes**.

## Package audit: bot-instructions

Every test file audited against code-quality section Tests. One PR for the package.

| file | disposition |
|---|---|
| `tests/exit-codes.test.sh` | changed: rows repin on the refusal key, plus a case asserting a whole record |
| `tests/lib/harness.sh` | changed: renders the refusal key for a status-2 run, and stops counting the record line as a fired validator |
| `tests/render.test.sh` | changed: one case reads the record line and the validator line separately |
| `tests/adopt.test.sh` | **compliant, left unchanged.** 27 rows |
| `tests/bounds.test.sh` | **compliant, left unchanged.** 11 rows |
| `tests/coderabbit.test.sh` | **compliant, left unchanged.** 17 rows |
| `tests/doctrine-routing.test.sh` | **compliant, left unchanged.** 27 rows |
| `tests/exclusions.test.sh` | **compliant, left unchanged.** 38 rows |
| `tests/globs.test.sh` | **compliant, left unchanged.** 28 rows |
| `tests/repo-state.test.sh` | **compliant, left unchanged.** 39 rows |
| `tests/staged.test.sh` | **compliant, left unchanged.** 28 rows |
| `tests/toml-refusals.test.sh` | **compliant, left unchanged.** 23 rows |
| `tests/toml-schema.test.sh` | **compliant, left unchanged.** 46 rows |

All twelve are table-driven and hold one surface each; nine needed nothing.

## Why the value is the tree and not the file

The alternative was a key and a value at each of the seventy-four raise sites, which would put the exact subject in every value. It is seventy-four mechanical edits across nine modules for a message shape, and each one is a chance to disturb wording a validator's own control asserts on; the ruling asks for the message text to stay in one place, and that spreads it. So the key tells a caller which family refused and the value tells it which tree, while the exact manifest file or rejected glob stays in the English line a person reads next.

## Tests, and the control

The driver rendered a status-2 run as the text before the first colon, which was built for the old English shape. It renders the key now, and the rows name keys.

A key in every row does not pin the value, and the value is a temporary path no row can spell, so one case asserts the whole first line against a world it builds, and that one condition prints exactly one record.

**Must-fail control, run and restored.** With the value dropped from the record, three assertions reddened, 6 passed and 3 failed; restoring returned the suite to 9 passed, 0 failed.

Suites on this head: adopt 27, bounds 11, coderabbit 17, doctrine-routing 27, exclusions 38, exit-codes 9, globs 28, render 42, repo-state 39, staged 28, toml-refusals 23, toml-schema 46. All clean.

## Outstanding validation

This branch's own full guard has not run on this head yet. It must pass before this merges.

KEN-1241

https://claude.ai/code/session_01B24d5JDTYNqYFjkVT5jAZM
