### PR TITLE
fix(KEN-1241): stabilize document limit diagnostics

### DIFF
--- a/.agents/skills/doc-limits/scripts/doc-limits
+++ b/.agents/skills/doc-limits/scripts/doc-limits
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Diagnostic protocol: refusals start error=KEY FIELD=VALUE; notices start
+# notice=KEY FIELD=VALUE. English detail follows on the next line.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/settings.sh
@@ -33,20 +35,30 @@ Class selection and exclusions: references/policy.md.
 Exit codes: 0 clean; 1 over-limit documents; 2 usage/config/collection error.
 EOF
 }
+diagnostic() {
+  local level="$1" key="$2" field="$3" value="$4" text="$5"
+  printf '%s=%s %s=%q\n' "$level" "$key" "$field" "$value" >&2
+  printf '::error::doc-limits: %s\n' "$text" >&2
+}
 config_error() {
-  echo "::error::doc-limits: $*" >&2
+  diagnostic error "$1" "$2" "$3" "$4"
   exit 2
 }
 collection_error() {
-  echo "::error::doc-limits: $*" >&2
+  diagnostic error "$1" "$2" "$3" "$4"
   exit 2
+}
+notice() {
+  local key="$1" field="$2" value="$3" text="$4"
+  printf 'notice=%s %s=%q\n' "$key" "$field" "$value"
+  printf '%s\n' "$text"
 }
 EXCLUDES_OPT=""
 EXCLUDES_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --excludes)
-      [ $# -ge 2 ] || config_error "--excludes requires a path"
+      [ $# -ge 2 ] || config_error argument-value-missing option --excludes "--excludes requires a path"
       shift
       EXCLUDES_OPT="$1"
       EXCLUDES_SET=1
@@ -54,13 +66,13 @@ while [ $# -gt 0 ]; do
     --excludes=*) EXCLUDES_OPT="${1#--excludes=}"; EXCLUDES_SET=1 ;;
     -h | --help) usage; exit 0 ;;
     --staged) STAGED=1 ;;
-    *) config_error "unknown argument '$1' (see --help)" ;;
+    *) config_error argument-unknown argument "$1" "unknown argument '$1' (see --help)" ;;
   esac
   shift
 done
-REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error "not inside a git repository"
-cd "$REPO_ROOT" || config_error "could not enter the repository root $REPO_ROOT"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX")" || config_error "could not create a temporary directory"
+REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error repository-root-missing path "$PWD" "not inside a git repository"
+cd "$REPO_ROOT" || config_error repository-root-unreadable path "$REPO_ROOT" "could not enter the repository root $REPO_ROOT"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX")" || config_error temp-create-failed path "${TMPDIR:-/tmp}" "could not create a temporary directory"
 trap 'rm -rf -- "${TMP:?}"' EXIT
 if [ "$STAGED" -eq 1 ]; then
   SR_SETTINGS_FROM_INDEX=1
@@ -88,22 +100,22 @@ parse_classes() { # SETTING-NAME VALUE — appends entries
     [ -n "$pair" ] || continue
     case "$pair" in
       *"="*) ;;
-      *) config_error "$name: entry '$pair' is not 'pattern=threshold'" ;;
+      *) config_error class-entry-invalid value "$pair" "$name: entry '$pair' is not 'pattern=threshold'" ;;
     esac
     cpat="${pair%=*}"
     craw="${pair##*=}"
     cpat="${cpat%"${cpat##*[![:space:]]}"}"
     craw="${craw#"${craw%%[![:space:]]*}"}"
-    [ -n "$cpat" ] || config_error "$name: entry '$pair' has an empty pattern"
+    [ -n "$cpat" ] || config_error class-pattern-empty value "$pair" "$name: entry '$pair' has an empty pattern"
     case "$cpat" in
-      *"$TAB"* | *"$NL"*) config_error "$name: entry '$pair' has a tab or newline in its pattern; the mapping is one line" ;;
+      *"$TAB"* | *"$NL"*) config_error class-pattern-invalid setting "$name" "$name: entry '$pair' has a tab or newline in its pattern; the mapping is one line" ;;
     esac
     case "$craw" in
       *k) cthr="${craw%k}" ;;
-      *) config_error "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
+      *) config_error class-threshold-invalid value "$craw" "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
     esac
     case "$cthr" in
-      "" | *[!0-9]* | 0*[0-9] | 0) config_error "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
+      "" | *[!0-9]* | 0*[0-9] | 0) config_error class-threshold-invalid value "$craw" "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
     esac
     cthr=$((cthr * 1024))
     CLASS_PATTERNS+=("$cpat")
@@ -116,7 +128,7 @@ parse_classes DOC_LIMITS_CLASSES "$CLASSES"
 DEFAULT_CLASSES="$(sr_setting DOC_LIMITS_DEFAULT_CLASSES "$SHIPPED_CLASSES")" || exit 2
 parse_classes DOC_LIMITS_DEFAULT_CLASSES "$DEFAULT_CLASSES"
 if [ "$EXCLUDES_SET" = "1" ]; then
-  [ -n "$EXCLUDES_OPT" ] || config_error "--excludes was given an empty path; pass a real path or omit the flag to use the configured default"
+  [ -n "$EXCLUDES_OPT" ] || config_error excludes-path-empty path "$EXCLUDES_OPT" "--excludes was given an empty path; pass a real path or omit the flag to use the configured default"
   EXCLUDES_FILE="$EXCLUDES_OPT"
 else
   EXCLUDES_FILE="$(sr_setting DOC_LIMITS_EXCLUDES "tools/doc-limits-excludes")" || exit 2
@@ -142,10 +154,11 @@ normalize_rel_path() { # PATH -> normalized on stdout; nonzero if it escapes
   [ -n "$out" ] || return 1
   printf '%s' "$out"
 }
-case "$EXCLUDES_FILE" in /*) config_error "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
-EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error "excludes path escapes the repository or normalizes empty"
-[ -n "$EXCLUDES_FILE" ] || config_error "excludes path resolved empty"
-case "$EXCLUDES_FILE" in -*) config_error "excludes path must not begin with '-': $EXCLUDES_FILE" ;; /*) config_error "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
+case "$EXCLUDES_FILE" in /*) config_error excludes-path-absolute path "$EXCLUDES_FILE" "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
+raw_excludes_file="$EXCLUDES_FILE"
+EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error excludes-path-invalid path "$raw_excludes_file" "excludes path escapes the repository or normalizes empty"
+[ -n "$EXCLUDES_FILE" ] || config_error excludes-path-empty path "$raw_excludes_file" "excludes path resolved empty"
+case "$EXCLUDES_FILE" in -*) config_error excludes-path-option path "$EXCLUDES_FILE" "excludes path must not begin with '-': $EXCLUDES_FILE" ;; /*) config_error excludes-path-absolute path "$EXCLUDES_FILE" "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
 staged_policy_state() { # PATH
   [ "$STAGED" -eq 1 ] || return 1
   read_index_file_mode "$1"
@@ -158,7 +171,7 @@ INDEX_FILE_MODE=""
 read_index_file_mode() { # PATH — sets INDEX_FILE_MODE ("" when untracked)
   local entry status=0
   entry="$(git ls-files -s -- ":(literal)$1")" || status=$?
-  [ "$status" -eq 0 ] || collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
+  [ "$status" -eq 0 ] || collection_error index-query-failed exit "$status" "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
   INDEX_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || INDEX_FILE_MODE=""
 }
@@ -172,20 +185,20 @@ read_head_file_mode() { # PATH — sets HEAD_FILE_MODE ("" when HEAD carries no 
   case "$head_status" in
     0) HEAD_EXISTS=1 ;;
     1) return 0 ;;
-    *) collection_error "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
+    *) collection_error head-query-failed exit "$head_status" "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
   esac
   entry="$(git ls-tree HEAD -- ":(literal)$1")" || status=$?
-  [ "$status" -eq 0 ] || collection_error "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
+  [ "$status" -eq 0 ] || collection_error head-tree-query-failed exit "$status" "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
   HEAD_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || HEAD_FILE_MODE=""
 }
 read_policy_from_index() { # PATH — stages the index copy of the list at $TMP/excludes
   case "$INDEX_FILE_MODE" in
     100*) ;;
-    *) config_error "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
+    *) config_error excludes-mode-invalid mode "$INDEX_FILE_MODE" "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
   esac
   git show ":$1" >"$TMP/excludes" \
-    || collection_error "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
+    || collection_error excludes-index-read-failed path "$1" "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
 }
 EXCLUDES_SOURCE="$EXCLUDES_FILE"
 EXCLUDES_LABEL="$EXCLUDES_FILE"
@@ -208,14 +221,14 @@ case "$excludes_state" in
     fi
     ;;
   2)
-    : >"$TMP/excludes" || collection_error "could not initialize the excludes scratch file"
+    : >"$TMP/excludes" || collection_error excludes-scratch-failed path "$TMP/excludes" "could not initialize the excludes scratch file"
     EXCLUDES_SOURCE="$TMP/excludes"
     ;;
 esac
 EXCLUDE_PATTERNS=()
 CARVE_PATTERNS=()
 if [ -f "$EXCLUDES_SOURCE" ]; then
-  [ -r "$EXCLUDES_SOURCE" ] || config_error "$EXCLUDES_LABEL: exists but cannot be read"
+  [ -r "$EXCLUDES_SOURCE" ] || config_error excludes-unreadable path "$EXCLUDES_LABEL" "$EXCLUDES_LABEL: exists but cannot be read"
   lineno=0
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))
@@ -225,7 +238,7 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     pat="${line%%"$TAB"*}"
     reason="${line#*"$TAB"}"
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
-      config_error "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+      config_error excludes-row-invalid line "$lineno" "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
     # A `!` pattern CARVES its matches back into the measured set, the only
     # way to govern documents living inside an excluded render tree
@@ -235,7 +248,7 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
       "!"*)
         carve="${pat#!}"
         [ -n "$carve" ] \
-          || config_error "$EXCLUDES_LABEL:$lineno: '!' carves matching paths back into the measured set and needs a pattern after it"
+          || config_error excludes-carve-empty line "$lineno" "$EXCLUDES_LABEL:$lineno: '!' carves matching paths back into the measured set and needs a pattern after it"
         CARVE_PATTERNS+=("$carve")
         ;;
       *) EXCLUDE_PATTERNS+=("$pat") ;;
@@ -257,7 +270,7 @@ if [ "$STAGED" -eq 0 ] && [ ! -f "$INVENTORY_SOURCE" ]; then
   read_index_file_mode .kendex-generated.json
   if [ -n "$INDEX_FILE_MODE" ]; then
     git show :0:.kendex-generated.json >"$TMP/generated.json" \
-      || collection_error 'cannot read .kendex-generated.json from the index; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
+      || collection_error inventory-index-read-failed path .kendex-generated.json 'cannot read .kendex-generated.json from the index; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
     INVENTORY_SOURCE="$TMP/generated.json"
   fi
 fi
@@ -270,7 +283,7 @@ if [ ! -e "$INVENTORY_SOURCE" ] && [ ! -L "$INVENTORY_SOURCE" ]; then
   inventory='[]'
 else
   inventory="$(cat -- "$INVENTORY_SOURCE")" \
-    || collection_error 'cannot read .kendex-generated.json; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
+    || collection_error inventory-read-failed path "$INVENTORY_SOURCE" 'cannot read .kendex-generated.json; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
 fi
 generated_paths_load "$inventory" || exit 2
 is_excluded() { # PATH — inclusion rows override both exclusion sources
@@ -292,7 +305,7 @@ path_threshold() { # PATH: first matching class, or no limit
 }
 # The index supplies both the tracked set and blob IDs. A single batch reads
 # their sizes, so staged checks do not materialize every document.
-git ls-files -s -z >"$TMP/files.z" || collection_error "could not enumerate tracked documents"
+git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"
 : >"$TMP/documents.tsv"
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
@@ -300,38 +313,38 @@ while IFS= read -r -d '' rec; do
   case "$f" in *.md) ;; *) continue ;; esac
   case "$mode" in 120000 | 160000) continue ;; esac
   case "$f" in
-    *"$NL"* | *"$TAB"*) config_error "tracked document path contains a tab or newline: '$f'" ;;
+    *"$NL"* | *"$TAB"*) config_error document-path-invalid path "$f" "tracked document path contains a tab or newline: '$f'" ;;
   esac
   is_excluded "$f" && continue
   path_threshold "$f"
   [ -n "$PT" ] || continue
   entry="${rec%%"$TAB"*}"
-  [ "${entry##* }" = 0 ] || collection_error "tracked document is unmerged: $f"
+  [ "${entry##* }" = 0 ] || collection_error document-unmerged path "$f" "tracked document is unmerged: $f"
   oid="${entry#* }"
   oid="${oid%% *}"
   printf '%s\t%s\t%s\t%s\n' "$oid" "$f" "$PT" "$PC" >>"$TMP/documents.tsv"
 done <"$TMP/files.z"
 cut -f1 "$TMP/documents.tsv" | git cat-file --batch-check >"$TMP/sizes" \
-  || collection_error "could not read document blob sizes"
+  || collection_error blob-sizes-read-failed exit "$?" "could not read document blob sizes"
 checked=0 violations=0
 while IFS="$TAB" read -r oid f limit class; do
-  IFS=' ' read -r actual_oid kind n <&3 || collection_error "document size response is incomplete: $f"
+  IFS=' ' read -r actual_oid kind n <&3 || collection_error blob-size-response-incomplete path "$f" "document size response is incomplete: $f"
   [ "$actual_oid" = "$oid" ] && [ "$kind" = blob ] \
-    || collection_error "could not read document blob: $f"
+    || collection_error document-blob-read-failed path "$f" "could not read document blob: $f"
   if [ "$STAGED" -eq 0 ] && [ -f "$f" ] && [ ! -L "$f" ]; then
-    n="$(wc -c <"$f")" || collection_error "could not measure tracked document: $f"
+    n="$(wc -c <"$f")" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
     n="${n#"${n%%[![:space:]]*}"}"
   fi
-  case "$n" in "" | *[!0-9]*) collection_error "invalid byte count for tracked document: $f" ;; esac
+  case "$n" in "" | *[!0-9]*) collection_error document-byte-count-invalid path "$f" "invalid byte count for tracked document: $f" ;; esac
   if [ "$n" -gt "$limit" ]; then
-    printf 'doc-limits FAIL: %s: %s bytes > %s bytes (class %s)\n' "$f" "$n" "$limit" "$class"
+    notice document-over-limit path "$f" "doc-limits FAIL: $f: $n bytes > $limit bytes (class $class)"
     printf '  remedy: split the document at a natural seam, move detail to a linked reference, or delete content the code or another document already states; a document that must stay whole gets a row in %s with its reason\n' "$EXCLUDES_FILE"
     violations=$((violations + 1))
   fi
   checked=$((checked + 1))
 done <"$TMP/documents.tsv" 3<"$TMP/sizes"
 if [ "$violations" -gt 0 ]; then
-  printf 'doc-limits: %s over-limit document(s), %s checked\n' "$violations" "$checked"
+  notice documents-over-limit count "$violations" "doc-limits: $violations over-limit document(s), $checked checked"
   exit 1
 fi
-printf 'doc-limits: OK: %s document(s) checked\n' "$checked"
+notice documents-checked count "$checked" "doc-limits: OK: $checked document(s) checked"

--- a/.agents/skills/doc-limits/scripts/doc-limits
+++ b/.agents/skills/doc-limits/scripts/doc-limits
@@ -70,9 +70,9 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error repository-root-missing path "$PWD" "not inside a git repository"
-cd "$REPO_ROOT" || config_error repository-root-unreadable path "$REPO_ROOT" "could not enter the repository root $REPO_ROOT"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX")" || config_error temp-create-failed path "${TMPDIR:-/tmp}" "could not create a temporary directory"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || config_error repository-root-missing path "$PWD" "not inside a git repository"
+cd "$REPO_ROOT" 2>/dev/null || config_error repository-root-unreadable path "$REPO_ROOT" "could not enter the repository root $REPO_ROOT"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX" 2>/dev/null)" || config_error temp-create-failed path "${TMPDIR:-/tmp}" "could not create a temporary directory"
 trap 'rm -rf -- "${TMP:?}"' EXIT
 if [ "$STAGED" -eq 1 ]; then
   SR_SETTINGS_FROM_INDEX=1
@@ -170,7 +170,7 @@ staged_policy_state() { # PATH
 INDEX_FILE_MODE=""
 read_index_file_mode() { # PATH — sets INDEX_FILE_MODE ("" when untracked)
   local entry status=0
-  entry="$(git ls-files -s -- ":(literal)$1")" || status=$?
+  entry="$(git ls-files -s -- ":(literal)$1" 2>/dev/null)" || status=$?
   [ "$status" -eq 0 ] || collection_error index-query-failed exit "$status" "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
   INDEX_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || INDEX_FILE_MODE=""
@@ -187,7 +187,7 @@ read_head_file_mode() { # PATH — sets HEAD_FILE_MODE ("" when HEAD carries no 
     1) return 0 ;;
     *) collection_error head-query-failed exit "$head_status" "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
   esac
-  entry="$(git ls-tree HEAD -- ":(literal)$1")" || status=$?
+  entry="$(git ls-tree HEAD -- ":(literal)$1" 2>/dev/null)" || status=$?
   [ "$status" -eq 0 ] || collection_error head-tree-query-failed exit "$status" "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
   HEAD_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || HEAD_FILE_MODE=""
@@ -197,7 +197,7 @@ read_policy_from_index() { # PATH — stages the index copy of the list at $TMP/
     100*) ;;
     *) config_error excludes-mode-invalid mode "$INDEX_FILE_MODE" "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
   esac
-  git show ":$1" >"$TMP/excludes" \
+  git show ":$1" >"$TMP/excludes" 2>/dev/null \
     || collection_error excludes-index-read-failed path "$1" "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
 }
 EXCLUDES_SOURCE="$EXCLUDES_FILE"
@@ -269,7 +269,7 @@ INVENTORY_SOURCE="$(sr_settings_source .kendex-generated.json)" || exit 2
 if [ "$STAGED" -eq 0 ] && [ ! -f "$INVENTORY_SOURCE" ]; then
   read_index_file_mode .kendex-generated.json
   if [ -n "$INDEX_FILE_MODE" ]; then
-    git show :0:.kendex-generated.json >"$TMP/generated.json" \
+    git show :0:.kendex-generated.json >"$TMP/generated.json" 2>/dev/null \
       || collection_error inventory-index-read-failed path .kendex-generated.json 'cannot read .kendex-generated.json from the index; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
     INVENTORY_SOURCE="$TMP/generated.json"
   fi
@@ -282,10 +282,11 @@ fi
 if [ ! -e "$INVENTORY_SOURCE" ] && [ ! -L "$INVENTORY_SOURCE" ]; then
   inventory='[]'
 else
-  inventory="$(cat -- "$INVENTORY_SOURCE")" \
+  inventory="$(cat -- "$INVENTORY_SOURCE" 2>/dev/null)" \
     || collection_error inventory-read-failed path "$INVENTORY_SOURCE" 'cannot read .kendex-generated.json; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
 fi
-generated_paths_load "$inventory" || exit 2
+generated_paths_load "$inventory" 2>/dev/null \
+  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
 is_excluded() { # PATH — inclusion rows override both exclusion sources
   generated_path_contains "$1" \
     || glob_match "$1" ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"} || return 1
@@ -305,7 +306,7 @@ path_threshold() { # PATH: first matching class, or no limit
 }
 # The index supplies both the tracked set and blob IDs. A single batch reads
 # their sizes, so staged checks do not materialize every document.
-git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"
+git ls-files -s -z >"$TMP/files.z" 2>/dev/null || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"
 : >"$TMP/documents.tsv"
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
@@ -324,7 +325,7 @@ while IFS= read -r -d '' rec; do
   oid="${oid%% *}"
   printf '%s\t%s\t%s\t%s\n' "$oid" "$f" "$PT" "$PC" >>"$TMP/documents.tsv"
 done <"$TMP/files.z"
-cut -f1 "$TMP/documents.tsv" | git cat-file --batch-check >"$TMP/sizes" \
+cut -f1 "$TMP/documents.tsv" 2>/dev/null | git cat-file --batch-check >"$TMP/sizes" 2>/dev/null \
   || collection_error blob-sizes-read-failed exit "$?" "could not read document blob sizes"
 checked=0 violations=0
 while IFS="$TAB" read -r oid f limit class; do
@@ -332,7 +333,7 @@ while IFS="$TAB" read -r oid f limit class; do
   [ "$actual_oid" = "$oid" ] && [ "$kind" = blob ] \
     || collection_error document-blob-read-failed path "$f" "could not read document blob: $f"
   if [ "$STAGED" -eq 0 ] && [ -f "$f" ] && [ ! -L "$f" ]; then
-    n="$(wc -c <"$f")" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
+    n="$(wc -c <"$f" 2>/dev/null)" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
     n="${n#"${n%%[![:space:]]*}"}"
   fi
   case "$n" in "" | *[!0-9]*) collection_error document-byte-count-invalid path "$f" "invalid byte count for tracked document: $f" ;; esac

--- a/.agents/skills/doc-limits/scripts/doc-limits
+++ b/.agents/skills/doc-limits/scripts/doc-limits
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Diagnostic protocol: refusals start error=KEY FIELD=VALUE; notices start
+# Diagnostic protocol: command refusals start error=KEY FIELD=VALUE; settings
+# refusals start doc-limits-error=KEY value=VALUE; notices start
 # notice=KEY FIELD=VALUE. English detail follows on the next line.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -333,7 +334,7 @@ while IFS="$TAB" read -r oid f limit class; do
   [ "$actual_oid" = "$oid" ] && [ "$kind" = blob ] \
     || collection_error document-blob-read-failed path "$f" "could not read document blob: $f"
   if [ "$STAGED" -eq 0 ] && [ -f "$f" ] && [ ! -L "$f" ]; then
-    n="$(wc -c <"$f" 2>/dev/null)" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
+    n="$(wc -c 2>/dev/null <"$f")" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
     n="${n#"${n%%[![:space:]]*}"}"
   fi
   case "$n" in "" | *[!0-9]*) collection_error document-byte-count-invalid path "$f" "invalid byte count for tracked document: $f" ;; esac

--- a/.agents/skills/doc-limits/scripts/doc-limits
+++ b/.agents/skills/doc-limits/scripts/doc-limits
@@ -4,7 +4,7 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/settings.sh
-source "$SCRIPT_DIR/lib/settings.sh"
+source "$SCRIPT_DIR/lib/settings.sh" || exit 2
 # shellcheck source=../../commit-guards/scripts/lib/generated-paths.sh
 source "$SCRIPT_DIR/../../commit-guards/scripts/lib/generated-paths.sh"
 TAB="$(printf '\t')"

--- a/.agents/skills/doc-limits/scripts/lib/diagnostics.sh
+++ b/.agents/skills/doc-limits/scripts/lib/diagnostics.sh
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+# Diagnostic protocol: the first line carries a stable kind/code and one
+# value escaped with Bash printf %q. Remaining lines explain the result.
+# Callers choose stdout or stderr. The command stdout protocol stays with
+# doc-limits and does not pass through this formatter.
+sr_message() { # KIND CODE VALUE MESSAGE
+  printf 'doc-limits-%s=%s value=%q\n%s\n' "$1" "$2" "$3" "$4"
+}

--- a/.agents/skills/doc-limits/scripts/lib/settings.sh
+++ b/.agents/skills/doc-limits/scripts/lib/settings.sh
@@ -32,6 +32,15 @@
 # The caller cds to the repo root before resolving, so the default settings
 # path is relative.
 
+# Refusals start with the stable diagnostics protocol; source values remain
+# the resolver's stdout protocol and never include diagnostic text.
+sr_settings_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
+. "$sr_settings_script_dir/diagnostics.sh" 2>/dev/null || {
+  printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
+  return 1
+}
+unset sr_settings_script_dir
+
 # Extract the value of one parsed dotenv assignment (text after `KEY=`).
 # Quoted values end at the FIRST closing delimiter — dotenv/shell
 # semantics; an embedded delimiter would need escaping, which this parser
@@ -86,9 +95,9 @@ sr_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
   { [ -e "$1" ] || [ -L "$1" ]; } || return 0
   [ ! -f "$1" ] || return 0
   if [ ! -e "$1" ]; then
-    echo "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
+    sr_message error settings-symlink "$1" "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
   else
-    echo "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
+    sr_message error settings-type "$1" "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
   fi
   return 1
 }
@@ -205,7 +214,7 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
         0)
           entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
           if [ "$tree_status" -ne 0 ]; then
-            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $tree_status); refusing to treat it as untracked" >&2
+            sr_message error settings-head-tree "$tree_status" "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $tree_status); refusing to treat it as untracked" >&2
             return 1
           fi
           case "${entry:+tracked}" in
@@ -218,7 +227,7 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
           ;;
         1) ;;
         *)
-          echo "::error::$file: could not resolve HEAD while resolving a setting (git rev-parse exit $head_status); refusing to treat it as untracked" >&2
+          sr_message error settings-head "$head_status" "::error::$file: could not resolve HEAD while resolving a setting (git rev-parse exit $head_status); refusing to treat it as untracked" >&2
           return 1
           ;;
       esac
@@ -226,19 +235,19 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
       return 0
       ;;
     *)
-      echo "::error::$file: could not query the index while resolving a setting (git ls-files exit $status); refusing to treat it as untracked" >&2
+      sr_message error settings-index-query "$status" "::error::$file: could not query the index while resolving a setting (git ls-files exit $status); refusing to treat it as untracked" >&2
       return 1
       ;;
   esac
   status=0
   entry="$(git ls-files -s -- ":(literal)$file" 2>/dev/null)" || status=$?
   if [ "$status" -ne 0 ]; then
-    echo "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
+    sr_message error settings-index-mode "$status" "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
     return 1
   fi
   case "${entry%% *}" in
     120000)
-      echo "::error::$file: tracked as a symlink; staged settings resolution cannot read through it" >&2
+      sr_message error settings-index-symlink "$file" "::error::$file: tracked as a symlink; staged settings resolution cannot read through it" >&2
       return 1
       ;;
   esac
@@ -247,7 +256,7 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
   if [ ! -f "$copy" ]; then
     if ! git show ":$file" >"$copy" 2>/dev/null; then
       rm -f -- "$copy"
-      echo "::error::$file: could not read the staged copy while resolving a setting" >&2
+      sr_message error settings-index-read "$file" "::error::$file: could not read the staged copy while resolving a setting" >&2
       return 1
     fi
   fi
@@ -259,8 +268,12 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
 # header or assignment it hides. Refuse the source whole, same discipline
 # as the header rule. Read via stdin so the path is never an operand.
 sr_bom_guard() { # FILE — 0 = no leading BOM; 1 + ::error otherwise
+  if [ ! -r "$1" ]; then
+    sr_message error settings-unreadable "$1" "::error::$1: settings source is not readable" >&2
+    return 1
+  fi
   if [ "$(head -c 3 < "$1" 2>/dev/null)" = "$(printf '\357\273\277')" ]; then
-    echo "::error::$1: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
+    sr_message error settings-bom "$1" "::error::$1: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
     return 1
   fi
 }
@@ -271,9 +284,9 @@ sr_bom_guard() { # FILE — 0 = no leading BOM; 1 + ::error otherwise
 # resolved value.
 sr_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
   local status=0
-  grep -E -- "$1" "$2" || status=$?
+  grep -E -- "$1" "$2" 2>/dev/null || status=$?
   if [ "$status" -gt 1 ]; then
-    echo "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
+    sr_message error settings-grep "$2" "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
     return 2
   fi
   return "$status"
@@ -295,7 +308,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
   sr_bom_guard "$1" || return 1
   awk -v src="$1" '
     /^[[:space:]]*\[/ && !/^[[:space:]]*\[[A-Za-z0-9_.-]+\][[:space:]]*$/ {
-      printf "::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", src, NR > "/dev/stderr"
+      printf "doc-limits-error=settings-header value=%d\n::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", NR, src, NR > "/dev/stderr"
       exit 3
     }
     /^[[:space:]]*\[/ {
@@ -319,7 +332,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
       sub(/[[:space:]]*=.*$/, "", key)
       if (key !~ /^[A-Za-z_][A-Za-z0-9_]*$/) { print; next }
       if (key in seen) {
-        printf "::error::%s: %s is assigned more than once in [env] (each key must be unique in the table)\n", src, key > "/dev/stderr"
+        printf "doc-limits-error=settings-duplicate value=%s\n::error::%s: %s is assigned more than once in [env] (each key must be unique in the table)\n", key, src, key > "/dev/stderr"
         exit 3
       }
       seen[key] = 1
@@ -327,7 +340,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
       sub(/^[^=]*=[[:space:]]*/, "", value)
       sub(/[[:space:]]+$/, "", value)
       if (value !~ /^"[^"\\]*"[[:space:]]*(#.*)?$/) {
