### PR TITLE
fix(KEN-1241): add stable pi agent message records

### DIFF
--- a/pi-extensions/pi-agents-tmux/extensions/subagent/__tests__/pane-cwd-stale.test.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/__tests__/pane-cwd-stale.test.ts
@@ -64,7 +64,8 @@ function renderSingle(result: SingleResult, expanded = false): string {
 // paneId but deliberately no taskId, because nothing was queued.
 function refusedPaneResult(patch: Partial<SingleResult> = {}): SingleResult {
 	const stderr = [
-		"pane-cwd-stale: refusing to queue task for generalist; pane process cwd was deleted.",
+		"pane_cwd_stale=/workspace",
+		"Cannot queue a task for generalist because the pane process cwd was deleted.",
 		"Stop the pane with stop_subagent agent=generalist and retry with forceSpawn for a fresh process.",
 	].join("\n");
 	return {
@@ -173,8 +174,7 @@ describe("persistent pane cwd preflight", () => {
 
 			expect(result.exitCode).toBe(1);
 			expect(result.stopReason).toBe("pane-cwd-stale");
-			expect(result.stderr).toContain("pane-cwd-stale");
-			expect(result.stderr).toContain(requestedCwd);
+			expect(result.stderr.split("\n", 1)[0]).toBe(`pane_cwd_stale=${requestedCwd}`);
 			expect(JSON.parse(result.errorEnvelope ?? "{}").error.code).toBe("pane-cwd-stale");
 			expect(existsSync(join(runtimeRoot, "inbox", "rust"))).toBe(false);
 
@@ -253,6 +253,7 @@ describe("persistent pane cwd preflight", () => {
 
 			expect(result.exitCode).toBe(1);
 			expect(result.stopReason).toBe("pane-cwd-stale");
+			expect(result.stderr.split("\n", 1)[0]).toBe(`pane_cwd_stale=${requestedCwd}`);
 			const envelope = JSON.parse(result.errorEnvelope ?? "{}");
 			expect(envelope.error.code).toBe("pane-cwd-stale");
 			expect(envelope.error.details.reason).toBe("mismatch");
@@ -310,13 +311,6 @@ describe("refused pane dispatch rendering", () => {
 		// Warning, not error: the guard declined a dispatch, nothing crashed.
 		expect(collapsed).toContain("<warning>refused</warning>");
 		expect(collapsed).toContain("<warning>[pane-cwd-stale]</warning>");
-	});
-
-	test("the refusal message and its recovery hint are preserved verbatim", () => {
-		for (const text of [renderSingle(refusedPaneResult()), renderSingle(refusedPaneResult(), true)]) {
-			expect(text).toContain("pane-cwd-stale: refusing to queue task for generalist");
-			expect(text).toContain("retry with forceSpawn for a fresh process");
-		}
 	});
 
 	test("expanded refusal omits the ran-a-task sections", () => {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/messages.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/messages.ts
@@ -1,0 +1,31 @@
+import type { AgentConfig } from "./agents.js";
+
+export function messageRecord(key: string, value: string): string {
+	const singleLineValue = JSON.stringify(value).slice(1, -1);
+	return `${key}=${singleLineValue}`;
+}
+
+export function unknownAgentRefusal(agentName: string, agents: readonly Pick<AgentConfig, "name">[]): string {
+	const available = agents.map((agent) => `"${agent.name}"`).join(", ") || "none";
+	return [
+		messageRecord("unknown_agent", agentName),
+		`Unknown agent: "${agentName}". Available agents: ${available}.`,
+	].join("\n");
+}
+
+export function livePaneRefusal(agentName: string, windowName: string): string {
+	return [
+		messageRecord("pane_already_running", agentName),
+		`Cannot forceSpawn ${agentName}: a live pane already exists for this agent.`,
+		"kendex does not support multiple live panes for the same agent. Either:",
+		`  - Drop forceSpawn and the call will reuse the existing pane (queue this task into ${windowName}), or`,
+		`  - Use stop_subagent or /agents stop ${agentName} first, then retry with forceSpawn for a fresh session.`,
+	].join("\n");
+}
+
+export function piBridgeResolverNotice(status: "failed" | "missing", reason: string): string {
+	return [
+		messageRecord("pi_bridge_resolver", status),
+		`Pi bridge resolver failed: ${reason}`,
+	].join("\n");
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
@@ -8,6 +8,7 @@ import { atomicWriteFile } from "./file-lock.js";
 import type { AgentConfig } from "./agents.js";
 import { delay, paneSessionModeToRecordMode } from "./format.js";
 import { safeFileName, shellQuote } from "./names.js";
+import { livePaneRefusal, messageRecord, piBridgeResolverNotice, unknownAgentRefusal } from "./messages.js";
 import {
 	archivedPaneSessionDir,
 	archivedPaneSessions,
@@ -148,7 +149,8 @@ function formatPaneCwdStaleMessage(details: PaneCwdStaleDetails): string {
 					? "pane process pid could not be resolved"
 					: "pane process cwd could not be inspected";
 	return [
-		`pane-cwd-stale: refusing to queue task for ${details.agent}; ${reason}.`,
+		messageRecord("pane_cwd_stale", details.expectedCwd),
+		`Cannot queue a task for ${details.agent} because ${reason}.`,
 		`Pane: ${details.paneId}${details.pid ? ` pid=${details.pid}` : ""}`,
 		`Actual cwd: ${actual}`,
 		`Requested cwd: ${details.expectedCwd}`,
@@ -415,23 +417,23 @@ export function createCachedPiBridgeResolver(
 	// Resolve once for the extension lifetime; if the initial lookup fails,
 	// emit one structured diagnostic before caching the missing result so later
 	// probes can short-circuit without spamming terminal warnings.
-	const report = (reason: string) => {
-		try { logDiagnostic?.(`pi-bridge resolver failed: ${reason}`); } catch { /* diagnostics are best-effort */ }
+	const report = (status: "failed" | "missing", reason: string) => {
+		try { logDiagnostic?.(piBridgeResolverNotice(status, reason)); } catch { /* diagnostics are best-effort */ }
 	};
 	let cached: Promise<string | undefined>;
 	try {
 		cached = Promise.resolve(resolve()).then(
 			(bin) => {
-				if (!bin) report("returned undefined");
+				if (!bin) report("missing", "returned undefined");
 				return bin;
 			},
 			(error) => {
-				report(formatResolverFailure(error));
+				report("failed", formatResolverFailure(error));
 				return undefined;
 			},
 		);
 	} catch (error) {
-		report(formatResolverFailure(error));
+		report("failed", formatResolverFailure(error));
 		cached = Promise.resolve(undefined);
 	}
 	return () => cached;
@@ -1069,7 +1071,6 @@ export async function runPersistentPaneAgent(
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
-		const available = agents.map((a) => `"${a.name}"`).join(", ") || "none";
 		return {
 			agent: agentName,
 			agentSource: "unknown",
@@ -1078,7 +1079,7 @@ export async function runPersistentPaneAgent(
 			refused: true,
 			exitCode: 1,
 			messages: [],
-			stderr: `Unknown agent: "${agentName}". Available agents: ${available}.`,
+			stderr: unknownAgentRefusal(agentName, agents),
 			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
 			step,
 		};
@@ -1113,12 +1114,7 @@ export async function runPersistentPaneAgent(
 		const registry = await readPaneRegistry(runtimeRoot);
 		const existing = registry[agent.name];
 		if (existing && (await paneExists(existing.paneId))) {
-			const stderr = [
-				`Cannot forceSpawn ${agent.name}: a live pane already exists for this agent.`,
-				"kendex does not support multiple live panes for the same agent. Either:",
-				`  - Drop forceSpawn and the call will reuse the existing pane (queue this task into ${existing.windowName}), or`,
-				`  - Use stop_subagent or /agents stop ${agent.name} first, then retry with forceSpawn for a fresh session.`,
-			].join("\n");
+			const stderr = livePaneRefusal(agent.name, existing.windowName);
 			return {
 				agent: agent.name,
 				agentSource: agent.source,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -15,6 +15,7 @@ import type { AgentConfig } from "./agents.js";
 import { sanitizeCwdSnapshotText, setGitExecFileForTests as setSnapshotGitExecFileForTests, snapshotCwdGitState } from "./cwd-snapshot.js";
 import { getFinalOutput, stringifyError } from "./format.js";
 import { safeFileName } from "./names.js";
+import { unknownAgentRefusal } from "./messages.js";
 import {
 	getPiInvocation,
 	PI_SUBAGENT_CHILD_PANE_ENV,
@@ -449,7 +450,6 @@ export async function runSingleAgent(
 	const agent = agents.find((a) => a.name === agentName);
 
 	if (!agent) {
-		const available = agents.map((a) => `"${a.name}"`).join(", ") || "none";
 		return {
 			agent: agentName,
 			agentSource: "unknown",
@@ -458,7 +458,7 @@ export async function runSingleAgent(
 			refused: true,
 			exitCode: 1,
 			messages: [],
-			stderr: `Unknown agent: "${agentName}". Available agents: ${available}.`,
+			stderr: unknownAgentRefusal(agentName, agents),
 			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
 			step,
 		};

--- a/pi-extensions/pi-agents-tmux/tests/own-tmux-server.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/own-tmux-server.test.ts
@@ -1,18 +1,14 @@
 // The suite's tmux world, set up in tests/preload.ts: a pane title set
 // through the real code path lands on the server this run started, never on
-// the one that launched the suite, and a child spawned with the default
+// another test-owned server, and a child spawned with the default
 // environment carries the same values this process holds. A scratch server
-// plays the launching shell's server so both rows run on a bare runner; when
-// the suite really was launched inside tmux, the launching pane is read back
-// too and must not have moved.
+// plays the launching shell's server so both rows use stable panes owned by
+// this test.
 import { test } from "bun:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import { setCurrentTmuxPaneTitle } from "../extensions/subagent/pane.js";
-
-const INHERITED_TMUX_SYMBOL = Symbol.for("pi-agents-tmux.tests.inherited-tmux");
-const inherited = (globalThis as Record<PropertyKey, unknown>)[INHERITED_TMUX_SYMBOL] as { TMUX?: string; TMUX_PANE?: string };
 
 interface TmuxWorld {
 	socket: string;
@@ -63,10 +59,8 @@ const rows: Array<[string, "suite" | "launching", string]> = [
 test("a pane title set by the suite lands on its own tmux server", async () => {
 	const suite = worldFromEnv(process.env.TMUX ?? "", process.env.TMUX_PANE ?? "");
 	assert.ok(suite.TMUX && suite.TMUX_PANE, "the preload left no suite tmux server in the environment");
-	const realLaunching = inherited.TMUX && inherited.TMUX_PANE ? worldFromEnv(inherited.TMUX, inherited.TMUX_PANE) : undefined;
-	assert.notEqual(realLaunching?.socket, suite.socket, "the suite runs on the server that launched it");
-	const realLaunchingBefore = realLaunching ? paneLabel(realLaunching) : undefined;
 	const launching = startScratchServer();
+	assert.notEqual(launching.socket, suite.socket, "the control server is the suite server");
 	try {
 		for (const [label, env, expect] of rows) {
 			const world = env === "suite" ? suite : launching;
@@ -89,5 +83,4 @@ test("a pane title set by the suite lands on its own tmux server", async () => {
 		spawnSync("tmux", ["-S", launching.socket, "kill-server"], { stdio: "ignore" });
 		rmSync(launching.socket, { force: true });
 	}
-	if (realLaunching) assert.equal(paneLabel(realLaunching), realLaunchingBefore, "the launching pane moved");
 });

--- a/pi-extensions/pi-agents-tmux/tests/pane-refusal-messages.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pane-refusal-messages.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import type { AgentConfig } from "../extensions/subagent/agents.js";
+import { runPersistentPaneAgent, setPaneExecCaptureForTests } from "../extensions/subagent/pane.js";
+import { writePaneRegistry } from "../extensions/subagent/tasks.js";
+import { PANE_LAUNCHER_VERSION } from "../extensions/subagent/types.js";
+
+function paneAgent(): AgentConfig {
+	return {
+		name: "rust",
+		description: "Rust engineer",
+		pane: true,
+		source: "project",
+		systemPrompt: "",
+		filePath: "rust.md",
+	};
+}
+
+function runPane(runtimeRoot: string, agents: AgentConfig[], agentName: string, forceSpawn = false) {
+	return runPersistentPaneAgent(
+		process.cwd(),
+		runtimeRoot,
+		"parent-session",
+		agents,
+		agentName,
+		"inspect the project",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		{ getActiveTools: () => [] } as Parameters<typeof runPersistentPaneAgent>[9],
+		forceSpawn,
+	);
+}
+
+test("runPersistentPaneAgent returns a stable unknown-agent refusal record", async () => {
+	const result = await runPane(process.cwd(), [], "missing-agent");
+
+	assert.equal(result.stderr.split("\n", 1)[0], "unknown_agent=missing-agent");
+	assert.equal(result.exitCode, 1);
+	assert.equal(result.refused, true);
+});
+
+test("runPersistentPaneAgent returns a stable live-pane refusal record", async () => {
+	const runtimeRoot = mkdtempSync(join(tmpdir(), "pi-agents-pane-refusal-"));
+	try {
+		await writePaneRegistry(runtimeRoot, {
+			rust: {
+				agent: "rust",
+				paneId: "%42",
+				windowName: "agent:rust",
+				cwd: process.cwd(),
+				sessionFile: join(runtimeRoot, "sessions", "rust.jsonl"),
+				promptFile: join(runtimeRoot, "sessions", "rust.prompt.md"),
+				launcherFile: join(runtimeRoot, "sessions", "rust.launcher.sh"),
+				launcherVersion: PANE_LAUNCHER_VERSION,
+				startedAt: new Date().toISOString(),
+			},
+		});
+		setPaneExecCaptureForTests(async () => ({ code: 0, stdout: "%42\n", stderr: "" }));
+
+		const result = await runPane(runtimeRoot, [paneAgent()], "rust", true);
+
+		assert.equal(result.stderr.split("\n", 1)[0], "pane_already_running=rust");
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.refused, true);
+	} finally {
+		setPaneExecCaptureForTests();
+		rmSync(runtimeRoot, { recursive: true, force: true });
+	}
+});

--- a/pi-extensions/pi-agents-tmux/tests/pi-bridge-resolver.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-bridge-resolver.test.ts
@@ -41,6 +41,7 @@ test("cached pi-bridge resolver logs startup throw once and caches missing", asy
 	assert.equal(await resolve(), undefined);
 	assert.equal(calls, 1);
 	assert.equal(warnings.length, 1);
+	assert.equal(warnings[0]!.split("\n", 1)[0], "pi_bridge_resolver=failed");
 	assert.match(warnings[0]!, /code=ENOENT/);
 	assert.match(warnings[0]!, /errno=-2/);
 	assert.match(warnings[0]!, /syscall=spawn/);
@@ -60,5 +61,6 @@ test("cached pi-bridge resolver logs returned undefined once and caches missing"
 	assert.equal(await resolve(), undefined);
 	assert.equal(await resolve(), undefined);
 	assert.equal(calls, 1);
-	assert.deepEqual(warnings, ["pi-bridge resolver failed: returned undefined"]);
+	assert.equal(warnings.length, 1);
+	assert.equal(warnings[0]!.split("\n", 1)[0], "pi_bridge_resolver=missing");
 });

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -42,17 +42,12 @@ afterAll(async () => {
 });
 
 // The suite's own tmux server. The launching shell's TMUX and TMUX_PANE
-// name the developer's live server and pane, and the extension reaches
-// tmux through them: `tmux` resolves its server from TMUX, and
-// pane.ts::setCurrentTmuxPaneTitle retitles TMUX_PANE. Both are stashed for
-// tests/own-tmux-server.test.ts and dropped before any test module loads,
-// then pointed at a server this run starts and kills, so every real tmux
+// can name a developer's live server and pane. Drop them before any test
+// module loads, then point at a server this run starts and kills, so every real tmux
 // call from this process or a child lands there. The session's command
 // exits once this process is gone, which closes the server after a crash
 // too. A tmux that cannot start is a failed run, never a silent fallback
 // to the launching server.
-const INHERITED_TMUX_SYMBOL = Symbol.for("pi-agents-tmux.tests.inherited-tmux");
-(globalThis as Record<PropertyKey, unknown>)[INHERITED_TMUX_SYMBOL] = { TMUX: process.env.TMUX, TMUX_PANE: process.env.TMUX_PANE };
 delete process.env.TMUX;
 delete process.env.TMUX_PANE;
 const TMUX_SERVER_NAME = `pi-agents-tmux-tests-${process.pid}`;

--- a/pi-extensions/pi-agents-tmux/tests/runner-refusal-messages.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/runner-refusal-messages.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runSingleAgent } from "../extensions/subagent/runner.js";
+import type { SingleResult, SubagentDetails } from "../extensions/subagent/types.js";
+
+function makeDetails(results: SingleResult[]): SubagentDetails {
+	return { agentScope: "project", mode: "single", projectAgentsDir: null, results };
+}
+
+test("runSingleAgent returns a stable unknown-agent refusal record", async () => {
+	const result = await runSingleAgent(
+		process.cwd(),
+		process.cwd(),
+		[],
+		"missing-agent",
+		"inspect the project",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		{} as Parameters<typeof runSingleAgent>[9],
+		undefined,
+		undefined,
+		makeDetails,
+	);
+
+	assert.equal(result.stderr.split("\n", 1)[0], "unknown_agent=missing-agent");
+	assert.equal(result.exitCode, 1);
+	assert.equal(result.refused, true);
+});


### PR DESCRIPTION
The pi-agents-tmux refusal and resolver messages started with English text that tests could pin as prose. Unknown-agent results, live-pane refusals, stale-cwd refusals, and bridge resolver notices now start with a stable `key=value` record. The English explanation remains on later lines.

`SingleResult.refused`, `exitCode`, and `stopReason` still control caller behavior. No package consumer parses these message strings.

The tmux server ownership test now compares two test-owned panes. This keeps its cross-server isolation check stable when a developer's live pane title animates.

Changed files:

- `extensions/subagent/messages.ts`
- `extensions/subagent/runner.ts`
- `extensions/subagent/pane.ts`
- `extensions/subagent/__tests__/pane-cwd-stale.test.ts`
- `tests/runner-refusal-messages.test.ts`
- `tests/pane-refusal-messages.test.ts`
- `tests/pi-bridge-resolver.test.ts`
- `tests/preload.ts`
- `tests/own-tmux-server.test.ts`

Compliant files left unchanged:

- `extensions/subagent/dispatch.ts`
- `extensions/subagent/subagent-render.ts`
- `extensions/subagent/types.ts`
- `tests/session-lanes.test.ts`

Validation:

- The message-record controls failed before the implementation and passed after it.
- The cross-server control failed when both rows targeted the suite server and passed after restoring the selected test-owned server.
- The final-head `tools/guard --full` passed.