-        printf "::error::%s: unsupported syntax for %s (expected a single-line basic string, no double quote and no backslash: %s = \"value\")\n", src, key, key > "/dev/stderr"
+        printf "doc-limits-error=settings-syntax value=%s\n::error::%s: unsupported syntax for %s (expected a single-line basic string, no double quote and no backslash: %s = \"value\")\n", key, src, key, key > "/dev/stderr"
         exit 3
       }
       print
@@ -335,7 +348,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
   ' < "$1" || status=$?
   [ "$status" -ne 3 ] || return 1
   if [ "$status" -ne 0 ]; then
-    echo "::error::$1: unreadable while resolving a setting (awk exit $status)" >&2
+    sr_message error settings-awk "$1" "::error::$1: unreadable while resolving a setting (awk exit $status)" >&2
     return 2
   fi
 }
@@ -344,7 +357,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   local name="$1" default="$2" line val file table status matches
   case "$name" in
     "" | [0-9]* | *[!A-Za-z0-9_]*)
-      echo "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
+      sr_message error settings-key "$name" "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
       return 1
       ;;
   esac
@@ -366,7 +379,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     if [ -f "$file" ]; then
       sr_bom_guard "$file" || return 1
       if [ ! -r "$file" ]; then
-        echo "::error::$file: unreadable while resolving a setting (permission denied)" >&2
+        sr_message error settings-unreadable "$file" "::error::$file: unreadable while resolving a setting (permission denied)" >&2
         return 1
       fi
     fi
@@ -390,7 +403,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     line="$(printf '%s\n' "$matches" | tail -n 1)"
     if [ -n "$line" ]; then
       if ! val="$(sr_dotenv_value "${line#*=}")"; then
-        echo "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+        sr_message error settings-dotenv "$name" "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
         return 1
       fi
       printf '%s' "$val"
@@ -407,7 +420,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     [ "$status" -le 1 ] || return 1
     if [ "$status" -eq 0 ]; then
       if [ "$(printf '%s\n' "$matches" | grep -c .)" -gt 1 ]; then
-        echo "::error::$file: $name is assigned more than once in [env] (each key must be unique in the table)" >&2
+        sr_message error settings-duplicate "$name" "::error::$file: $name is assigned more than once in [env] (each key must be unique in the table)" >&2
         return 1
       fi
       # The first line in-shell, never `printf | head -n 1`: head closes the
@@ -416,7 +429,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       # file sets no mode of its own; it runs in the caller's, which does.
       line="${matches%%$'\n'*}"
       if ! printf '%s\n' "$line" | grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"\\\\]*\"[[:space:]]*(#.*)?\$"; then
-        echo "::error::$file: unsupported syntax for $name (expected a single-line basic string with no '\"' and no '\\': $name = \"value\")" >&2
+        sr_message error settings-syntax "$name" "::error::$file: unsupported syntax for $name (expected a single-line basic string with no '\"' and no '\\': $name = \"value\")" >&2
         return 1
       fi
       val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"

--- a/.agents/skills/doc-limits/scripts/lib/settings.sh
+++ b/.agents/skills/doc-limits/scripts/lib/settings.sh
@@ -271,13 +271,14 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
 # to any reader here, so a BOM-prefixed first line silently misfiles the
 # header or assignment it hides. Refuse the source whole, same discipline
 # as the header rule. Read via stdin so the path is never an operand.
-sr_bom_guard() { # FILE — 0 = no leading BOM; 1 + ::error otherwise
+sr_bom_guard() { # FILE [LABEL] — 0 = no leading BOM; 1 + ::error otherwise
+  local label="${2:-$1}"
   if [ ! -r "$1" ]; then
-    sr_message error settings-unreadable "$1" "::error::$1: settings source is not readable" >&2
+    sr_message error settings-unreadable "$label" "::error::$label: settings source is not readable" >&2
     return 1
   fi
   if [ "$(head -c 3 < "$1" 2>/dev/null)" = "$(printf '\357\273\277')" ]; then
-    sr_message error settings-bom "$1" "::error::$1: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
+    sr_message error settings-bom "$label" "::error::$label: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
     return 1
   fi
 }
@@ -306,11 +307,11 @@ sr_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
 # containing `=` as a variable assignment and would read no input while the
 # resolver silently returns defaults. awk failing to read the source is an
 # unreadable source and fails loud, same discipline as sr_settings_grep.
-sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
+sr_env_table() { # FILE [LABEL] — [env]-table lines on stdout; 1 + ::error on a
                  # malformed header or leading BOM; 2 + ::error when unreadable
-  local status=0
-  sr_bom_guard "$1" || return 1
-  awk -v src="$1" '
+  local status=0 label="${2:-$1}"
+  sr_bom_guard "$1" "$label" || return 1
+  awk -v src="$label" '
     /^[[:space:]]*\[/ && !/^[[:space:]]*\[[A-Za-z0-9_.-]+\][[:space:]]*$/ {
       printf "doc-limits-error=settings-header value=%d\n::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", NR, src, NR > "/dev/stderr"
       exit 3
@@ -352,13 +353,13 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
   ' < "$1" || status=$?
   [ "$status" -ne 3 ] || return 1
   if [ "$status" -ne 0 ]; then
-    sr_message error settings-awk "$1" "::error::$1: unreadable while resolving a setting (awk exit $status)" >&2
+    sr_message error settings-awk "$label" "::error::$label: unreadable while resolving a setting (awk exit $status)" >&2
     return 2
   fi
 }
 
 sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
-  local name="$1" default="$2" line val file table status matches
+  local name="$1" default="$2" line val file source table status matches
   case "$name" in
     "" | [0-9]* | *[!A-Za-z0-9_]*)
       sr_message error settings-key "$name" "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
@@ -372,16 +373,17 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       set -- ".kendex/settings.toml" "kendex.settings.toml"
     fi
     for file in "$@"; do
+      source="$file"
       file="$(sr_settings_source "$file")" || return 1
       sr_settings_usable "$file" || return 1
       if [ -f "$file" ]; then
-        sr_env_table "$file" >/dev/null || return 1
+        sr_env_table "$file" "$source" >/dev/null || return 1
       fi
     done
     file="$(sr_settings_source ".env.local")" || return 1
     sr_settings_usable "$file" || return 1
     if [ -f "$file" ]; then
-      sr_bom_guard "$file" || return 1
+      sr_bom_guard "$file" ".env.local" || return 1
       if [ ! -r "$file" ]; then
         sr_message error settings-unreadable "$file" "::error::$file: unreadable while resolving a setting (permission denied)" >&2
         return 1
@@ -400,7 +402,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   local_env="$(sr_settings_source ".env.local")" || return 1
   sr_settings_usable "$local_env" || return 1
   if [ -f "$local_env" ]; then
-    sr_bom_guard "$local_env" || return 1
+    sr_bom_guard "$local_env" ".env.local" || return 1
     status=0
     matches="$(sr_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" "$local_env")" || status=$?
     [ "$status" -le 1 ] || return 1
@@ -415,10 +417,11 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     fi
   fi
   for file in "$@"; do
+  source="$file"
   file="$(sr_settings_source "$file")" || return 1
   sr_settings_usable "$file" || return 1
   if [ -f "$file" ]; then
-    table="$(sr_env_table "$file")" || return 1
+    table="$(sr_env_table "$file" "$source")" || return 1
     status=0
     matches="$(printf '%s\n' "$table" | grep -E -- "^[[:space:]]*${name}[[:space:]]*=")" || status=$?
     [ "$status" -le 1 ] || return 1

--- a/.agents/skills/doc-limits/scripts/lib/settings.sh
+++ b/.agents/skills/doc-limits/scripts/lib/settings.sh
@@ -35,10 +35,11 @@
 # Refusals start with the stable diagnostics protocol; source values remain
 # the resolver's stdout protocol and never include diagnostic text.
 sr_settings_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
-. "$sr_settings_script_dir/diagnostics.sh" 2>/dev/null || {
+if [ ! -f "$sr_settings_script_dir/diagnostics.sh" ] || [ ! -r "$sr_settings_script_dir/diagnostics.sh" ]; then
   printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
   return 1
-}
+fi
+. "$sr_settings_script_dir/diagnostics.sh"
 unset sr_settings_script_dir
 
 # Extract the value of one parsed dotenv assignment (text after `KEY=`).

--- a/.agents/skills/doc-limits/scripts/lib/settings.sh
+++ b/.agents/skills/doc-limits/scripts/lib/settings.sh
@@ -35,11 +35,14 @@
 # Refusals start with the stable diagnostics protocol; source values remain
 # the resolver's stdout protocol and never include diagnostic text.
 sr_settings_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
-if [ ! -f "$sr_settings_script_dir/diagnostics.sh" ] || [ ! -r "$sr_settings_script_dir/diagnostics.sh" ]; then
+if [ ! -r "$sr_settings_script_dir/diagnostics.sh" ]; then
   printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
   return 1
 fi
-. "$sr_settings_script_dir/diagnostics.sh"
+. "$sr_settings_script_dir/diagnostics.sh" 2>/dev/null || {
+  printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
+  return 1
+}
 unset sr_settings_script_dir
 
 # Extract the value of one parsed dotenv assignment (text after `KEY=`).

--- a/.agents/skills/doc-limits/tests/generated-paths.test.sh
+++ b/.agents/skills/doc-limits/tests/generated-paths.test.sh
@@ -33,6 +33,22 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
+must_fail_first_line() { # FORMER-LINE LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" != "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -87,7 +103,7 @@ if [ "$MODE_ASSERTIONS" -eq 0 ]; then
 fi
 
 INVENTORY_ASSERTIONS=0
-while IFS='|' read -r name mode operation expected; do
+while IFS='|' read -r name mode operation expected first_line; do
   case "$operation" in
     inventory-worktree-empty) printf '[]\n' >"$R/.kendex-generated.json" ;;
     unchanged) : ;;
@@ -119,6 +135,7 @@ while IFS='|' read -r name mode operation expected; do
   esac
   run_mode "$mode"
   expect "$expected" "$name: $mode"
+  [ -z "$first_line" ] || expect_first_line "$first_line" "$name diagnostic: $mode"
   INVENTORY_ASSERTIONS=$((INVENTORY_ASSERTIONS + 1))
 done <<'INVENTORY_CASES'
 inventory-worktree-empty|worktree|inventory-worktree-empty|1
@@ -127,8 +144,8 @@ inventory-empty-staged|staged|stage-empty|1
 inventory-deleted-from-index|staged|delete-from-index|1
 inventory-absent-small-document|staged|small-without-inventory|0
 inventory-worktree-missing-index-fallback|worktree|missing-worktree-fallback|0
-inventory-invalid|worktree|invalid-inventory|2
-inventory-invalid|staged|unchanged|2
+inventory-invalid|worktree|invalid-inventory|2|error=inventory-invalid path=.kendex-generated.json
+inventory-invalid|staged|unchanged|2|error=inventory-invalid path=.kendex-generated.json
 render-carved-back|worktree|carve-back|1
 render-carved-back|staged|unchanged|1
 INVENTORY_CASES
@@ -169,10 +186,21 @@ SR="$SOURCE_COMMAND"
 
 printf '{}\n' >"$R/.kendex-generated.json"
 git -C "$R" add .kendex-generated.json
+private_command inventory-diagnostic
+[ "$(grep -Fxc "  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'" "$MUTANT")" -eq 1 ]
+sed 's/collection_error inventory-invalid path/collection_error inventory-renamed path/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'error=inventory-invalid path=.kendex-generated.json' 'inventory diagnostic control: changing the stable key fails inventory-invalid'
+
 private_command inventory-parse
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc 'generated_paths_load "$inventory" || exit 2' "$MUTANT")" -eq 1 ]
-sed 's/^generated_paths_load "\$inventory" || exit 2$/generated_paths_load "$inventory" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc "  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'" "$MUTANT")" -eq 1 ]
+sed "s#^  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'\$#  || :#" "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/.agents/skills/doc-limits/tests/generated-paths.test.sh
+++ b/.agents/skills/doc-limits/tests/generated-paths.test.sh
@@ -129,6 +129,9 @@ while IFS='|' read -r name mode operation expected first_line; do
       printf '{}\n' >"$R/.kendex-generated.json"
       git -C "$R" add .kendex-generated.json
       ;;
+    inventory-unreadable)
+      chmod 000 "$R/.kendex-generated.json"
+      ;;
     carve-back)
       git -C "$R" checkout HEAD -- .kendex-generated.json
       printf '!.agents/skills/rendered/*\tmeasure this render explicitly\n' >"$R/tools/doc-limits-excludes"
@@ -150,11 +153,16 @@ inventory-invalid|worktree|invalid-inventory|2|error=inventory-invalid path=.ken
 inventory-invalid|staged|unchanged|2|error=inventory-invalid path=.kendex-generated.json
 render-carved-back|worktree|carve-back|1
 render-carved-back|staged|unchanged|1
+inventory-unreadable-shape|worktree|inventory-unreadable|2|error=inventory-read-failed path=.kendex-generated.json
 INVENTORY_CASES
 if [ "$INVENTORY_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: INVENTORY_CASES executed no assertions\n' >&2
   exit 1
 fi
+
+chmod 600 "$R/.kendex-generated.json"
+printf '[".agents/skills/rendered/SKILL.md"]\n' >"$R/.kendex-generated.json"
+git -C "$R" add .kendex-generated.json
 
 git -C "$R" rm -qf tools/doc-limits-excludes
 private_command generated-exclusion

--- a/.agents/skills/doc-limits/tests/generated-paths.test.sh
+++ b/.agents/skills/doc-limits/tests/generated-paths.test.sh
@@ -42,11 +42,13 @@ expect_first_line() { # EXPECTED LABEL
   fi
 }
 must_fail_first_line() { # FORMER-LINE LABEL
-  local first="${OUT%%$'\n'*}"
-  if [ "$first" != "$1" ]; then
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
     PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
   fi
 }
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -149,7 +149,7 @@ run
 expect 2 'diagnostics-load-failure'
 expect_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load failure'
 MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
-[ "$(grep -Fxc "  printf 'doc-limits-error=diagnostics-load value=%q\\n%s\\n' \"\$sr_settings_script_dir/diagnostics.sh\" 'Could not load the diagnostics library.' >&2" "$MUTANT_SETTINGS")" -eq 1 ]
+[ "$(grep -Fxc "  printf 'doc-limits-error=diagnostics-load value=%q\\n%s\\n' \"\$sr_settings_script_dir/diagnostics.sh\" 'Could not load the diagnostics library.' >&2" "$MUTANT_SETTINGS")" -eq 2 ]
 sed 's/doc-limits-error=diagnostics-load/doc-limits-error=diagnostics-renamed/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
 if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
 mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -178,6 +178,12 @@ done <<'INVALID_CLASS_CASES'
 =1k|class-pattern-empty|=1k
 INVALID_CLASS_CASES
 
+DOC_LIMITS_CLASSES="*.m$(printf '\t')d=1k"
+export DOC_LIMITS_CLASSES
+run
+expect 2 'invalid-class-tab-pattern'
+expect_first_line 'error=class-pattern-invalid setting=DOC_LIMITS_CLASSES' 'invalid-class-tab-pattern diagnostic'
+
 private_command invalid-classes
 [ ! -L "$MUTANT" ]
 [ "$(grep -Fxc 'parse_classes() { # SETTING-NAME VALUE — appends entries' "$MUTANT")" -eq 1 ]
@@ -276,6 +282,10 @@ while IFS='|' read -r name operation first_line; do
     header) printf '[env] # invalid\n' >"$R/.kendex/settings.toml" ;;
     syntax) printf '[env]\nDOC_LIMITS_CLASSES = 1\n' >"$R/.kendex/settings.toml" ;;
     dotenv) printf 'DOC_LIMITS_CLASSES="*.md=1k"tail\n' >"$R/.env.local" ;;
+    unreadable)
+      printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml"
+      chmod 000 "$R/.kendex/settings.toml"
+      ;;
   esac
   run
   expect 2 "$name"
@@ -288,6 +298,7 @@ settings-bom|bom|doc-limits-error=settings-bom value=.kendex/settings.toml
 settings-header|header|doc-limits-error=settings-header value=1
 settings-syntax|syntax|doc-limits-error=settings-syntax value=DOC_LIMITS_CLASSES
 settings-dotenv|dotenv|doc-limits-error=settings-dotenv value=DOC_LIMITS_CLASSES
+settings-unreadable|unreadable|doc-limits-error=settings-unreadable value=.kendex/settings.toml
 SETTINGS_ERROR_CASES
 if [ "$SETTINGS_ERROR_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: SETTINGS_ERROR_CASES executed no assertions\n' >&2
@@ -396,6 +407,12 @@ run
 expect 2 'outside-repository'
 expect_first_line "error=repository-root-missing path=$(printf '%q' "$R")" 'outside-repository diagnostic precedes Git stderr'
 R="$REPO_FIXTURE"
+
+export TMPDIR="$TMP/missing-temp-parent"
+run
+expect 2 'temporary-directory-parent-missing'
+expect_first_line "error=temp-create-failed path=$(printf '%q' "$TMPDIR")" 'temporary-directory diagnostic'
+unset TMPDIR
 
 # Git is the real producer of policy lookup, document enumeration, and blob sizes.
 REAL_GIT="$(command -v git)"

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -137,6 +137,14 @@ SR="$MUTANT"
 run
 expect 2 'diagnostics-load-failure'
 expect_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load failure'
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc "  printf 'doc-limits-error=diagnostics-load value=%q\\n%s\\n' \"\$sr_settings_script_dir/diagnostics.sh\" 'Could not load the diagnostics library.' >&2" "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/doc-limits-error=diagnostics-load/doc-limits-error=diagnostics-renamed/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+run
+must_fail_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load control: changing the stable key fails the refusal'
 sed 's#^source "\$SCRIPT_DIR/lib/settings.sh" || exit 2$#source "$SCRIPT_DIR/lib/settings.sh" || exit 1#' "$MUTANT" >"$MUTANT.changed"
 if cmp -s "$MUTANT" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
@@ -264,6 +272,14 @@ run --unknown
 expect 2 'unknown-option'
 expect_first_line 'error=argument-unknown argument=--unknown' 'unknown-option diagnostic'
 
+REPO_FIXTURE="$R"
+R="$TMP/outside-repository"
+mkdir "$R"
+run
+expect 2 'outside-repository'
+expect_first_line "error=repository-root-missing path=$(printf '%q' "$R")" 'outside-repository diagnostic precedes Git stderr'
+R="$REPO_FIXTURE"
+
 # Git is the real producer of policy lookup, document enumeration, and blob sizes.
 REAL_GIT="$(command -v git)"
 export REAL_GIT
@@ -314,8 +330,8 @@ fi
 
 private_command enumeration-guard
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
-sed 's/^git ls-files -s -z >"\$TMP\/files.z" || collection_error documents-enumeration-failed exit "\$?" "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" 2>/dev/null || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
+sed 's/^git ls-files -s -z >"\$TMP\/files.z" 2>\/dev\/null || collection_error documents-enumeration-failed exit "\$?" "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" 2>\/dev\/null || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -23,6 +23,22 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
+must_fail_first_line() { # FORMER-LINE LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" != "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -199,8 +215,25 @@ run
 must_fail 1 0 'carve-back control: disabling carve-back fails exclusion-carve-back'
 SR="$SOURCE_COMMAND"
 
+run --excludes
+expect 2 'missing-excludes-value'
+expect_first_line 'error=argument-value-missing option=--excludes' 'missing-excludes-value diagnostic'
+
+private_command excludes-diagnostic
+[ "$(grep -Fxc '      [ $# -ge 2 ] || config_error argument-value-missing option --excludes "--excludes requires a path"' "$MUTANT")" -eq 1 ]
+sed 's/config_error argument-value-missing option --excludes/config_error argument-value-renamed option --excludes/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --excludes
+must_fail_first_line 'error=argument-value-missing option=--excludes' 'diagnostic control: changing the stable key fails the missing-value assertion'
+SR="$SOURCE_COMMAND"
+
 run --unknown
 expect 2 'unknown-option'
+expect_first_line 'error=argument-unknown argument=--unknown' 'unknown-option diagnostic'
 
 # Git is the real producer of policy lookup, document enumeration, and blob sizes.
 REAL_GIT="$(command -v git)"
@@ -252,8 +285,8 @@ fi
 
 private_command enumeration-guard
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" || collection_error "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
-sed 's/^git ls-files -s -z >"\$TMP\/files.z" || collection_error "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
+sed 's/^git ls-files -s -z >"\$TMP\/files.z" || collection_error documents-enumeration-failed exit "\$?" "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"
@@ -265,8 +298,8 @@ must_fail 2 0 'collection table control: bypassing enumeration failure fails git
 
 private_command batch-guard
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc '  || collection_error "could not read document blob sizes"' "$MUTANT")" -eq 1 ]
-sed 's/^  || collection_error "could not read document blob sizes"$/  || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc '  || collection_error blob-sizes-read-failed exit "$?" "could not read document blob sizes"' "$MUTANT")" -eq 1 ]
+sed 's/^  || collection_error blob-sizes-read-failed exit "\$?" "could not read document blob sizes"$/  || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -129,6 +129,23 @@ run
 must_fail 1 0 'precedence table control: disabling .env.local fails dotenv-local-over-local'
 SR="$SOURCE_COMMAND"
 
+private_command diagnostics-load
+MUTANT_DIAGNOSTICS="$(dirname "$MUTANT")/lib/diagnostics.sh"
+[ "$(grep -Fxc 'source "$SCRIPT_DIR/lib/settings.sh" || exit 2' "$MUTANT")" -eq 1 ]
+rm "$MUTANT_DIAGNOSTICS"
+SR="$MUTANT"
+run
+expect 2 'diagnostics-load-failure'
+expect_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load failure'
+sed 's#^source "\$SCRIPT_DIR/lib/settings.sh" || exit 2$#source "$SCRIPT_DIR/lib/settings.sh" || exit 1#' "$MUTANT" >"$MUTANT.changed"
+if cmp -s "$MUTANT" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+run
+must_fail 2 1 'diagnostics-load control: wrong loader exit fails the refusal'
+SR="$SOURCE_COMMAND"
+
 for value in '*.md=0k' '*.md=400' '*.md=invalid' '*.md' '=1k'; do
   export DOC_LIMITS_CLASSES="$value"
   run
@@ -196,6 +213,18 @@ unset DOC_LIMITS_CLASSES
 printf '[env]\nDUP = "a"\nDUP = "b"\n' >"$R/kendex.settings.toml"
 run
 expect 2 'duplicate-settings-key'
+expect_first_line 'doc-limits-error=settings-duplicate value=DUP' 'duplicate-settings-key diagnostic'
+private_command settings-diagnostic
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc '        printf "doc-limits-error=settings-duplicate value=%s\n::error::%s: %s is assigned more than once in [env] (each key must be unique in the table)\n", key, src, key > "/dev/stderr"' "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/doc-limits-error=settings-duplicate value=%s/doc-limits-error=settings-renamed value=%s/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+SR="$MUTANT"
+run
+must_fail_first_line 'doc-limits-error=settings-duplicate value=DUP' 'settings diagnostic control: changing the stable key fails the duplicate assertion'
+SR="$SOURCE_COMMAND"
 rm "$R/kendex.settings.toml" "$R/.env.local" "$R/.kendex/settings.toml"
 printf '*.md\tfixture exception\n!AGENTS.md\tkeep root instructions checked\n' >"$R/tools/doc-limits-excludes"
 export DOC_LIMITS_CLASSES='*.md=1k'

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -66,6 +66,15 @@ private_command() { # NAME: copy the command and set MUTANT
   ln -s "$TEST_DIR/../../commit-guards" "$root/skills/commit-guards"
   MUTANT="$root/skills/doc-limits/scripts/doc-limits"
 }
+clear_settings_sources() {
+  local path="$R/.kendex/settings.toml"
+  if [ -L "$path" ] || [ -f "$path" ]; then
+    rm "$path"
+  elif [ -d "$path" ]; then
+    rmdir "$path"
+  fi
+  rm -f "$R/kendex.settings.toml" "$R/.env.local"
+}
 
 bytes AGENTS.md 2049
 git -C "$R" add AGENTS.md
@@ -255,7 +264,64 @@ SR="$MUTANT"
 run
 must_fail_first_line 'doc-limits-error=settings-duplicate value=DUP' 'settings diagnostic control: changing the stable key fails the duplicate assertion'
 SR="$SOURCE_COMMAND"
-rm "$R/kendex.settings.toml" "$R/.env.local" "$R/.kendex/settings.toml"
+clear_settings_sources
+
+SETTINGS_ERROR_ASSERTIONS=0
+while IFS='|' read -r name operation first_line; do
+  clear_settings_sources
+  case "$operation" in
+    dangling) ln -s missing "$R/.kendex/settings.toml" ;;
+    directory) mkdir "$R/.kendex/settings.toml" ;;
+    bom) printf '\357\273\277[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml" ;;
+    header) printf '[env] # invalid\n' >"$R/.kendex/settings.toml" ;;
+    syntax) printf '[env]\nDOC_LIMITS_CLASSES = 1\n' >"$R/.kendex/settings.toml" ;;
+    dotenv) printf 'DOC_LIMITS_CLASSES="*.md=1k"tail\n' >"$R/.env.local" ;;
+  esac
+  run
+  expect 2 "$name"
+  expect_first_line "$first_line" "$name diagnostic"
+  SETTINGS_ERROR_ASSERTIONS=$((SETTINGS_ERROR_ASSERTIONS + 1))
+done <<'SETTINGS_ERROR_CASES'
+settings-dangling-symlink|dangling|doc-limits-error=settings-symlink value=.kendex/settings.toml
+settings-directory|directory|doc-limits-error=settings-type value=.kendex/settings.toml
+settings-bom|bom|doc-limits-error=settings-bom value=.kendex/settings.toml
+settings-header|header|doc-limits-error=settings-header value=1
+settings-syntax|syntax|doc-limits-error=settings-syntax value=DOC_LIMITS_CLASSES
+settings-dotenv|dotenv|doc-limits-error=settings-dotenv value=DOC_LIMITS_CLASSES
+SETTINGS_ERROR_CASES
+if [ "$SETTINGS_ERROR_ASSERTIONS" -eq 0 ]; then
+  printf 'FAIL: SETTINGS_ERROR_CASES executed no assertions\n' >&2
+  exit 1
+fi
+
+clear_settings_sources
+ln -s missing "$R/.kendex/settings.toml"
+private_command settings-message
+MUTANT_DIAGNOSTICS="$(dirname "$MUTANT")/lib/diagnostics.sh"
+[ "$(grep -Fxc "  printf 'doc-limits-%s=%s value=%q\\n%s\\n' \"\$1\" \"\$2\" \"\$3\" \"\$4\"" "$MUTANT_DIAGNOSTICS")" -eq 1 ]
+sed 's/doc-limits-%s=%s/renamed-%s=%s/' "$MUTANT_DIAGNOSTICS" >"$MUTANT_DIAGNOSTICS.changed"
+if cmp -s "$MUTANT_DIAGNOSTICS" "$MUTANT_DIAGNOSTICS.changed"; then exit 1; fi
+mv "$MUTANT_DIAGNOSTICS.changed" "$MUTANT_DIAGNOSTICS"
+bash -n "$MUTANT_DIAGNOSTICS"
+SR="$MUTANT"
+run
+must_fail_first_line 'doc-limits-error=settings-symlink value=.kendex/settings.toml' 'settings formatter control: changing the stable prefix fails the symlink row'
+
+clear_settings_sources
+printf '[env] # invalid\n' >"$R/.kendex/settings.toml"
+private_command settings-awk-message
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc '      printf "doc-limits-error=settings-header value=%d\n::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", NR, src, NR > "/dev/stderr"' "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/doc-limits-error=settings-header value=%d/doc-limits-error=settings-header-renamed value=%d/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+SR="$MUTANT"
+run
+must_fail_first_line 'doc-limits-error=settings-header value=1' 'settings parser control: changing the stable key fails the header row'
+SR="$SOURCE_COMMAND"
+clear_settings_sources
+
 printf '*.md\tfixture exception\n!AGENTS.md\tkeep root instructions checked\n' >"$R/tools/doc-limits-excludes"
 export DOC_LIMITS_CLASSES='*.md=1k'
 run
@@ -288,6 +354,35 @@ bash -n "$MUTANT"
 SR="$MUTANT"
 run --excludes
 must_fail_first_line 'error=argument-value-missing option=--excludes' 'diagnostic control: changing the stable key fails the missing-value assertion'
+SR="$SOURCE_COMMAND"
+
+EXCLUDES_PATH_ASSERTIONS=0
+while IFS='|' read -r name argument key relevant; do
+  run "$argument"
+  expect 2 "$name"
+  expect_first_line "error=$key path=$(printf '%q' "$relevant")" "$name diagnostic"
+  EXCLUDES_PATH_ASSERTIONS=$((EXCLUDES_PATH_ASSERTIONS + 1))
+done <<'EXCLUDES_PATH_CASES'
+excludes-empty|--excludes=|excludes-path-empty|
+excludes-absolute|--excludes=/outside|excludes-path-absolute|/outside
+excludes-parent|--excludes=../outside|excludes-path-invalid|../outside
+excludes-option|--excludes=-outside|excludes-path-option|-outside
+EXCLUDES_PATH_CASES
+if [ "$EXCLUDES_PATH_ASSERTIONS" -eq 0 ]; then
+  printf 'FAIL: EXCLUDES_PATH_CASES executed no assertions\n' >&2
+  exit 1
+fi
+
+private_command excludes-path-diagnostic
+[ "$(grep -Fxc 'case "$EXCLUDES_FILE" in /*) config_error excludes-path-absolute path "$EXCLUDES_FILE" "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac' "$MUTANT")" -eq 1 ]
+sed 's/config_error excludes-path-absolute path/config_error excludes-path-absolute-renamed path/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --excludes=/outside
+must_fail_first_line 'error=excludes-path-absolute path=/outside' 'excludes-path control: changing the stable key fails the absolute row'
 SR="$SOURCE_COMMAND"
 
 run --unknown

--- a/.agents/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/.agents/skills/doc-limits/tests/settings-and-config.test.sh
@@ -32,11 +32,13 @@ expect_first_line() { # EXPECTED LABEL
   fi
 }
 must_fail_first_line() { # FORMER-LINE LABEL
-  local first="${OUT%%$'\n'*}"
-  if [ "$first" != "$1" ]; then
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
     PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
   fi
 }
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
@@ -154,11 +156,18 @@ run
 must_fail 2 1 'diagnostics-load control: wrong loader exit fails the refusal'
 SR="$SOURCE_COMMAND"
 
-for value in '*.md=0k' '*.md=400' '*.md=invalid' '*.md' '=1k'; do
+while IFS='|' read -r value key relevant; do
   export DOC_LIMITS_CLASSES="$value"
   run
   expect 2 "invalid-class: $value"
-done
+  expect_first_line "error=$key value=$(printf '%q' "$relevant")" "invalid-class diagnostic: $value"
+done <<'INVALID_CLASS_CASES'
+*.md=0k|class-threshold-invalid|0k
+*.md=400|class-threshold-invalid|400
+*.md=invalid|class-threshold-invalid|invalid
+*.md|class-entry-invalid|*.md
+=1k|class-pattern-empty|=1k
+INVALID_CLASS_CASES
 
 private_command invalid-classes
 [ ! -L "$MUTANT" ]
@@ -174,6 +183,19 @@ for value in '*.md=0k' '*.md=400' '*.md=invalid' '*.md' '=1k'; do
   run
   must_fail 2 0 "invalid-class table control: $value"
 done
+SR="$SOURCE_COMMAND"
+
+private_command class-diagnostic
+[ "$(grep -Fxc '      *) config_error class-threshold-invalid value "$craw" "$name: entry '\''$pair'\'' needs a positive integer with the '\''k'\'' byte suffix" ;;' "$MUTANT")" -eq 1 ]
+sed 's/config_error class-threshold-invalid value "$craw"/config_error class-threshold-renamed value "$craw"/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+export DOC_LIMITS_CLASSES='*.md=400'
+run
+must_fail_first_line 'error=class-threshold-invalid value=400' 'class diagnostic control: changing the stable key fails the suffix row'
 SR="$SOURCE_COMMAND"
 
 CLASS_ORDER_ASSERTIONS=0
@@ -310,23 +332,37 @@ chmod +x "$TMP/bin/git"
 export PATH="$TMP/bin:$PATH"
 
 COLLECTION_ASSERTIONS=0
-while IFS='|' read -r name fault expected; do
+while IFS='|' read -r name fault expected first_line; do
   export GIT_FAULT="$fault"
   run --staged
   expect "$expected" "$name"
+  expect_first_line "$first_line" "$name diagnostic"
   COLLECTION_ASSERTIONS=$((COLLECTION_ASSERTIONS + 1))
 done <<'COLLECTION_CASES'
-git-policy-lookup-failure|policy-lookup|2
-git-enumeration-failure|enumeration|2
-git-batch-empty-failure|batch-empty-failure|2
-git-batch-failure|batch-complete-failure|2
-empty-successful-batch-response|batch-empty-success|2
-collection-restored|none|1
+git-policy-lookup-failure|policy-lookup|2|doc-limits-error=settings-index-query value=9
+git-enumeration-failure|enumeration|2|error=documents-enumeration-failed exit=9
+git-batch-empty-failure|batch-empty-failure|2|error=blob-sizes-read-failed exit=9
+git-batch-failure|batch-complete-failure|2|error=blob-sizes-read-failed exit=9
+empty-successful-batch-response|batch-empty-success|2|error=blob-size-response-incomplete path=AGENTS.md
+collection-restored|none|1|notice=document-over-limit path=AGENTS.md
 COLLECTION_CASES
 if [ "$COLLECTION_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: COLLECTION_CASES executed no assertions\n' >&2
   exit 1
 fi
+
+private_command collection-diagnostic
+[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" 2>/dev/null || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
+sed 's/collection_error documents-enumeration-failed exit/collection_error documents-enumeration-renamed exit/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+export GIT_FAULT=enumeration
+run --staged
+must_fail_first_line 'error=documents-enumeration-failed exit=9' 'collection diagnostic control: changing the stable key fails enumeration'
+SR="$SOURCE_COMMAND"
 
 private_command enumeration-guard
 [ ! -L "$MUTANT" ]

--- a/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -32,11 +32,13 @@ expect_first_line() { # EXPECTED LABEL
   fi
 }
 must_fail_first_line() { # FORMER-LINE LABEL
-  local first="${OUT%%$'\n'*}"
-  if [ "$first" != "$1" ]; then
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
     PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
   fi
 }
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red

--- a/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -31,6 +31,14 @@ expect_first_line() { # EXPECTED LABEL
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
   fi
 }
+must_fail_first_line() { # FORMER-LINE LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" != "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -94,6 +102,21 @@ if [ "$CLASS_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: CLASSES executed no assertions\n' >&2
   exit 1
 fi
+
+bytes README.md 16384
+git -C "$R" add README.md
+private_command notice-protocol
+[ "$(grep -Fxc "  printf 'notice=%s %s=%q\\n' \"\$key\" \"\$field\" \"\$value\"" "$MUTANT")" -eq 1 ]
+sed "s/printf 'notice=%s %s=%q\\\\n'/printf 'renamed=%s %s=%q\\\\n'/" "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'notice=documents-checked count=1' 'notice protocol control: changing the formatter fails the pass notice'
+SR="$SOURCE_COMMAND"
+git -C "$R" rm -qf README.md
 
 bytes src/large.rs 100000
 git -C "$R" add src/large.rs

--- a/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -23,6 +23,14 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -56,13 +64,15 @@ while IFS=' ' read -r path limit; do
   git -C "$R" add -- "$path"
   run --staged
   expect 0 "$path at its class limit passes"
+  expect_first_line 'notice=documents-checked count=1' "$path pass notice"
   bytes "$path" "$((limit + 1))"
   git -C "$R" add -- "$path"
   run --staged
   expect 1 "$path one byte over fails"
+  expect_first_line "notice=document-over-limit path=$path" "$path failure notice"
   case "$OUT" in
-    *"$path: $((limit + 1)) bytes > $limit bytes"*) ;;
-    *) FAIL=$((FAIL + 1)); printf '  FAIL: wrong document or limit: %s\n' "$OUT" ;;
+    *"notice=documents-over-limit count=1"*) PASS=$((PASS + 1)); printf '  ok: %s\n' "$path failure count" ;;
+    *) FAIL=$((FAIL + 1)); printf '  FAIL: %s\n' "$path failure count" ;;
   esac
   git -C "$R" rm -qf -- "$path"
   CLASS_ASSERTIONS=$((CLASS_ASSERTIONS + 1))

--- a/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -120,6 +120,36 @@ must_fail_first_line 'notice=documents-checked count=1' 'notice protocol control
 SR="$SOURCE_COMMAND"
 git -C "$R" rm -qf README.md
 
+DOCUMENT_PATH="bad$(printf '\t')path.md"
+bytes "$DOCUMENT_PATH" 1
+git -C "$R" add -- "$DOCUMENT_PATH"
+run --staged
+expect 2 'document-path-tab'
+expect_first_line "error=document-path-invalid path=$(printf '%q' "$DOCUMENT_PATH")" 'document-path-tab diagnostic'
+git -C "$R" rm -qf -- "$DOCUMENT_PATH"
+
+printf 'conflict\n' >"$R/conflict.md"
+git -C "$R" add conflict.md
+CONFLICT_OID="$(git -C "$R" hash-object conflict.md)"
+git -C "$R" rm -q --cached conflict.md
+printf '100644 %s 1\tconflict.md\n100644 %s 2\tconflict.md\n100644 %s 3\tconflict.md\n' "$CONFLICT_OID" "$CONFLICT_OID" "$CONFLICT_OID" | git -C "$R" update-index --index-info
+run --staged
+expect 2 'document-unmerged'
+expect_first_line 'error=document-unmerged path=conflict.md' 'document-unmerged diagnostic'
+private_command document-diagnostic
+[ "$(grep -Fxc '  [ "${entry##* }" = 0 ] || collection_error document-unmerged path "$f" "tracked document is unmerged: $f"' "$MUTANT")" -eq 1 ]
+sed 's/collection_error document-unmerged path/collection_error document-unmerged-renamed path/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'error=document-unmerged path=conflict.md' 'document diagnostic control: changing the stable key fails the unmerged row'
+SR="$SOURCE_COMMAND"
+git -C "$R" update-index --force-remove conflict.md
+rm "$R/conflict.md"
+
 bytes src/large.rs 100000
 git -C "$R" add src/large.rs
 export DOC_LIMITS_CLASSES='*=1k'
@@ -145,11 +175,15 @@ bytes AGENTS.md 16385
 git -C "$R" add AGENTS.md
 EXCLUSION_ASSERTIONS=0
 while IFS='|' read -r name operation expected first_line; do
+  rm -f "$R/tools/doc-limits-excludes"
   case "$operation" in
     reasoned) printf 'AGENTS.md\tdeliberate fixture exception\n' >"$R/tools/doc-limits-excludes" ;;
     missing-reason) printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes" ;;
     removed) : >"$R/tools/doc-limits-excludes" ;;
     empty-carve) printf '!\tmissing pattern\n' >"$R/tools/doc-limits-excludes" ;;
+    symlink)
+      ln -s ../AGENTS.md "$R/tools/doc-limits-excludes"
+      ;;
   esac
   git -C "$R" add tools/doc-limits-excludes
   run --staged
@@ -161,12 +195,14 @@ reasoned-exclusion|reasoned|0|notice=documents-checked count=0
 exclusion-missing-reason|missing-reason|2|error=excludes-row-invalid line=1
 exclusion-removed|removed|1|notice=document-over-limit path=AGENTS.md
 exclusion-empty-carve|empty-carve|2|error=excludes-carve-empty line=1
+exclusion-symlink|symlink|2|error=excludes-mode-invalid mode=120000
 EXCLUSION_CASES
 if [ "$EXCLUSION_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: EXCLUSION_CASES executed no assertions\n' >&2
   exit 1
 fi
 
+rm -f "$R/tools/doc-limits-excludes"
 printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes"
 git -C "$R" add tools/doc-limits-excludes
 private_command exclusion-diagnostic

--- a/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/.agents/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -144,25 +144,42 @@ git -C "$R" rm -qf src/large.rs
 bytes AGENTS.md 16385
 git -C "$R" add AGENTS.md
 EXCLUSION_ASSERTIONS=0
-while IFS='|' read -r name operation expected; do
+while IFS='|' read -r name operation expected first_line; do
   case "$operation" in
     reasoned) printf 'AGENTS.md\tdeliberate fixture exception\n' >"$R/tools/doc-limits-excludes" ;;
     missing-reason) printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes" ;;
     removed) : >"$R/tools/doc-limits-excludes" ;;
+    empty-carve) printf '!\tmissing pattern\n' >"$R/tools/doc-limits-excludes" ;;
   esac
   git -C "$R" add tools/doc-limits-excludes
   run --staged
   expect "$expected" "$name"
+  expect_first_line "$first_line" "$name diagnostic"
   EXCLUSION_ASSERTIONS=$((EXCLUSION_ASSERTIONS + 1))
 done <<'EXCLUSION_CASES'
-reasoned-exclusion|reasoned|0
-exclusion-missing-reason|missing-reason|2
-exclusion-removed|removed|1
+reasoned-exclusion|reasoned|0|notice=documents-checked count=0
+exclusion-missing-reason|missing-reason|2|error=excludes-row-invalid line=1
+exclusion-removed|removed|1|notice=document-over-limit path=AGENTS.md
+exclusion-empty-carve|empty-carve|2|error=excludes-carve-empty line=1
 EXCLUSION_CASES
 if [ "$EXCLUSION_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: EXCLUSION_CASES executed no assertions\n' >&2
   exit 1
 fi
+
+printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes"
+git -C "$R" add tools/doc-limits-excludes
+private_command exclusion-diagnostic
+[ "$(grep -Fxc '      config_error excludes-row-invalid line "$lineno" "$EXCLUDES_LABEL:$lineno: expected '\''pattern<TAB>reason'\'' (every exclusion carries its justification)"' "$MUTANT")" -eq 1 ]
+sed 's/config_error excludes-row-invalid line/config_error excludes-row-renamed line/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'error=excludes-row-invalid line=1' 'exclusion diagnostic control: changing the stable key fails the malformed row'
+SR="$SOURCE_COMMAND"
 
 printf 'AGENTS.md\tdeliberate fixture exception\n' >"$R/tools/doc-limits-excludes"
 git -C "$R" add tools/doc-limits-excludes

--- a/.agents/skills/doc-limits/tests/staged-scope.test.sh
+++ b/.agents/skills/doc-limits/tests/staged-scope.test.sh
@@ -130,8 +130,8 @@ git -C "$R" commit -qm 'control fixture'
 printf 'AGENTS.md\tfixture exception\n' >"$R/tools/doc-limits-excludes"
 private_command exclusion-source
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc '  git show ":$1" >"$TMP/excludes" \' "$MUTANT")" -eq 1 ]
-sed 's#  git show ":\$1" >"\$TMP/excludes" \\#  cp -- "$1" "$TMP/excludes" \\#' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc '  git show ":$1" >"$TMP/excludes" 2>/dev/null \' "$MUTANT")" -eq 1 ]
+sed 's#  git show ":\$1" >"\$TMP/excludes" 2>/dev/null \\#  cp -- "$1" "$TMP/excludes" 2>/dev/null \\#' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/.agents/skills/doc-limits/tests/staged-scope.test.sh
+++ b/.agents/skills/doc-limits/tests/staged-scope.test.sh
@@ -23,6 +23,24 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
+must_fail_first_line() { # FORMER-LINE LABEL
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -148,7 +166,7 @@ git -C "$R" add AGENTS.md
 unset DOC_LIMITS_CLASSES
 
 SETTINGS_ASSERTIONS=0
-while IFS='|' read -r name operation mode expected; do
+while IFS='|' read -r name operation mode expected first_line; do
   case "$operation" in
     split-settings)
       printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
@@ -162,24 +180,46 @@ while IFS='|' read -r name operation mode expected; do
       git -C "$R" rm -q --cached kendex.settings.toml
       printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
       ;;
+    stage-bom)
+      rm "$R/kendex.settings.toml"
+      mkdir -p "$R/.kendex"
+      printf '\357\273\277[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml"
+      git -C "$R" add .kendex/settings.toml
+      ;;
   esac
   case "$mode" in
     worktree) run ;;
     staged) run --staged ;;
   esac
   expect "$expected" "$name"
+  [ -z "$first_line" ] || expect_first_line "$first_line" "$name diagnostic"
   SETTINGS_ASSERTIONS=$((SETTINGS_ASSERTIONS + 1))
 done <<'SETTINGS_CASES'
 settings-staged-strict|split-settings|staged|1
 settings-worktree-relaxed|unchanged|worktree|0
 settings-relaxed-staged|stage-relaxed|staged|0
 settings-deleted-from-index|delete-settings|staged|0
+settings-staged-bom|stage-bom|staged|2|doc-limits-error=settings-bom value=.kendex/settings.toml
 SETTINGS_CASES
 if [ "$SETTINGS_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: SETTINGS_CASES executed no assertions\n' >&2
   exit 1
 fi
 
+private_command staged-settings-label
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc '        sr_env_table "$file" "$source" >/dev/null || return 1' "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/^        sr_env_table "\$file" "\$source" >\/dev\/null || return 1$/        sr_env_table "$file" >\/dev\/null || return 1/' "$TEST_DIR/../scripts/lib/settings.sh" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$TEST_DIR/../scripts/lib/settings.sh" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'doc-limits-error=settings-bom value=.kendex/settings.toml' 'staged settings label control: the snapshot path fails the BOM row'
+SR="$SOURCE_COMMAND"
+
+git -C "$R" rm -qf .kendex/settings.toml
+printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
 git -C "$R" add kendex.settings.toml
 git -C "$R" commit -qm 'strict settings control'
 printf '[env]\nDOC_LIMITS_CLASSES = "*.md=2k"\n' >"$R/kendex.settings.toml"

--- a/.agents/skills/doc-limits/tests/staged-scope.test.sh
+++ b/.agents/skills/doc-limits/tests/staged-scope.test.sh
@@ -181,9 +181,15 @@ while IFS='|' read -r name operation mode expected first_line; do
       printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
       ;;
     stage-bom)
-      rm "$R/kendex.settings.toml"
+      rm -f "$R/kendex.settings.toml" "$R/.kendex/settings.toml"
       mkdir -p "$R/.kendex"
       printf '\357\273\277[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml"
+      git -C "$R" add .kendex/settings.toml
+      ;;
+    stage-symlink)
+      rm -f "$R/kendex.settings.toml" "$R/.kendex/settings.toml"
+      mkdir -p "$R/.kendex"
+      ln -s ../kendex.settings.toml "$R/.kendex/settings.toml"
       git -C "$R" add .kendex/settings.toml
       ;;
   esac
@@ -199,6 +205,7 @@ settings-staged-strict|split-settings|staged|1
 settings-worktree-relaxed|unchanged|worktree|0
 settings-relaxed-staged|stage-relaxed|staged|0
 settings-deleted-from-index|delete-settings|staged|0
+settings-staged-symlink|stage-symlink|staged|2|doc-limits-error=settings-index-symlink value=.kendex/settings.toml
 settings-staged-bom|stage-bom|staged|2|doc-limits-error=settings-bom value=.kendex/settings.toml
 SETTINGS_CASES
 if [ "$SETTINGS_ASSERTIONS" -eq 0 ]; then

--- a/skills/doc-limits/scripts/doc-limits
+++ b/skills/doc-limits/scripts/doc-limits
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Diagnostic protocol: refusals start error=KEY FIELD=VALUE; notices start
+# notice=KEY FIELD=VALUE. English detail follows on the next line.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/settings.sh
@@ -33,20 +35,30 @@ Class selection and exclusions: references/policy.md.
 Exit codes: 0 clean; 1 over-limit documents; 2 usage/config/collection error.
 EOF
 }
+diagnostic() {
+  local level="$1" key="$2" field="$3" value="$4" text="$5"
+  printf '%s=%s %s=%q\n' "$level" "$key" "$field" "$value" >&2
+  printf '::error::doc-limits: %s\n' "$text" >&2
+}
 config_error() {
-  echo "::error::doc-limits: $*" >&2
+  diagnostic error "$1" "$2" "$3" "$4"
   exit 2
 }
 collection_error() {
-  echo "::error::doc-limits: $*" >&2
+  diagnostic error "$1" "$2" "$3" "$4"
   exit 2
+}
+notice() {
+  local key="$1" field="$2" value="$3" text="$4"
+  printf 'notice=%s %s=%q\n' "$key" "$field" "$value"
+  printf '%s\n' "$text"
 }
 EXCLUDES_OPT=""
 EXCLUDES_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --excludes)
-      [ $# -ge 2 ] || config_error "--excludes requires a path"
+      [ $# -ge 2 ] || config_error argument-value-missing option --excludes "--excludes requires a path"
       shift
       EXCLUDES_OPT="$1"
       EXCLUDES_SET=1
@@ -54,13 +66,13 @@ while [ $# -gt 0 ]; do
     --excludes=*) EXCLUDES_OPT="${1#--excludes=}"; EXCLUDES_SET=1 ;;
     -h | --help) usage; exit 0 ;;
     --staged) STAGED=1 ;;
-    *) config_error "unknown argument '$1' (see --help)" ;;
+    *) config_error argument-unknown argument "$1" "unknown argument '$1' (see --help)" ;;
   esac
   shift
 done
-REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error "not inside a git repository"
-cd "$REPO_ROOT" || config_error "could not enter the repository root $REPO_ROOT"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX")" || config_error "could not create a temporary directory"
+REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error repository-root-missing path "$PWD" "not inside a git repository"
+cd "$REPO_ROOT" || config_error repository-root-unreadable path "$REPO_ROOT" "could not enter the repository root $REPO_ROOT"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX")" || config_error temp-create-failed path "${TMPDIR:-/tmp}" "could not create a temporary directory"
 trap 'rm -rf -- "${TMP:?}"' EXIT
 if [ "$STAGED" -eq 1 ]; then
   SR_SETTINGS_FROM_INDEX=1
@@ -88,22 +100,22 @@ parse_classes() { # SETTING-NAME VALUE — appends entries
     [ -n "$pair" ] || continue
     case "$pair" in
       *"="*) ;;
-      *) config_error "$name: entry '$pair' is not 'pattern=threshold'" ;;
+      *) config_error class-entry-invalid value "$pair" "$name: entry '$pair' is not 'pattern=threshold'" ;;
     esac
     cpat="${pair%=*}"
     craw="${pair##*=}"
     cpat="${cpat%"${cpat##*[![:space:]]}"}"
     craw="${craw#"${craw%%[![:space:]]*}"}"
-    [ -n "$cpat" ] || config_error "$name: entry '$pair' has an empty pattern"
+    [ -n "$cpat" ] || config_error class-pattern-empty value "$pair" "$name: entry '$pair' has an empty pattern"
     case "$cpat" in
-      *"$TAB"* | *"$NL"*) config_error "$name: entry '$pair' has a tab or newline in its pattern; the mapping is one line" ;;
+      *"$TAB"* | *"$NL"*) config_error class-pattern-invalid setting "$name" "$name: entry '$pair' has a tab or newline in its pattern; the mapping is one line" ;;
     esac
     case "$craw" in
       *k) cthr="${craw%k}" ;;
-      *) config_error "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
+      *) config_error class-threshold-invalid value "$craw" "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
     esac
     case "$cthr" in
-      "" | *[!0-9]* | 0*[0-9] | 0) config_error "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
+      "" | *[!0-9]* | 0*[0-9] | 0) config_error class-threshold-invalid value "$craw" "$name: entry '$pair' needs a positive integer with the 'k' byte suffix" ;;
     esac
     cthr=$((cthr * 1024))
     CLASS_PATTERNS+=("$cpat")
@@ -116,7 +128,7 @@ parse_classes DOC_LIMITS_CLASSES "$CLASSES"
 DEFAULT_CLASSES="$(sr_setting DOC_LIMITS_DEFAULT_CLASSES "$SHIPPED_CLASSES")" || exit 2
 parse_classes DOC_LIMITS_DEFAULT_CLASSES "$DEFAULT_CLASSES"
 if [ "$EXCLUDES_SET" = "1" ]; then
-  [ -n "$EXCLUDES_OPT" ] || config_error "--excludes was given an empty path; pass a real path or omit the flag to use the configured default"
+  [ -n "$EXCLUDES_OPT" ] || config_error excludes-path-empty path "$EXCLUDES_OPT" "--excludes was given an empty path; pass a real path or omit the flag to use the configured default"
   EXCLUDES_FILE="$EXCLUDES_OPT"
 else
   EXCLUDES_FILE="$(sr_setting DOC_LIMITS_EXCLUDES "tools/doc-limits-excludes")" || exit 2
@@ -142,10 +154,11 @@ normalize_rel_path() { # PATH -> normalized on stdout; nonzero if it escapes
   [ -n "$out" ] || return 1
   printf '%s' "$out"
 }
-case "$EXCLUDES_FILE" in /*) config_error "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
-EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error "excludes path escapes the repository or normalizes empty"
-[ -n "$EXCLUDES_FILE" ] || config_error "excludes path resolved empty"
-case "$EXCLUDES_FILE" in -*) config_error "excludes path must not begin with '-': $EXCLUDES_FILE" ;; /*) config_error "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
+case "$EXCLUDES_FILE" in /*) config_error excludes-path-absolute path "$EXCLUDES_FILE" "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
+raw_excludes_file="$EXCLUDES_FILE"
+EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error excludes-path-invalid path "$raw_excludes_file" "excludes path escapes the repository or normalizes empty"
+[ -n "$EXCLUDES_FILE" ] || config_error excludes-path-empty path "$raw_excludes_file" "excludes path resolved empty"
+case "$EXCLUDES_FILE" in -*) config_error excludes-path-option path "$EXCLUDES_FILE" "excludes path must not begin with '-': $EXCLUDES_FILE" ;; /*) config_error excludes-path-absolute path "$EXCLUDES_FILE" "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
 staged_policy_state() { # PATH
   [ "$STAGED" -eq 1 ] || return 1
   read_index_file_mode "$1"
@@ -158,7 +171,7 @@ INDEX_FILE_MODE=""
 read_index_file_mode() { # PATH — sets INDEX_FILE_MODE ("" when untracked)
   local entry status=0
   entry="$(git ls-files -s -- ":(literal)$1")" || status=$?
-  [ "$status" -eq 0 ] || collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
+  [ "$status" -eq 0 ] || collection_error index-query-failed exit "$status" "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
   INDEX_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || INDEX_FILE_MODE=""
 }
@@ -172,20 +185,20 @@ read_head_file_mode() { # PATH — sets HEAD_FILE_MODE ("" when HEAD carries no 
   case "$head_status" in
     0) HEAD_EXISTS=1 ;;
     1) return 0 ;;
-    *) collection_error "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
+    *) collection_error head-query-failed exit "$head_status" "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
   esac
   entry="$(git ls-tree HEAD -- ":(literal)$1")" || status=$?
-  [ "$status" -eq 0 ] || collection_error "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
+  [ "$status" -eq 0 ] || collection_error head-tree-query-failed exit "$status" "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
   HEAD_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || HEAD_FILE_MODE=""
 }
 read_policy_from_index() { # PATH — stages the index copy of the list at $TMP/excludes
   case "$INDEX_FILE_MODE" in
     100*) ;;
-    *) config_error "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
+    *) config_error excludes-mode-invalid mode "$INDEX_FILE_MODE" "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
   esac
   git show ":$1" >"$TMP/excludes" \
-    || collection_error "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
+    || collection_error excludes-index-read-failed path "$1" "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
 }
 EXCLUDES_SOURCE="$EXCLUDES_FILE"
 EXCLUDES_LABEL="$EXCLUDES_FILE"
@@ -208,14 +221,14 @@ case "$excludes_state" in
     fi
     ;;
   2)
-    : >"$TMP/excludes" || collection_error "could not initialize the excludes scratch file"
+    : >"$TMP/excludes" || collection_error excludes-scratch-failed path "$TMP/excludes" "could not initialize the excludes scratch file"
     EXCLUDES_SOURCE="$TMP/excludes"
     ;;
 esac
 EXCLUDE_PATTERNS=()
 CARVE_PATTERNS=()
 if [ -f "$EXCLUDES_SOURCE" ]; then
-  [ -r "$EXCLUDES_SOURCE" ] || config_error "$EXCLUDES_LABEL: exists but cannot be read"
+  [ -r "$EXCLUDES_SOURCE" ] || config_error excludes-unreadable path "$EXCLUDES_LABEL" "$EXCLUDES_LABEL: exists but cannot be read"
   lineno=0
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))
@@ -225,7 +238,7 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     pat="${line%%"$TAB"*}"
     reason="${line#*"$TAB"}"
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
-      config_error "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+      config_error excludes-row-invalid line "$lineno" "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
     # A `!` pattern CARVES its matches back into the measured set, the only
     # way to govern documents living inside an excluded render tree
@@ -235,7 +248,7 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
       "!"*)
         carve="${pat#!}"
         [ -n "$carve" ] \
-          || config_error "$EXCLUDES_LABEL:$lineno: '!' carves matching paths back into the measured set and needs a pattern after it"
+          || config_error excludes-carve-empty line "$lineno" "$EXCLUDES_LABEL:$lineno: '!' carves matching paths back into the measured set and needs a pattern after it"
         CARVE_PATTERNS+=("$carve")
         ;;
       *) EXCLUDE_PATTERNS+=("$pat") ;;
@@ -257,7 +270,7 @@ if [ "$STAGED" -eq 0 ] && [ ! -f "$INVENTORY_SOURCE" ]; then
   read_index_file_mode .kendex-generated.json
   if [ -n "$INDEX_FILE_MODE" ]; then
     git show :0:.kendex-generated.json >"$TMP/generated.json" \
-      || collection_error 'cannot read .kendex-generated.json from the index; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
+      || collection_error inventory-index-read-failed path .kendex-generated.json 'cannot read .kendex-generated.json from the index; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
     INVENTORY_SOURCE="$TMP/generated.json"
   fi
 fi
@@ -270,7 +283,7 @@ if [ ! -e "$INVENTORY_SOURCE" ] && [ ! -L "$INVENTORY_SOURCE" ]; then
   inventory='[]'
 else
   inventory="$(cat -- "$INVENTORY_SOURCE")" \
-    || collection_error 'cannot read .kendex-generated.json; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
+    || collection_error inventory-read-failed path "$INVENTORY_SOURCE" 'cannot read .kendex-generated.json; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
 fi
 generated_paths_load "$inventory" || exit 2
 is_excluded() { # PATH — inclusion rows override both exclusion sources
@@ -292,7 +305,7 @@ path_threshold() { # PATH: first matching class, or no limit
 }
 # The index supplies both the tracked set and blob IDs. A single batch reads
 # their sizes, so staged checks do not materialize every document.
-git ls-files -s -z >"$TMP/files.z" || collection_error "could not enumerate tracked documents"
+git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"
 : >"$TMP/documents.tsv"
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
@@ -300,38 +313,38 @@ while IFS= read -r -d '' rec; do
   case "$f" in *.md) ;; *) continue ;; esac
   case "$mode" in 120000 | 160000) continue ;; esac
   case "$f" in
-    *"$NL"* | *"$TAB"*) config_error "tracked document path contains a tab or newline: '$f'" ;;
+    *"$NL"* | *"$TAB"*) config_error document-path-invalid path "$f" "tracked document path contains a tab or newline: '$f'" ;;
   esac
   is_excluded "$f" && continue
   path_threshold "$f"
   [ -n "$PT" ] || continue
   entry="${rec%%"$TAB"*}"
-  [ "${entry##* }" = 0 ] || collection_error "tracked document is unmerged: $f"
+  [ "${entry##* }" = 0 ] || collection_error document-unmerged path "$f" "tracked document is unmerged: $f"
   oid="${entry#* }"
   oid="${oid%% *}"
   printf '%s\t%s\t%s\t%s\n' "$oid" "$f" "$PT" "$PC" >>"$TMP/documents.tsv"
 done <"$TMP/files.z"
 cut -f1 "$TMP/documents.tsv" | git cat-file --batch-check >"$TMP/sizes" \
-  || collection_error "could not read document blob sizes"
+  || collection_error blob-sizes-read-failed exit "$?" "could not read document blob sizes"
 checked=0 violations=0
 while IFS="$TAB" read -r oid f limit class; do
-  IFS=' ' read -r actual_oid kind n <&3 || collection_error "document size response is incomplete: $f"
+  IFS=' ' read -r actual_oid kind n <&3 || collection_error blob-size-response-incomplete path "$f" "document size response is incomplete: $f"
   [ "$actual_oid" = "$oid" ] && [ "$kind" = blob ] \
-    || collection_error "could not read document blob: $f"
+    || collection_error document-blob-read-failed path "$f" "could not read document blob: $f"
   if [ "$STAGED" -eq 0 ] && [ -f "$f" ] && [ ! -L "$f" ]; then
-    n="$(wc -c <"$f")" || collection_error "could not measure tracked document: $f"
+    n="$(wc -c <"$f")" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
     n="${n#"${n%%[![:space:]]*}"}"
   fi
-  case "$n" in "" | *[!0-9]*) collection_error "invalid byte count for tracked document: $f" ;; esac
+  case "$n" in "" | *[!0-9]*) collection_error document-byte-count-invalid path "$f" "invalid byte count for tracked document: $f" ;; esac
   if [ "$n" -gt "$limit" ]; then
-    printf 'doc-limits FAIL: %s: %s bytes > %s bytes (class %s)\n' "$f" "$n" "$limit" "$class"
+    notice document-over-limit path "$f" "doc-limits FAIL: $f: $n bytes > $limit bytes (class $class)"
     printf '  remedy: split the document at a natural seam, move detail to a linked reference, or delete content the code or another document already states; a document that must stay whole gets a row in %s with its reason\n' "$EXCLUDES_FILE"
     violations=$((violations + 1))
   fi
   checked=$((checked + 1))
 done <"$TMP/documents.tsv" 3<"$TMP/sizes"
 if [ "$violations" -gt 0 ]; then
-  printf 'doc-limits: %s over-limit document(s), %s checked\n' "$violations" "$checked"
+  notice documents-over-limit count "$violations" "doc-limits: $violations over-limit document(s), $checked checked"
   exit 1
 fi
-printf 'doc-limits: OK: %s document(s) checked\n' "$checked"
+notice documents-checked count "$checked" "doc-limits: OK: $checked document(s) checked"

--- a/skills/doc-limits/scripts/doc-limits
+++ b/skills/doc-limits/scripts/doc-limits
@@ -70,9 +70,9 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error repository-root-missing path "$PWD" "not inside a git repository"
-cd "$REPO_ROOT" || config_error repository-root-unreadable path "$REPO_ROOT" "could not enter the repository root $REPO_ROOT"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX")" || config_error temp-create-failed path "${TMPDIR:-/tmp}" "could not create a temporary directory"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || config_error repository-root-missing path "$PWD" "not inside a git repository"
+cd "$REPO_ROOT" 2>/dev/null || config_error repository-root-unreadable path "$REPO_ROOT" "could not enter the repository root $REPO_ROOT"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doc-limits.XXXXXX" 2>/dev/null)" || config_error temp-create-failed path "${TMPDIR:-/tmp}" "could not create a temporary directory"
 trap 'rm -rf -- "${TMP:?}"' EXIT
 if [ "$STAGED" -eq 1 ]; then
   SR_SETTINGS_FROM_INDEX=1
@@ -170,7 +170,7 @@ staged_policy_state() { # PATH
 INDEX_FILE_MODE=""
 read_index_file_mode() { # PATH — sets INDEX_FILE_MODE ("" when untracked)
   local entry status=0
-  entry="$(git ls-files -s -- ":(literal)$1")" || status=$?
+  entry="$(git ls-files -s -- ":(literal)$1" 2>/dev/null)" || status=$?
   [ "$status" -eq 0 ] || collection_error index-query-failed exit "$status" "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
   INDEX_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || INDEX_FILE_MODE=""
@@ -187,7 +187,7 @@ read_head_file_mode() { # PATH — sets HEAD_FILE_MODE ("" when HEAD carries no 
     1) return 0 ;;
     *) collection_error head-query-failed exit "$head_status" "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
   esac
-  entry="$(git ls-tree HEAD -- ":(literal)$1")" || status=$?
+  entry="$(git ls-tree HEAD -- ":(literal)$1" 2>/dev/null)" || status=$?
   [ "$status" -eq 0 ] || collection_error head-tree-query-failed exit "$status" "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
   HEAD_FILE_MODE="${entry%% *}"
   [ -n "$entry" ] || HEAD_FILE_MODE=""
@@ -197,7 +197,7 @@ read_policy_from_index() { # PATH — stages the index copy of the list at $TMP/
     100*) ;;
     *) config_error excludes-mode-invalid mode "$INDEX_FILE_MODE" "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
   esac
-  git show ":$1" >"$TMP/excludes" \
+  git show ":$1" >"$TMP/excludes" 2>/dev/null \
     || collection_error excludes-index-read-failed path "$1" "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
 }
 EXCLUDES_SOURCE="$EXCLUDES_FILE"
@@ -269,7 +269,7 @@ INVENTORY_SOURCE="$(sr_settings_source .kendex-generated.json)" || exit 2
 if [ "$STAGED" -eq 0 ] && [ ! -f "$INVENTORY_SOURCE" ]; then
   read_index_file_mode .kendex-generated.json
   if [ -n "$INDEX_FILE_MODE" ]; then
-    git show :0:.kendex-generated.json >"$TMP/generated.json" \
+    git show :0:.kendex-generated.json >"$TMP/generated.json" 2>/dev/null \
       || collection_error inventory-index-read-failed path .kendex-generated.json 'cannot read .kendex-generated.json from the index; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
     INVENTORY_SOURCE="$TMP/generated.json"
   fi
@@ -282,10 +282,11 @@ fi
 if [ ! -e "$INVENTORY_SOURCE" ] && [ ! -L "$INVENTORY_SOURCE" ]; then
   inventory='[]'
 else
-  inventory="$(cat -- "$INVENTORY_SOURCE")" \
+  inventory="$(cat -- "$INVENTORY_SOURCE" 2>/dev/null)" \
     || collection_error inventory-read-failed path "$INVENTORY_SOURCE" 'cannot read .kendex-generated.json; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
 fi
-generated_paths_load "$inventory" || exit 2
+generated_paths_load "$inventory" 2>/dev/null \
+  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
 is_excluded() { # PATH — inclusion rows override both exclusion sources
   generated_path_contains "$1" \
     || glob_match "$1" ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"} || return 1
@@ -305,7 +306,7 @@ path_threshold() { # PATH: first matching class, or no limit
 }
 # The index supplies both the tracked set and blob IDs. A single batch reads
 # their sizes, so staged checks do not materialize every document.
-git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"
+git ls-files -s -z >"$TMP/files.z" 2>/dev/null || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"
 : >"$TMP/documents.tsv"
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
@@ -324,7 +325,7 @@ while IFS= read -r -d '' rec; do
   oid="${oid%% *}"
   printf '%s\t%s\t%s\t%s\n' "$oid" "$f" "$PT" "$PC" >>"$TMP/documents.tsv"
 done <"$TMP/files.z"
-cut -f1 "$TMP/documents.tsv" | git cat-file --batch-check >"$TMP/sizes" \
+cut -f1 "$TMP/documents.tsv" 2>/dev/null | git cat-file --batch-check >"$TMP/sizes" 2>/dev/null \
   || collection_error blob-sizes-read-failed exit "$?" "could not read document blob sizes"
 checked=0 violations=0
 while IFS="$TAB" read -r oid f limit class; do
@@ -332,7 +333,7 @@ while IFS="$TAB" read -r oid f limit class; do
   [ "$actual_oid" = "$oid" ] && [ "$kind" = blob ] \
     || collection_error document-blob-read-failed path "$f" "could not read document blob: $f"
   if [ "$STAGED" -eq 0 ] && [ -f "$f" ] && [ ! -L "$f" ]; then
-    n="$(wc -c <"$f")" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
+    n="$(wc -c <"$f" 2>/dev/null)" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
     n="${n#"${n%%[![:space:]]*}"}"
   fi
   case "$n" in "" | *[!0-9]*) collection_error document-byte-count-invalid path "$f" "invalid byte count for tracked document: $f" ;; esac

--- a/skills/doc-limits/scripts/doc-limits
+++ b/skills/doc-limits/scripts/doc-limits
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Diagnostic protocol: refusals start error=KEY FIELD=VALUE; notices start
+# Diagnostic protocol: command refusals start error=KEY FIELD=VALUE; settings
+# refusals start doc-limits-error=KEY value=VALUE; notices start
 # notice=KEY FIELD=VALUE. English detail follows on the next line.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -333,7 +334,7 @@ while IFS="$TAB" read -r oid f limit class; do
   [ "$actual_oid" = "$oid" ] && [ "$kind" = blob ] \
     || collection_error document-blob-read-failed path "$f" "could not read document blob: $f"
   if [ "$STAGED" -eq 0 ] && [ -f "$f" ] && [ ! -L "$f" ]; then
-    n="$(wc -c <"$f" 2>/dev/null)" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
+    n="$(wc -c 2>/dev/null <"$f")" || collection_error document-measure-failed path "$f" "could not measure tracked document: $f"
     n="${n#"${n%%[![:space:]]*}"}"
   fi
   case "$n" in "" | *[!0-9]*) collection_error document-byte-count-invalid path "$f" "invalid byte count for tracked document: $f" ;; esac

--- a/skills/doc-limits/scripts/doc-limits
+++ b/skills/doc-limits/scripts/doc-limits
@@ -4,7 +4,7 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/settings.sh
-source "$SCRIPT_DIR/lib/settings.sh"
+source "$SCRIPT_DIR/lib/settings.sh" || exit 2
 # shellcheck source=../../commit-guards/scripts/lib/generated-paths.sh
 source "$SCRIPT_DIR/../../commit-guards/scripts/lib/generated-paths.sh"
 TAB="$(printf '\t')"

--- a/skills/doc-limits/scripts/lib/diagnostics.sh
+++ b/skills/doc-limits/scripts/lib/diagnostics.sh
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+# Diagnostic protocol: the first line carries a stable kind/code and one
+# value escaped with Bash printf %q. Remaining lines explain the result.
+# Callers choose stdout or stderr. The command stdout protocol stays with
+# doc-limits and does not pass through this formatter.
+sr_message() { # KIND CODE VALUE MESSAGE
+  printf 'doc-limits-%s=%s value=%q\n%s\n' "$1" "$2" "$3" "$4"
+}

--- a/skills/doc-limits/scripts/lib/settings.sh
+++ b/skills/doc-limits/scripts/lib/settings.sh
@@ -32,6 +32,15 @@
 # The caller cds to the repo root before resolving, so the default settings
 # path is relative.
 
+# Refusals start with the stable diagnostics protocol; source values remain
+# the resolver's stdout protocol and never include diagnostic text.
+sr_settings_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
+. "$sr_settings_script_dir/diagnostics.sh" 2>/dev/null || {
+  printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
+  return 1
+}
+unset sr_settings_script_dir
+
 # Extract the value of one parsed dotenv assignment (text after `KEY=`).
 # Quoted values end at the FIRST closing delimiter — dotenv/shell
 # semantics; an embedded delimiter would need escaping, which this parser
@@ -86,9 +95,9 @@ sr_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
   { [ -e "$1" ] || [ -L "$1" ]; } || return 0
   [ ! -f "$1" ] || return 0
   if [ ! -e "$1" ]; then
-    echo "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
+    sr_message error settings-symlink "$1" "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
   else
-    echo "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
+    sr_message error settings-type "$1" "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
   fi
   return 1
 }
@@ -205,7 +214,7 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
         0)
           entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
           if [ "$tree_status" -ne 0 ]; then
-            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $tree_status); refusing to treat it as untracked" >&2
+            sr_message error settings-head-tree "$tree_status" "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $tree_status); refusing to treat it as untracked" >&2
             return 1
           fi
           case "${entry:+tracked}" in
@@ -218,7 +227,7 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
           ;;
         1) ;;
         *)
-          echo "::error::$file: could not resolve HEAD while resolving a setting (git rev-parse exit $head_status); refusing to treat it as untracked" >&2
+          sr_message error settings-head "$head_status" "::error::$file: could not resolve HEAD while resolving a setting (git rev-parse exit $head_status); refusing to treat it as untracked" >&2
           return 1
           ;;
       esac
@@ -226,19 +235,19 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
       return 0
       ;;
     *)
-      echo "::error::$file: could not query the index while resolving a setting (git ls-files exit $status); refusing to treat it as untracked" >&2
+      sr_message error settings-index-query "$status" "::error::$file: could not query the index while resolving a setting (git ls-files exit $status); refusing to treat it as untracked" >&2
       return 1
       ;;
   esac
   status=0
   entry="$(git ls-files -s -- ":(literal)$file" 2>/dev/null)" || status=$?
   if [ "$status" -ne 0 ]; then
-    echo "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
+    sr_message error settings-index-mode "$status" "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
     return 1
   fi
   case "${entry%% *}" in
     120000)
-      echo "::error::$file: tracked as a symlink; staged settings resolution cannot read through it" >&2
+      sr_message error settings-index-symlink "$file" "::error::$file: tracked as a symlink; staged settings resolution cannot read through it" >&2
       return 1
       ;;
   esac
@@ -247,7 +256,7 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
   if [ ! -f "$copy" ]; then
     if ! git show ":$file" >"$copy" 2>/dev/null; then
       rm -f -- "$copy"
-      echo "::error::$file: could not read the staged copy while resolving a setting" >&2
+      sr_message error settings-index-read "$file" "::error::$file: could not read the staged copy while resolving a setting" >&2
       return 1
     fi
   fi
@@ -259,8 +268,12 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
 # header or assignment it hides. Refuse the source whole, same discipline
 # as the header rule. Read via stdin so the path is never an operand.
 sr_bom_guard() { # FILE — 0 = no leading BOM; 1 + ::error otherwise
+  if [ ! -r "$1" ]; then
+    sr_message error settings-unreadable "$1" "::error::$1: settings source is not readable" >&2
+    return 1
+  fi
   if [ "$(head -c 3 < "$1" 2>/dev/null)" = "$(printf '\357\273\277')" ]; then
-    echo "::error::$1: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
+    sr_message error settings-bom "$1" "::error::$1: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
     return 1
   fi
 }
@@ -271,9 +284,9 @@ sr_bom_guard() { # FILE — 0 = no leading BOM; 1 + ::error otherwise
 # resolved value.
 sr_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
   local status=0
-  grep -E -- "$1" "$2" || status=$?
+  grep -E -- "$1" "$2" 2>/dev/null || status=$?
   if [ "$status" -gt 1 ]; then
-    echo "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
+    sr_message error settings-grep "$2" "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
     return 2
   fi
   return "$status"
@@ -295,7 +308,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
   sr_bom_guard "$1" || return 1
   awk -v src="$1" '
     /^[[:space:]]*\[/ && !/^[[:space:]]*\[[A-Za-z0-9_.-]+\][[:space:]]*$/ {
-      printf "::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", src, NR > "/dev/stderr"
+      printf "doc-limits-error=settings-header value=%d\n::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", NR, src, NR > "/dev/stderr"
       exit 3
     }
     /^[[:space:]]*\[/ {
@@ -319,7 +332,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
       sub(/[[:space:]]*=.*$/, "", key)
       if (key !~ /^[A-Za-z_][A-Za-z0-9_]*$/) { print; next }
       if (key in seen) {
-        printf "::error::%s: %s is assigned more than once in [env] (each key must be unique in the table)\n", src, key > "/dev/stderr"
+        printf "doc-limits-error=settings-duplicate value=%s\n::error::%s: %s is assigned more than once in [env] (each key must be unique in the table)\n", key, src, key > "/dev/stderr"
         exit 3
       }
       seen[key] = 1
@@ -327,7 +340,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
       sub(/^[^=]*=[[:space:]]*/, "", value)
       sub(/[[:space:]]+$/, "", value)
       if (value !~ /^"[^"\\]*"[[:space:]]*(#.*)?$/) {
-        printf "::error::%s: unsupported syntax for %s (expected a single-line basic string, no double quote and no backslash: %s = \"value\")\n", src, key, key > "/dev/stderr"
+        printf "doc-limits-error=settings-syntax value=%s\n::error::%s: unsupported syntax for %s (expected a single-line basic string, no double quote and no backslash: %s = \"value\")\n", key, src, key, key > "/dev/stderr"
         exit 3
       }
       print
@@ -335,7 +348,7 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
   ' < "$1" || status=$?
   [ "$status" -ne 3 ] || return 1
   if [ "$status" -ne 0 ]; then
-    echo "::error::$1: unreadable while resolving a setting (awk exit $status)" >&2
+    sr_message error settings-awk "$1" "::error::$1: unreadable while resolving a setting (awk exit $status)" >&2
     return 2
   fi
 }
@@ -344,7 +357,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   local name="$1" default="$2" line val file table status matches
   case "$name" in
     "" | [0-9]* | *[!A-Za-z0-9_]*)
-      echo "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
+      sr_message error settings-key "$name" "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
       return 1
       ;;
   esac
@@ -366,7 +379,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     if [ -f "$file" ]; then
       sr_bom_guard "$file" || return 1
       if [ ! -r "$file" ]; then
-        echo "::error::$file: unreadable while resolving a setting (permission denied)" >&2
+        sr_message error settings-unreadable "$file" "::error::$file: unreadable while resolving a setting (permission denied)" >&2
         return 1
       fi
     fi
@@ -390,7 +403,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     line="$(printf '%s\n' "$matches" | tail -n 1)"
     if [ -n "$line" ]; then
       if ! val="$(sr_dotenv_value "${line#*=}")"; then
-        echo "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+        sr_message error settings-dotenv "$name" "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
         return 1
       fi
       printf '%s' "$val"
@@ -407,7 +420,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     [ "$status" -le 1 ] || return 1
     if [ "$status" -eq 0 ]; then
       if [ "$(printf '%s\n' "$matches" | grep -c .)" -gt 1 ]; then
-        echo "::error::$file: $name is assigned more than once in [env] (each key must be unique in the table)" >&2
+        sr_message error settings-duplicate "$name" "::error::$file: $name is assigned more than once in [env] (each key must be unique in the table)" >&2
         return 1
       fi
       # The first line in-shell, never `printf | head -n 1`: head closes the
@@ -416,7 +429,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       # file sets no mode of its own; it runs in the caller's, which does.
       line="${matches%%$'\n'*}"
       if ! printf '%s\n' "$line" | grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"\\\\]*\"[[:space:]]*(#.*)?\$"; then
-        echo "::error::$file: unsupported syntax for $name (expected a single-line basic string with no '\"' and no '\\': $name = \"value\")" >&2
+        sr_message error settings-syntax "$name" "::error::$file: unsupported syntax for $name (expected a single-line basic string with no '\"' and no '\\': $name = \"value\")" >&2
         return 1
       fi
       val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"

--- a/skills/doc-limits/scripts/lib/settings.sh
+++ b/skills/doc-limits/scripts/lib/settings.sh
@@ -271,13 +271,14 @@ sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error 
 # to any reader here, so a BOM-prefixed first line silently misfiles the
 # header or assignment it hides. Refuse the source whole, same discipline
 # as the header rule. Read via stdin so the path is never an operand.
-sr_bom_guard() { # FILE — 0 = no leading BOM; 1 + ::error otherwise
+sr_bom_guard() { # FILE [LABEL] — 0 = no leading BOM; 1 + ::error otherwise
+  local label="${2:-$1}"
   if [ ! -r "$1" ]; then
-    sr_message error settings-unreadable "$1" "::error::$1: settings source is not readable" >&2
+    sr_message error settings-unreadable "$label" "::error::$label: settings source is not readable" >&2
     return 1
   fi
   if [ "$(head -c 3 < "$1" 2>/dev/null)" = "$(printf '\357\273\277')" ]; then
-    sr_message error settings-bom "$1" "::error::$1: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
+    sr_message error settings-bom "$label" "::error::$label: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" >&2
     return 1
   fi
 }
@@ -306,11 +307,11 @@ sr_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
 # containing `=` as a variable assignment and would read no input while the
 # resolver silently returns defaults. awk failing to read the source is an
 # unreadable source and fails loud, same discipline as sr_settings_grep.
-sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
+sr_env_table() { # FILE [LABEL] — [env]-table lines on stdout; 1 + ::error on a
                  # malformed header or leading BOM; 2 + ::error when unreadable
-  local status=0
-  sr_bom_guard "$1" || return 1
-  awk -v src="$1" '
+  local status=0 label="${2:-$1}"
+  sr_bom_guard "$1" "$label" || return 1
+  awk -v src="$label" '
     /^[[:space:]]*\[/ && !/^[[:space:]]*\[[A-Za-z0-9_.-]+\][[:space:]]*$/ {
       printf "doc-limits-error=settings-header value=%d\n::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", NR, src, NR > "/dev/stderr"
       exit 3
@@ -352,13 +353,13 @@ sr_env_table() { # FILE — [env]-table lines on stdout; 1 + ::error on a
   ' < "$1" || status=$?
   [ "$status" -ne 3 ] || return 1
   if [ "$status" -ne 0 ]; then
-    sr_message error settings-awk "$1" "::error::$1: unreadable while resolving a setting (awk exit $status)" >&2
+    sr_message error settings-awk "$label" "::error::$label: unreadable while resolving a setting (awk exit $status)" >&2
     return 2
   fi
 }
 
 sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
-  local name="$1" default="$2" line val file table status matches
+  local name="$1" default="$2" line val file source table status matches
   case "$name" in
     "" | [0-9]* | *[!A-Za-z0-9_]*)
       sr_message error settings-key "$name" "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
@@ -372,16 +373,17 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       set -- ".kendex/settings.toml" "kendex.settings.toml"
     fi
     for file in "$@"; do
+      source="$file"
       file="$(sr_settings_source "$file")" || return 1
       sr_settings_usable "$file" || return 1
       if [ -f "$file" ]; then
-        sr_env_table "$file" >/dev/null || return 1
+        sr_env_table "$file" "$source" >/dev/null || return 1
       fi
     done
     file="$(sr_settings_source ".env.local")" || return 1
     sr_settings_usable "$file" || return 1
     if [ -f "$file" ]; then
-      sr_bom_guard "$file" || return 1
+      sr_bom_guard "$file" ".env.local" || return 1
       if [ ! -r "$file" ]; then
         sr_message error settings-unreadable "$file" "::error::$file: unreadable while resolving a setting (permission denied)" >&2
         return 1
@@ -400,7 +402,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   local_env="$(sr_settings_source ".env.local")" || return 1
   sr_settings_usable "$local_env" || return 1
   if [ -f "$local_env" ]; then
-    sr_bom_guard "$local_env" || return 1
+    sr_bom_guard "$local_env" ".env.local" || return 1
     status=0
     matches="$(sr_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" "$local_env")" || status=$?
     [ "$status" -le 1 ] || return 1
@@ -415,10 +417,11 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     fi
   fi
   for file in "$@"; do
+  source="$file"
   file="$(sr_settings_source "$file")" || return 1
   sr_settings_usable "$file" || return 1
   if [ -f "$file" ]; then
-    table="$(sr_env_table "$file")" || return 1
+    table="$(sr_env_table "$file" "$source")" || return 1
     status=0
     matches="$(printf '%s\n' "$table" | grep -E -- "^[[:space:]]*${name}[[:space:]]*=")" || status=$?
     [ "$status" -le 1 ] || return 1

--- a/skills/doc-limits/scripts/lib/settings.sh
+++ b/skills/doc-limits/scripts/lib/settings.sh
@@ -35,10 +35,11 @@
 # Refusals start with the stable diagnostics protocol; source values remain
 # the resolver's stdout protocol and never include diagnostic text.
 sr_settings_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
-. "$sr_settings_script_dir/diagnostics.sh" 2>/dev/null || {
+if [ ! -f "$sr_settings_script_dir/diagnostics.sh" ] || [ ! -r "$sr_settings_script_dir/diagnostics.sh" ]; then
   printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
   return 1
-}
+fi
+. "$sr_settings_script_dir/diagnostics.sh"
 unset sr_settings_script_dir
 
 # Extract the value of one parsed dotenv assignment (text after `KEY=`).

--- a/skills/doc-limits/scripts/lib/settings.sh
+++ b/skills/doc-limits/scripts/lib/settings.sh
@@ -35,11 +35,14 @@
 # Refusals start with the stable diagnostics protocol; source values remain
 # the resolver's stdout protocol and never include diagnostic text.
 sr_settings_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
-if [ ! -f "$sr_settings_script_dir/diagnostics.sh" ] || [ ! -r "$sr_settings_script_dir/diagnostics.sh" ]; then
+if [ ! -r "$sr_settings_script_dir/diagnostics.sh" ]; then
   printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
   return 1
 fi
-. "$sr_settings_script_dir/diagnostics.sh"
+. "$sr_settings_script_dir/diagnostics.sh" 2>/dev/null || {
+  printf 'doc-limits-error=diagnostics-load value=%q\n%s\n' "$sr_settings_script_dir/diagnostics.sh" 'Could not load the diagnostics library.' >&2
+  return 1
+}
 unset sr_settings_script_dir
 
 # Extract the value of one parsed dotenv assignment (text after `KEY=`).

--- a/skills/doc-limits/tests/generated-paths.test.sh
+++ b/skills/doc-limits/tests/generated-paths.test.sh
@@ -33,6 +33,22 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
+must_fail_first_line() { # FORMER-LINE LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" != "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -87,7 +103,7 @@ if [ "$MODE_ASSERTIONS" -eq 0 ]; then
 fi
 
 INVENTORY_ASSERTIONS=0
-while IFS='|' read -r name mode operation expected; do
+while IFS='|' read -r name mode operation expected first_line; do
   case "$operation" in
     inventory-worktree-empty) printf '[]\n' >"$R/.kendex-generated.json" ;;
     unchanged) : ;;
@@ -119,6 +135,7 @@ while IFS='|' read -r name mode operation expected; do
   esac
   run_mode "$mode"
   expect "$expected" "$name: $mode"
+  [ -z "$first_line" ] || expect_first_line "$first_line" "$name diagnostic: $mode"
   INVENTORY_ASSERTIONS=$((INVENTORY_ASSERTIONS + 1))
 done <<'INVENTORY_CASES'
 inventory-worktree-empty|worktree|inventory-worktree-empty|1
@@ -127,8 +144,8 @@ inventory-empty-staged|staged|stage-empty|1
 inventory-deleted-from-index|staged|delete-from-index|1
 inventory-absent-small-document|staged|small-without-inventory|0
 inventory-worktree-missing-index-fallback|worktree|missing-worktree-fallback|0
-inventory-invalid|worktree|invalid-inventory|2
-inventory-invalid|staged|unchanged|2
+inventory-invalid|worktree|invalid-inventory|2|error=inventory-invalid path=.kendex-generated.json
+inventory-invalid|staged|unchanged|2|error=inventory-invalid path=.kendex-generated.json
 render-carved-back|worktree|carve-back|1
 render-carved-back|staged|unchanged|1
 INVENTORY_CASES
@@ -169,10 +186,21 @@ SR="$SOURCE_COMMAND"
 
 printf '{}\n' >"$R/.kendex-generated.json"
 git -C "$R" add .kendex-generated.json
+private_command inventory-diagnostic
+[ "$(grep -Fxc "  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'" "$MUTANT")" -eq 1 ]
+sed 's/collection_error inventory-invalid path/collection_error inventory-renamed path/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'error=inventory-invalid path=.kendex-generated.json' 'inventory diagnostic control: changing the stable key fails inventory-invalid'
+
 private_command inventory-parse
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc 'generated_paths_load "$inventory" || exit 2' "$MUTANT")" -eq 1 ]
-sed 's/^generated_paths_load "\$inventory" || exit 2$/generated_paths_load "$inventory" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc "  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'" "$MUTANT")" -eq 1 ]
+sed "s#^  || collection_error inventory-invalid path .kendex-generated.json 'cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'\$#  || :#" "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/skills/doc-limits/tests/generated-paths.test.sh
+++ b/skills/doc-limits/tests/generated-paths.test.sh
@@ -129,6 +129,9 @@ while IFS='|' read -r name mode operation expected first_line; do
       printf '{}\n' >"$R/.kendex-generated.json"
       git -C "$R" add .kendex-generated.json
       ;;
+    inventory-unreadable)
+      chmod 000 "$R/.kendex-generated.json"
+      ;;
     carve-back)
       git -C "$R" checkout HEAD -- .kendex-generated.json
       printf '!.agents/skills/rendered/*\tmeasure this render explicitly\n' >"$R/tools/doc-limits-excludes"
@@ -150,11 +153,16 @@ inventory-invalid|worktree|invalid-inventory|2|error=inventory-invalid path=.ken
 inventory-invalid|staged|unchanged|2|error=inventory-invalid path=.kendex-generated.json
 render-carved-back|worktree|carve-back|1
 render-carved-back|staged|unchanged|1
+inventory-unreadable-shape|worktree|inventory-unreadable|2|error=inventory-read-failed path=.kendex-generated.json
 INVENTORY_CASES
 if [ "$INVENTORY_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: INVENTORY_CASES executed no assertions\n' >&2
   exit 1
 fi
+
+chmod 600 "$R/.kendex-generated.json"
+printf '[".agents/skills/rendered/SKILL.md"]\n' >"$R/.kendex-generated.json"
+git -C "$R" add .kendex-generated.json
 
 git -C "$R" rm -qf tools/doc-limits-excludes
 private_command generated-exclusion

--- a/skills/doc-limits/tests/generated-paths.test.sh
+++ b/skills/doc-limits/tests/generated-paths.test.sh
@@ -42,11 +42,13 @@ expect_first_line() { # EXPECTED LABEL
   fi
 }
 must_fail_first_line() { # FORMER-LINE LABEL
-  local first="${OUT%%$'\n'*}"
-  if [ "$first" != "$1" ]; then
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
     PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
   fi
 }
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -149,7 +149,7 @@ run
 expect 2 'diagnostics-load-failure'
 expect_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load failure'
 MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
-[ "$(grep -Fxc "  printf 'doc-limits-error=diagnostics-load value=%q\\n%s\\n' \"\$sr_settings_script_dir/diagnostics.sh\" 'Could not load the diagnostics library.' >&2" "$MUTANT_SETTINGS")" -eq 1 ]
+[ "$(grep -Fxc "  printf 'doc-limits-error=diagnostics-load value=%q\\n%s\\n' \"\$sr_settings_script_dir/diagnostics.sh\" 'Could not load the diagnostics library.' >&2" "$MUTANT_SETTINGS")" -eq 2 ]
 sed 's/doc-limits-error=diagnostics-load/doc-limits-error=diagnostics-renamed/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
 if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
 mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -178,6 +178,12 @@ done <<'INVALID_CLASS_CASES'
 =1k|class-pattern-empty|=1k
 INVALID_CLASS_CASES
 
+DOC_LIMITS_CLASSES="*.m$(printf '\t')d=1k"
+export DOC_LIMITS_CLASSES
+run
+expect 2 'invalid-class-tab-pattern'
+expect_first_line 'error=class-pattern-invalid setting=DOC_LIMITS_CLASSES' 'invalid-class-tab-pattern diagnostic'
+
 private_command invalid-classes
 [ ! -L "$MUTANT" ]
 [ "$(grep -Fxc 'parse_classes() { # SETTING-NAME VALUE — appends entries' "$MUTANT")" -eq 1 ]
@@ -276,6 +282,10 @@ while IFS='|' read -r name operation first_line; do
     header) printf '[env] # invalid\n' >"$R/.kendex/settings.toml" ;;
     syntax) printf '[env]\nDOC_LIMITS_CLASSES = 1\n' >"$R/.kendex/settings.toml" ;;
     dotenv) printf 'DOC_LIMITS_CLASSES="*.md=1k"tail\n' >"$R/.env.local" ;;
+    unreadable)
+      printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml"
+      chmod 000 "$R/.kendex/settings.toml"
+      ;;
   esac
   run
   expect 2 "$name"
@@ -288,6 +298,7 @@ settings-bom|bom|doc-limits-error=settings-bom value=.kendex/settings.toml
 settings-header|header|doc-limits-error=settings-header value=1
 settings-syntax|syntax|doc-limits-error=settings-syntax value=DOC_LIMITS_CLASSES
 settings-dotenv|dotenv|doc-limits-error=settings-dotenv value=DOC_LIMITS_CLASSES
+settings-unreadable|unreadable|doc-limits-error=settings-unreadable value=.kendex/settings.toml
 SETTINGS_ERROR_CASES
 if [ "$SETTINGS_ERROR_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: SETTINGS_ERROR_CASES executed no assertions\n' >&2
@@ -396,6 +407,12 @@ run
 expect 2 'outside-repository'
 expect_first_line "error=repository-root-missing path=$(printf '%q' "$R")" 'outside-repository diagnostic precedes Git stderr'
 R="$REPO_FIXTURE"
+
+export TMPDIR="$TMP/missing-temp-parent"
+run
+expect 2 'temporary-directory-parent-missing'
+expect_first_line "error=temp-create-failed path=$(printf '%q' "$TMPDIR")" 'temporary-directory diagnostic'
+unset TMPDIR
 
 # Git is the real producer of policy lookup, document enumeration, and blob sizes.
 REAL_GIT="$(command -v git)"

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -137,6 +137,14 @@ SR="$MUTANT"
 run
 expect 2 'diagnostics-load-failure'
 expect_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load failure'
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc "  printf 'doc-limits-error=diagnostics-load value=%q\\n%s\\n' \"\$sr_settings_script_dir/diagnostics.sh\" 'Could not load the diagnostics library.' >&2" "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/doc-limits-error=diagnostics-load/doc-limits-error=diagnostics-renamed/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+run
+must_fail_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load control: changing the stable key fails the refusal'
 sed 's#^source "\$SCRIPT_DIR/lib/settings.sh" || exit 2$#source "$SCRIPT_DIR/lib/settings.sh" || exit 1#' "$MUTANT" >"$MUTANT.changed"
 if cmp -s "$MUTANT" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
@@ -264,6 +272,14 @@ run --unknown
 expect 2 'unknown-option'
 expect_first_line 'error=argument-unknown argument=--unknown' 'unknown-option diagnostic'
 
+REPO_FIXTURE="$R"
+R="$TMP/outside-repository"
+mkdir "$R"
+run
+expect 2 'outside-repository'
+expect_first_line "error=repository-root-missing path=$(printf '%q' "$R")" 'outside-repository diagnostic precedes Git stderr'
+R="$REPO_FIXTURE"
+
 # Git is the real producer of policy lookup, document enumeration, and blob sizes.
 REAL_GIT="$(command -v git)"
 export REAL_GIT
@@ -314,8 +330,8 @@ fi
 
 private_command enumeration-guard
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
-sed 's/^git ls-files -s -z >"\$TMP\/files.z" || collection_error documents-enumeration-failed exit "\$?" "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" 2>/dev/null || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
+sed 's/^git ls-files -s -z >"\$TMP\/files.z" 2>\/dev\/null || collection_error documents-enumeration-failed exit "\$?" "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" 2>\/dev\/null || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -23,6 +23,22 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
+must_fail_first_line() { # FORMER-LINE LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" != "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -199,8 +215,25 @@ run
 must_fail 1 0 'carve-back control: disabling carve-back fails exclusion-carve-back'
 SR="$SOURCE_COMMAND"
 
+run --excludes
+expect 2 'missing-excludes-value'
+expect_first_line 'error=argument-value-missing option=--excludes' 'missing-excludes-value diagnostic'
+
+private_command excludes-diagnostic
+[ "$(grep -Fxc '      [ $# -ge 2 ] || config_error argument-value-missing option --excludes "--excludes requires a path"' "$MUTANT")" -eq 1 ]
+sed 's/config_error argument-value-missing option --excludes/config_error argument-value-renamed option --excludes/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --excludes
+must_fail_first_line 'error=argument-value-missing option=--excludes' 'diagnostic control: changing the stable key fails the missing-value assertion'
+SR="$SOURCE_COMMAND"
+
 run --unknown
 expect 2 'unknown-option'
+expect_first_line 'error=argument-unknown argument=--unknown' 'unknown-option diagnostic'
 
 # Git is the real producer of policy lookup, document enumeration, and blob sizes.
 REAL_GIT="$(command -v git)"
@@ -252,8 +285,8 @@ fi
 
 private_command enumeration-guard
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" || collection_error "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
-sed 's/^git ls-files -s -z >"\$TMP\/files.z" || collection_error "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
+sed 's/^git ls-files -s -z >"\$TMP\/files.z" || collection_error documents-enumeration-failed exit "\$?" "could not enumerate tracked documents"$/git ls-files -s -z >"$TMP\/files.z" || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"
@@ -265,8 +298,8 @@ must_fail 2 0 'collection table control: bypassing enumeration failure fails git
 
 private_command batch-guard
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc '  || collection_error "could not read document blob sizes"' "$MUTANT")" -eq 1 ]
-sed 's/^  || collection_error "could not read document blob sizes"$/  || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc '  || collection_error blob-sizes-read-failed exit "$?" "could not read document blob sizes"' "$MUTANT")" -eq 1 ]
+sed 's/^  || collection_error blob-sizes-read-failed exit "\$?" "could not read document blob sizes"$/  || :/' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -129,6 +129,23 @@ run
 must_fail 1 0 'precedence table control: disabling .env.local fails dotenv-local-over-local'
 SR="$SOURCE_COMMAND"
 
+private_command diagnostics-load
+MUTANT_DIAGNOSTICS="$(dirname "$MUTANT")/lib/diagnostics.sh"
+[ "$(grep -Fxc 'source "$SCRIPT_DIR/lib/settings.sh" || exit 2' "$MUTANT")" -eq 1 ]
+rm "$MUTANT_DIAGNOSTICS"
+SR="$MUTANT"
+run
+expect 2 'diagnostics-load-failure'
+expect_first_line "doc-limits-error=diagnostics-load value=$(printf '%q' "$MUTANT_DIAGNOSTICS")" 'diagnostics-load failure'
+sed 's#^source "\$SCRIPT_DIR/lib/settings.sh" || exit 2$#source "$SCRIPT_DIR/lib/settings.sh" || exit 1#' "$MUTANT" >"$MUTANT.changed"
+if cmp -s "$MUTANT" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+run
+must_fail 2 1 'diagnostics-load control: wrong loader exit fails the refusal'
+SR="$SOURCE_COMMAND"
+
 for value in '*.md=0k' '*.md=400' '*.md=invalid' '*.md' '=1k'; do
   export DOC_LIMITS_CLASSES="$value"
   run
@@ -196,6 +213,18 @@ unset DOC_LIMITS_CLASSES
 printf '[env]\nDUP = "a"\nDUP = "b"\n' >"$R/kendex.settings.toml"
 run
 expect 2 'duplicate-settings-key'
+expect_first_line 'doc-limits-error=settings-duplicate value=DUP' 'duplicate-settings-key diagnostic'
+private_command settings-diagnostic
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc '        printf "doc-limits-error=settings-duplicate value=%s\n::error::%s: %s is assigned more than once in [env] (each key must be unique in the table)\n", key, src, key > "/dev/stderr"' "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/doc-limits-error=settings-duplicate value=%s/doc-limits-error=settings-renamed value=%s/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+SR="$MUTANT"
+run
+must_fail_first_line 'doc-limits-error=settings-duplicate value=DUP' 'settings diagnostic control: changing the stable key fails the duplicate assertion'
+SR="$SOURCE_COMMAND"
 rm "$R/kendex.settings.toml" "$R/.env.local" "$R/.kendex/settings.toml"
 printf '*.md\tfixture exception\n!AGENTS.md\tkeep root instructions checked\n' >"$R/tools/doc-limits-excludes"
 export DOC_LIMITS_CLASSES='*.md=1k'

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -66,6 +66,15 @@ private_command() { # NAME: copy the command and set MUTANT
   ln -s "$TEST_DIR/../../commit-guards" "$root/skills/commit-guards"
   MUTANT="$root/skills/doc-limits/scripts/doc-limits"
 }
+clear_settings_sources() {
+  local path="$R/.kendex/settings.toml"
+  if [ -L "$path" ] || [ -f "$path" ]; then
+    rm "$path"
+  elif [ -d "$path" ]; then
+    rmdir "$path"
+  fi
+  rm -f "$R/kendex.settings.toml" "$R/.env.local"
+}
 
 bytes AGENTS.md 2049
 git -C "$R" add AGENTS.md
@@ -255,7 +264,64 @@ SR="$MUTANT"
 run
 must_fail_first_line 'doc-limits-error=settings-duplicate value=DUP' 'settings diagnostic control: changing the stable key fails the duplicate assertion'
 SR="$SOURCE_COMMAND"
-rm "$R/kendex.settings.toml" "$R/.env.local" "$R/.kendex/settings.toml"
+clear_settings_sources
+
+SETTINGS_ERROR_ASSERTIONS=0
+while IFS='|' read -r name operation first_line; do
+  clear_settings_sources
+  case "$operation" in
+    dangling) ln -s missing "$R/.kendex/settings.toml" ;;
+    directory) mkdir "$R/.kendex/settings.toml" ;;
+    bom) printf '\357\273\277[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml" ;;
+    header) printf '[env] # invalid\n' >"$R/.kendex/settings.toml" ;;
+    syntax) printf '[env]\nDOC_LIMITS_CLASSES = 1\n' >"$R/.kendex/settings.toml" ;;
+    dotenv) printf 'DOC_LIMITS_CLASSES="*.md=1k"tail\n' >"$R/.env.local" ;;
+  esac
+  run
+  expect 2 "$name"
+  expect_first_line "$first_line" "$name diagnostic"
+  SETTINGS_ERROR_ASSERTIONS=$((SETTINGS_ERROR_ASSERTIONS + 1))
+done <<'SETTINGS_ERROR_CASES'
+settings-dangling-symlink|dangling|doc-limits-error=settings-symlink value=.kendex/settings.toml
+settings-directory|directory|doc-limits-error=settings-type value=.kendex/settings.toml
+settings-bom|bom|doc-limits-error=settings-bom value=.kendex/settings.toml
+settings-header|header|doc-limits-error=settings-header value=1
+settings-syntax|syntax|doc-limits-error=settings-syntax value=DOC_LIMITS_CLASSES
+settings-dotenv|dotenv|doc-limits-error=settings-dotenv value=DOC_LIMITS_CLASSES
+SETTINGS_ERROR_CASES
+if [ "$SETTINGS_ERROR_ASSERTIONS" -eq 0 ]; then
+  printf 'FAIL: SETTINGS_ERROR_CASES executed no assertions\n' >&2
+  exit 1
+fi
+
+clear_settings_sources
+ln -s missing "$R/.kendex/settings.toml"
+private_command settings-message
+MUTANT_DIAGNOSTICS="$(dirname "$MUTANT")/lib/diagnostics.sh"
+[ "$(grep -Fxc "  printf 'doc-limits-%s=%s value=%q\\n%s\\n' \"\$1\" \"\$2\" \"\$3\" \"\$4\"" "$MUTANT_DIAGNOSTICS")" -eq 1 ]
+sed 's/doc-limits-%s=%s/renamed-%s=%s/' "$MUTANT_DIAGNOSTICS" >"$MUTANT_DIAGNOSTICS.changed"
+if cmp -s "$MUTANT_DIAGNOSTICS" "$MUTANT_DIAGNOSTICS.changed"; then exit 1; fi
+mv "$MUTANT_DIAGNOSTICS.changed" "$MUTANT_DIAGNOSTICS"
+bash -n "$MUTANT_DIAGNOSTICS"
+SR="$MUTANT"
+run
+must_fail_first_line 'doc-limits-error=settings-symlink value=.kendex/settings.toml' 'settings formatter control: changing the stable prefix fails the symlink row'
+
+clear_settings_sources
+printf '[env] # invalid\n' >"$R/.kendex/settings.toml"
+private_command settings-awk-message
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc '      printf "doc-limits-error=settings-header value=%d\n::error::%s:%d: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)\n", NR, src, NR > "/dev/stderr"' "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/doc-limits-error=settings-header value=%d/doc-limits-error=settings-header-renamed value=%d/' "$MUTANT_SETTINGS" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$MUTANT_SETTINGS" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+SR="$MUTANT"
+run
+must_fail_first_line 'doc-limits-error=settings-header value=1' 'settings parser control: changing the stable key fails the header row'
+SR="$SOURCE_COMMAND"
+clear_settings_sources
+
 printf '*.md\tfixture exception\n!AGENTS.md\tkeep root instructions checked\n' >"$R/tools/doc-limits-excludes"
 export DOC_LIMITS_CLASSES='*.md=1k'
 run
@@ -288,6 +354,35 @@ bash -n "$MUTANT"
 SR="$MUTANT"
 run --excludes
 must_fail_first_line 'error=argument-value-missing option=--excludes' 'diagnostic control: changing the stable key fails the missing-value assertion'
+SR="$SOURCE_COMMAND"
+
+EXCLUDES_PATH_ASSERTIONS=0
+while IFS='|' read -r name argument key relevant; do
+  run "$argument"
+  expect 2 "$name"
+  expect_first_line "error=$key path=$(printf '%q' "$relevant")" "$name diagnostic"
+  EXCLUDES_PATH_ASSERTIONS=$((EXCLUDES_PATH_ASSERTIONS + 1))
+done <<'EXCLUDES_PATH_CASES'
+excludes-empty|--excludes=|excludes-path-empty|
+excludes-absolute|--excludes=/outside|excludes-path-absolute|/outside
+excludes-parent|--excludes=../outside|excludes-path-invalid|../outside
+excludes-option|--excludes=-outside|excludes-path-option|-outside
+EXCLUDES_PATH_CASES
+if [ "$EXCLUDES_PATH_ASSERTIONS" -eq 0 ]; then
+  printf 'FAIL: EXCLUDES_PATH_CASES executed no assertions\n' >&2
+  exit 1
+fi
+
+private_command excludes-path-diagnostic
+[ "$(grep -Fxc 'case "$EXCLUDES_FILE" in /*) config_error excludes-path-absolute path "$EXCLUDES_FILE" "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac' "$MUTANT")" -eq 1 ]
+sed 's/config_error excludes-path-absolute path/config_error excludes-path-absolute-renamed path/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --excludes=/outside
+must_fail_first_line 'error=excludes-path-absolute path=/outside' 'excludes-path control: changing the stable key fails the absolute row'
 SR="$SOURCE_COMMAND"
 
 run --unknown

--- a/skills/doc-limits/tests/settings-and-config.test.sh
+++ b/skills/doc-limits/tests/settings-and-config.test.sh
@@ -32,11 +32,13 @@ expect_first_line() { # EXPECTED LABEL
   fi
 }
 must_fail_first_line() { # FORMER-LINE LABEL
-  local first="${OUT%%$'\n'*}"
-  if [ "$first" != "$1" ]; then
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
     PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
   fi
 }
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
@@ -154,11 +156,18 @@ run
 must_fail 2 1 'diagnostics-load control: wrong loader exit fails the refusal'
 SR="$SOURCE_COMMAND"
 
-for value in '*.md=0k' '*.md=400' '*.md=invalid' '*.md' '=1k'; do
+while IFS='|' read -r value key relevant; do
   export DOC_LIMITS_CLASSES="$value"
   run
   expect 2 "invalid-class: $value"
-done
+  expect_first_line "error=$key value=$(printf '%q' "$relevant")" "invalid-class diagnostic: $value"
+done <<'INVALID_CLASS_CASES'
+*.md=0k|class-threshold-invalid|0k
+*.md=400|class-threshold-invalid|400
+*.md=invalid|class-threshold-invalid|invalid
+*.md|class-entry-invalid|*.md
+=1k|class-pattern-empty|=1k
+INVALID_CLASS_CASES
 
 private_command invalid-classes
 [ ! -L "$MUTANT" ]
@@ -174,6 +183,19 @@ for value in '*.md=0k' '*.md=400' '*.md=invalid' '*.md' '=1k'; do
   run
   must_fail 2 0 "invalid-class table control: $value"
 done
+SR="$SOURCE_COMMAND"
+
+private_command class-diagnostic
+[ "$(grep -Fxc '      *) config_error class-threshold-invalid value "$craw" "$name: entry '\''$pair'\'' needs a positive integer with the '\''k'\'' byte suffix" ;;' "$MUTANT")" -eq 1 ]
+sed 's/config_error class-threshold-invalid value "$craw"/config_error class-threshold-renamed value "$craw"/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+export DOC_LIMITS_CLASSES='*.md=400'
+run
+must_fail_first_line 'error=class-threshold-invalid value=400' 'class diagnostic control: changing the stable key fails the suffix row'
 SR="$SOURCE_COMMAND"
 
 CLASS_ORDER_ASSERTIONS=0
@@ -310,23 +332,37 @@ chmod +x "$TMP/bin/git"
 export PATH="$TMP/bin:$PATH"
 
 COLLECTION_ASSERTIONS=0
-while IFS='|' read -r name fault expected; do
+while IFS='|' read -r name fault expected first_line; do
   export GIT_FAULT="$fault"
   run --staged
   expect "$expected" "$name"
+  expect_first_line "$first_line" "$name diagnostic"
   COLLECTION_ASSERTIONS=$((COLLECTION_ASSERTIONS + 1))
 done <<'COLLECTION_CASES'
-git-policy-lookup-failure|policy-lookup|2
-git-enumeration-failure|enumeration|2
-git-batch-empty-failure|batch-empty-failure|2
-git-batch-failure|batch-complete-failure|2
-empty-successful-batch-response|batch-empty-success|2
-collection-restored|none|1
+git-policy-lookup-failure|policy-lookup|2|doc-limits-error=settings-index-query value=9
+git-enumeration-failure|enumeration|2|error=documents-enumeration-failed exit=9
+git-batch-empty-failure|batch-empty-failure|2|error=blob-sizes-read-failed exit=9
+git-batch-failure|batch-complete-failure|2|error=blob-sizes-read-failed exit=9
+empty-successful-batch-response|batch-empty-success|2|error=blob-size-response-incomplete path=AGENTS.md
+collection-restored|none|1|notice=document-over-limit path=AGENTS.md
 COLLECTION_CASES
 if [ "$COLLECTION_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: COLLECTION_CASES executed no assertions\n' >&2
   exit 1
 fi
+
+private_command collection-diagnostic
+[ "$(grep -Fxc 'git ls-files -s -z >"$TMP/files.z" 2>/dev/null || collection_error documents-enumeration-failed exit "$?" "could not enumerate tracked documents"' "$MUTANT")" -eq 1 ]
+sed 's/collection_error documents-enumeration-failed exit/collection_error documents-enumeration-renamed exit/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+export GIT_FAULT=enumeration
+run --staged
+must_fail_first_line 'error=documents-enumeration-failed exit=9' 'collection diagnostic control: changing the stable key fails enumeration'
+SR="$SOURCE_COMMAND"
 
 private_command enumeration-guard
 [ ! -L "$MUTANT" ]

--- a/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -32,11 +32,13 @@ expect_first_line() { # EXPECTED LABEL
   fi
 }
 must_fail_first_line() { # FORMER-LINE LABEL
-  local first="${OUT%%$'\n'*}"
-  if [ "$first" != "$1" ]; then
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
     PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
   fi
 }
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red

--- a/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -31,6 +31,14 @@ expect_first_line() { # EXPECTED LABEL
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
   fi
 }
+must_fail_first_line() { # FORMER-LINE LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" != "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: mutant retained <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -94,6 +102,21 @@ if [ "$CLASS_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: CLASSES executed no assertions\n' >&2
   exit 1
 fi
+
+bytes README.md 16384
+git -C "$R" add README.md
+private_command notice-protocol
+[ "$(grep -Fxc "  printf 'notice=%s %s=%q\\n' \"\$key\" \"\$field\" \"\$value\"" "$MUTANT")" -eq 1 ]
+sed "s/printf 'notice=%s %s=%q\\\\n'/printf 'renamed=%s %s=%q\\\\n'/" "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'notice=documents-checked count=1' 'notice protocol control: changing the formatter fails the pass notice'
+SR="$SOURCE_COMMAND"
+git -C "$R" rm -qf README.md
 
 bytes src/large.rs 100000
 git -C "$R" add src/large.rs

--- a/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -23,6 +23,14 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -56,13 +64,15 @@ while IFS=' ' read -r path limit; do
   git -C "$R" add -- "$path"
   run --staged
   expect 0 "$path at its class limit passes"
+  expect_first_line 'notice=documents-checked count=1' "$path pass notice"
   bytes "$path" "$((limit + 1))"
   git -C "$R" add -- "$path"
   run --staged
   expect 1 "$path one byte over fails"
+  expect_first_line "notice=document-over-limit path=$path" "$path failure notice"
   case "$OUT" in
-    *"$path: $((limit + 1)) bytes > $limit bytes"*) ;;
-    *) FAIL=$((FAIL + 1)); printf '  FAIL: wrong document or limit: %s\n' "$OUT" ;;
+    *"notice=documents-over-limit count=1"*) PASS=$((PASS + 1)); printf '  ok: %s\n' "$path failure count" ;;
+    *) FAIL=$((FAIL + 1)); printf '  FAIL: %s\n' "$path failure count" ;;
   esac
   git -C "$R" rm -qf -- "$path"
   CLASS_ASSERTIONS=$((CLASS_ASSERTIONS + 1))

--- a/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -120,6 +120,36 @@ must_fail_first_line 'notice=documents-checked count=1' 'notice protocol control
 SR="$SOURCE_COMMAND"
 git -C "$R" rm -qf README.md
 
+DOCUMENT_PATH="bad$(printf '\t')path.md"
+bytes "$DOCUMENT_PATH" 1
+git -C "$R" add -- "$DOCUMENT_PATH"
+run --staged
+expect 2 'document-path-tab'
+expect_first_line "error=document-path-invalid path=$(printf '%q' "$DOCUMENT_PATH")" 'document-path-tab diagnostic'
+git -C "$R" rm -qf -- "$DOCUMENT_PATH"
+
+printf 'conflict\n' >"$R/conflict.md"
+git -C "$R" add conflict.md
+CONFLICT_OID="$(git -C "$R" hash-object conflict.md)"
+git -C "$R" rm -q --cached conflict.md
+printf '100644 %s 1\tconflict.md\n100644 %s 2\tconflict.md\n100644 %s 3\tconflict.md\n' "$CONFLICT_OID" "$CONFLICT_OID" "$CONFLICT_OID" | git -C "$R" update-index --index-info
+run --staged
+expect 2 'document-unmerged'
+expect_first_line 'error=document-unmerged path=conflict.md' 'document-unmerged diagnostic'
+private_command document-diagnostic
+[ "$(grep -Fxc '  [ "${entry##* }" = 0 ] || collection_error document-unmerged path "$f" "tracked document is unmerged: $f"' "$MUTANT")" -eq 1 ]
+sed 's/collection_error document-unmerged path/collection_error document-unmerged-renamed path/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'error=document-unmerged path=conflict.md' 'document diagnostic control: changing the stable key fails the unmerged row'
+SR="$SOURCE_COMMAND"
+git -C "$R" update-index --force-remove conflict.md
+rm "$R/conflict.md"
+
 bytes src/large.rs 100000
 git -C "$R" add src/large.rs
 export DOC_LIMITS_CLASSES='*=1k'
@@ -145,11 +175,15 @@ bytes AGENTS.md 16385
 git -C "$R" add AGENTS.md
 EXCLUSION_ASSERTIONS=0
 while IFS='|' read -r name operation expected first_line; do
+  rm -f "$R/tools/doc-limits-excludes"
   case "$operation" in
     reasoned) printf 'AGENTS.md\tdeliberate fixture exception\n' >"$R/tools/doc-limits-excludes" ;;
     missing-reason) printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes" ;;
     removed) : >"$R/tools/doc-limits-excludes" ;;
     empty-carve) printf '!\tmissing pattern\n' >"$R/tools/doc-limits-excludes" ;;
+    symlink)
+      ln -s ../AGENTS.md "$R/tools/doc-limits-excludes"
+      ;;
   esac
   git -C "$R" add tools/doc-limits-excludes
   run --staged
@@ -161,12 +195,14 @@ reasoned-exclusion|reasoned|0|notice=documents-checked count=0
 exclusion-missing-reason|missing-reason|2|error=excludes-row-invalid line=1
 exclusion-removed|removed|1|notice=document-over-limit path=AGENTS.md
 exclusion-empty-carve|empty-carve|2|error=excludes-carve-empty line=1
+exclusion-symlink|symlink|2|error=excludes-mode-invalid mode=120000
 EXCLUSION_CASES
 if [ "$EXCLUSION_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: EXCLUSION_CASES executed no assertions\n' >&2
   exit 1
 fi
 
+rm -f "$R/tools/doc-limits-excludes"
 printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes"
 git -C "$R" add tools/doc-limits-excludes
 private_command exclusion-diagnostic

--- a/skills/doc-limits/tests/shipped-defaults.test.sh
+++ b/skills/doc-limits/tests/shipped-defaults.test.sh
@@ -144,25 +144,42 @@ git -C "$R" rm -qf src/large.rs
 bytes AGENTS.md 16385
 git -C "$R" add AGENTS.md
 EXCLUSION_ASSERTIONS=0
-while IFS='|' read -r name operation expected; do
+while IFS='|' read -r name operation expected first_line; do
   case "$operation" in
     reasoned) printf 'AGENTS.md\tdeliberate fixture exception\n' >"$R/tools/doc-limits-excludes" ;;
     missing-reason) printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes" ;;
     removed) : >"$R/tools/doc-limits-excludes" ;;
+    empty-carve) printf '!\tmissing pattern\n' >"$R/tools/doc-limits-excludes" ;;
   esac
   git -C "$R" add tools/doc-limits-excludes
   run --staged
   expect "$expected" "$name"
+  expect_first_line "$first_line" "$name diagnostic"
   EXCLUSION_ASSERTIONS=$((EXCLUSION_ASSERTIONS + 1))
 done <<'EXCLUSION_CASES'
-reasoned-exclusion|reasoned|0
-exclusion-missing-reason|missing-reason|2
-exclusion-removed|removed|1
+reasoned-exclusion|reasoned|0|notice=documents-checked count=0
+exclusion-missing-reason|missing-reason|2|error=excludes-row-invalid line=1
+exclusion-removed|removed|1|notice=document-over-limit path=AGENTS.md
+exclusion-empty-carve|empty-carve|2|error=excludes-carve-empty line=1
 EXCLUSION_CASES
 if [ "$EXCLUSION_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: EXCLUSION_CASES executed no assertions\n' >&2
   exit 1
 fi
+
+printf 'AGENTS.md\n' >"$R/tools/doc-limits-excludes"
+git -C "$R" add tools/doc-limits-excludes
+private_command exclusion-diagnostic
+[ "$(grep -Fxc '      config_error excludes-row-invalid line "$lineno" "$EXCLUDES_LABEL:$lineno: expected '\''pattern<TAB>reason'\'' (every exclusion carries its justification)"' "$MUTANT")" -eq 1 ]
+sed 's/config_error excludes-row-invalid line/config_error excludes-row-renamed line/' "$SOURCE_COMMAND" >"$MUTANT.changed"
+if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
+mv "$MUTANT.changed" "$MUTANT"
+chmod +x "$MUTANT"
+bash -n "$MUTANT"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'error=excludes-row-invalid line=1' 'exclusion diagnostic control: changing the stable key fails the malformed row'
+SR="$SOURCE_COMMAND"
 
 printf 'AGENTS.md\tdeliberate fixture exception\n' >"$R/tools/doc-limits-excludes"
 git -C "$R" add tools/doc-limits-excludes

--- a/skills/doc-limits/tests/staged-scope.test.sh
+++ b/skills/doc-limits/tests/staged-scope.test.sh
@@ -130,8 +130,8 @@ git -C "$R" commit -qm 'control fixture'
 printf 'AGENTS.md\tfixture exception\n' >"$R/tools/doc-limits-excludes"
 private_command exclusion-source
 [ ! -L "$MUTANT" ]
-[ "$(grep -Fxc '  git show ":$1" >"$TMP/excludes" \' "$MUTANT")" -eq 1 ]
-sed 's#  git show ":\$1" >"\$TMP/excludes" \\#  cp -- "$1" "$TMP/excludes" \\#' "$SOURCE_COMMAND" >"$MUTANT.changed"
+[ "$(grep -Fxc '  git show ":$1" >"$TMP/excludes" 2>/dev/null \' "$MUTANT")" -eq 1 ]
+sed 's#  git show ":\$1" >"\$TMP/excludes" 2>/dev/null \\#  cp -- "$1" "$TMP/excludes" 2>/dev/null \\#' "$SOURCE_COMMAND" >"$MUTANT.changed"
 if cmp -s "$SOURCE_COMMAND" "$MUTANT.changed"; then exit 1; fi
 mv "$MUTANT.changed" "$MUTANT"
 chmod +x "$MUTANT"

--- a/skills/doc-limits/tests/staged-scope.test.sh
+++ b/skills/doc-limits/tests/staged-scope.test.sh
@@ -23,6 +23,24 @@ expect() { # EXPECTED-EXIT LABEL: assert the preceding run's result
     FAIL=$((FAIL + 1)); printf '  FAIL: %s: exit %s\n%s\n' "$2" "$RC" "$OUT"
   fi
 }
+expect_first_line() { # EXPECTED LABEL
+  local first="${OUT%%$'\n'*}"
+  if [ "$first" = "$1" ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first line <%s>\n' "$2" "$first"
+  fi
+}
+must_fail_first_line() { # FORMER-LINE LABEL
+  local assertion_rc=0
+  (PASS=0; FAIL=0; expect_first_line "$1" "$2"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
+  if [ "$assertion_rc" -ne 0 ]; then
+    PASS=$((PASS + 1)); printf '  ok: %s\n' "$2"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL: %s: first-line assertion stayed green\n' "$2"
+    cat "$TMP/control.log"
+  fi
+}
 must_fail() { # FORMER-EXIT MUTANT-EXIT LABEL: prove the former assertion turns red
   local assertion_rc=0
   (PASS=0; FAIL=0; expect "$1" "$3"; [ "$FAIL" -eq 0 ]) >"$TMP/control.log" || assertion_rc=$?
@@ -148,7 +166,7 @@ git -C "$R" add AGENTS.md
 unset DOC_LIMITS_CLASSES
 
 SETTINGS_ASSERTIONS=0
-while IFS='|' read -r name operation mode expected; do
+while IFS='|' read -r name operation mode expected first_line; do
   case "$operation" in
     split-settings)
       printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
@@ -162,24 +180,46 @@ while IFS='|' read -r name operation mode expected; do
       git -C "$R" rm -q --cached kendex.settings.toml
       printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
       ;;
+    stage-bom)
+      rm "$R/kendex.settings.toml"
+      mkdir -p "$R/.kendex"
+      printf '\357\273\277[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml"
+      git -C "$R" add .kendex/settings.toml
+      ;;
   esac
   case "$mode" in
     worktree) run ;;
     staged) run --staged ;;
   esac
   expect "$expected" "$name"
+  [ -z "$first_line" ] || expect_first_line "$first_line" "$name diagnostic"
   SETTINGS_ASSERTIONS=$((SETTINGS_ASSERTIONS + 1))
 done <<'SETTINGS_CASES'
 settings-staged-strict|split-settings|staged|1
 settings-worktree-relaxed|unchanged|worktree|0
 settings-relaxed-staged|stage-relaxed|staged|0
 settings-deleted-from-index|delete-settings|staged|0
+settings-staged-bom|stage-bom|staged|2|doc-limits-error=settings-bom value=.kendex/settings.toml
 SETTINGS_CASES
 if [ "$SETTINGS_ASSERTIONS" -eq 0 ]; then
   printf 'FAIL: SETTINGS_CASES executed no assertions\n' >&2
   exit 1
 fi
 
+private_command staged-settings-label
+MUTANT_SETTINGS="$(dirname "$MUTANT")/lib/settings.sh"
+[ "$(grep -Fxc '        sr_env_table "$file" "$source" >/dev/null || return 1' "$MUTANT_SETTINGS")" -eq 1 ]
+sed 's/^        sr_env_table "\$file" "\$source" >\/dev\/null || return 1$/        sr_env_table "$file" >\/dev\/null || return 1/' "$TEST_DIR/../scripts/lib/settings.sh" >"$MUTANT_SETTINGS.changed"
+if cmp -s "$TEST_DIR/../scripts/lib/settings.sh" "$MUTANT_SETTINGS.changed"; then exit 1; fi
+mv "$MUTANT_SETTINGS.changed" "$MUTANT_SETTINGS"
+bash -n "$MUTANT_SETTINGS"
+SR="$MUTANT"
+run --staged
+must_fail_first_line 'doc-limits-error=settings-bom value=.kendex/settings.toml' 'staged settings label control: the snapshot path fails the BOM row'
+SR="$SOURCE_COMMAND"
+
+git -C "$R" rm -qf .kendex/settings.toml
+printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
 git -C "$R" add kendex.settings.toml
 git -C "$R" commit -qm 'strict settings control'
 printf '[env]\nDOC_LIMITS_CLASSES = "*.md=2k"\n' >"$R/kendex.settings.toml"

--- a/skills/doc-limits/tests/staged-scope.test.sh
+++ b/skills/doc-limits/tests/staged-scope.test.sh
@@ -181,9 +181,15 @@ while IFS='|' read -r name operation mode expected first_line; do
       printf '[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/kendex.settings.toml"
       ;;
     stage-bom)
-      rm "$R/kendex.settings.toml"
+      rm -f "$R/kendex.settings.toml" "$R/.kendex/settings.toml"
       mkdir -p "$R/.kendex"
       printf '\357\273\277[env]\nDOC_LIMITS_CLASSES = "*.md=1k"\n' >"$R/.kendex/settings.toml"
+      git -C "$R" add .kendex/settings.toml
+      ;;
+    stage-symlink)
+      rm -f "$R/kendex.settings.toml" "$R/.kendex/settings.toml"
+      mkdir -p "$R/.kendex"
+      ln -s ../kendex.settings.toml "$R/.kendex/settings.toml"
       git -C "$R" add .kendex/settings.toml
       ;;
   esac
@@ -199,6 +205,7 @@ settings-staged-strict|split-settings|staged|1
 settings-worktree-relaxed|unchanged|worktree|0
 settings-relaxed-staged|stage-relaxed|staged|0
 settings-deleted-from-index|delete-settings|staged|0
+settings-staged-symlink|stage-symlink|staged|2|doc-limits-error=settings-index-symlink value=.kendex/settings.toml
 settings-staged-bom|stage-bom|staged|2|doc-limits-error=settings-bom value=.kendex/settings.toml
 SETTINGS_CASES
 if [ "$SETTINGS_ASSERTIONS" -eq 0 ]; then


### PR DESCRIPTION
Document-limits now emits stable first-line keys and relevant values for command notices, command refusals, and settings-loader failures. English explanations remain on following lines.

- Audit the settings, configuration, and shipped-default test surfaces with visible input tables and one must-fail control per changed behavior.
- Vendor the review-gate settings diagnostics mechanism with document-limits `sr_` names.
- Keep source files and tracked `.agents` renders together.
- Cover malformed render inventories in both worktree and staged modes. Update the staged-policy control after dependency stderr is suppressed.

Compliant files left unchanged: none. Each package test file needed either the audit changes or a review fix for the stable output protocol.

Validation: all document-limits suites pass. The final-head guard runs with `TMPDIR` unset.

KEN-1241 remains open for the other package audits.
