### PR TITLE
fix(KEN-1241): accept checked mktemp assignments

### DIFF
--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -732,6 +732,18 @@ has_exit_trap() { # FILE
 # opens with `$(`, and it runs no command and carries no status, so a loop
 # counter — the commonest line in this repo's own tooling — is not the shape.
 SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
+# A substitution assignment's status is checked when the assignment is the
+# condition, or when an operator follows the substitution's closing `)`.
+# Reading only the tail keeps an operator inside the substitution out.
+substitution_status_checked() { # LINE
+  if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1"; then
+    return 0
+  fi
+  case "${1##*)}" in
+    *'||'* | *'&&'*) return 0 ;;
+  esac
+  return 1
+}
 # The guard the assignment was written to reach: a test naming the assigned
 # variable on one of the lines just below. It is the whole finding — a
 # variable nothing below tests belongs to a command whose failure is MEANT to
@@ -1207,7 +1219,9 @@ while IFS= read -r f; do
     n="${rec%%"$TAB"*}"
     content="${rec#*"$TAB"}"
 
-    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] && printf '%s' "$content" | grep -Eq -- "$MKTEMP_ASSIGN"; then
+    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] \
+      && grep -Eq -- "$MKTEMP_ASSIGN" <<<"$content" \
+      && ! substitution_status_checked "$content"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
     fi
 
@@ -1222,22 +1236,13 @@ while IFS= read -r f; do
       && [ "$has_ee" = 1 ] && [ "$has_noee" = 0 ]; then
       case "$content" in
         *'$('*)
-          # The operator is a status capture only OUTSIDE the substitution, so
-          # the skip reads the tail past the last `)`: `VAR="$(cmd)" || VAR=""`
-          # is the fix shape and stays out, while `VAR="$(cd "$d" && cmd)"` —
-          # whose inner operator captures nothing — is judged like any other.
-          case "${content##*)}" in
-            *'||'* | *'&&'*) ;;
-            *)
-              if grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
-                assign_var="${content#"${content%%[![:space:]]*}"}"
-                assign_var="${assign_var%%=*}"
-                if guard_tests_var "$cpath" "$n" "$assign_var"; then
-                  emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
-                fi
-              fi
-              ;;
-          esac
+          if ! substitution_status_checked "$content" && grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
+            assign_var="${content#"${content%%[![:space:]]*}"}"
+            assign_var="${assign_var%%=*}"
+            if guard_tests_var "$cpath" "$n" "$assign_var"; then
+              emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
+            fi
+          fi
           ;;
       esac
     fi

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -733,15 +733,14 @@ has_exit_trap() { # FILE
 # counter — the commonest line in this repo's own tooling — is not the shape.
 SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
 # A substitution assignment's status is checked when the assignment is the
-# condition, or when an operator follows the substitution's closing `)`.
-# Reading only the tail keeps an operator inside the substitution out.
+# condition, or when an operator immediately follows the substitution.
+# Reading only the tail keeps an operator inside the substitution out, and
+# requiring the operator at the tail's start keeps a later command out.
 substitution_status_checked() { # LINE
   if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1"; then
     return 0
   fi
-  case "${1##*)}" in
-    *'||'* | *'&&'*) return 0 ;;
-  esac
+  grep -Eq -- '^"?[[:space:]]*(&&|\|\|)' <<<"${1##*)}" && return 0
   return 1
 }
 # The guard the assignment was written to reach: a test naming the assigned

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -737,7 +737,8 @@ SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
 # Reading only the tail keeps an operator inside the substitution out, and
 # requiring the operator at the tail's start keeps a later command out.
 substitution_status_checked() { # LINE
-  if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1"; then
+  if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1" \
+    && ! grep -Eq -- '(&&|\|\|)' <<<"${1%%)*}"; then
     return 0
   fi
   grep -Eq -- '^"?[[:space:]]*(&&|\|\|)' <<<"${1##*)}" && return 0

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -282,7 +282,7 @@ seed mktempchecked
 mkdir -p "$R/scripts/lib"
 cat >"$R/scripts/lib/or-list.sh" <<'EOF'
 #!/usr/bin/env bash
-read_error_file="$(mktemp)" || { echo "could not create error file" >&2; return 1; }
+read_error_file="$(mktemp)" || { echo "could not create error file" >&2; exit 1; }
 trap 'rm -f "${read_error_file:-}"' EXIT
 EOF
 cat >"$R/scripts/lib/condition.sh" <<'EOF'
@@ -292,24 +292,32 @@ if false; then
 elif _elt_tmp="$(mktemp)"; then
   rm -f "$_elt_tmp"
 else
-  return 1
+  exit 1
 fi
 trap ':' EXIT
 EOF
 run_pf
 clean "an OR-list handler and an elif condition check mktemp status" 2
 
-echo "=== control: inner and later operators do not check the assignment ==="
+echo "=== control: inner, later, and conditional-inner operators do not check the assignment ==="
 cat >"$R/scripts/lib/or-list.sh" <<'EOF'
 #!/usr/bin/env bash
 read_error_file="$(mktemp || true)"
 later_error_file="$(mktemp)"; false || true
 trap 'rm -f "${read_error_file:-}"' EXIT
 EOF
+cat >"$R/scripts/lib/condition.sh" <<'EOF'
+#!/usr/bin/env bash
+if conditional_tmp="$(mktemp || true)"; then
+  :
+fi
+trap 'rm -f "${conditional_tmp:-}"' EXIT
+EOF
 run_pf
-fires "inner and later operators leave both assignments unchecked" \
+fires "inner, later, and conditional-inner operators leave the assignments unchecked" \
   "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp" \
-  "scripts/lib/or-list.sh:3: [fail-open] unchecked mktemp"
+  "scripts/lib/or-list.sh:3: [fail-open] unchecked mktemp" \
+  "scripts/lib/condition.sh:2: [fail-open] unchecked mktemp"
 
 echo "=== inert trap text arms nothing; quoted command text swallows nothing; an untracked runner wires ==="
 seed inert

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -299,14 +299,17 @@ EOF
 run_pf
 clean "an OR-list handler and an elif condition check mktemp status" 2
 
-echo "=== control: an operator inside mktemp does not check the assignment ==="
+echo "=== control: inner and later operators do not check the assignment ==="
 cat >"$R/scripts/lib/or-list.sh" <<'EOF'
 #!/usr/bin/env bash
 read_error_file="$(mktemp || true)"
+later_error_file="$(mktemp)"; false || true
 trap 'rm -f "${read_error_file:-}"' EXIT
 EOF
 run_pf
-fires "an operator hidden inside the substitution leaves the assignment unchecked" "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp"
+fires "inner and later operators leave both assignments unchecked" \
+  "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp" \
+  "scripts/lib/or-list.sh:3: [fail-open] unchecked mktemp"
 
 echo "=== inert trap text arms nothing; quoted command text swallows nothing; an untracked runner wires ==="
 seed inert

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -277,6 +277,37 @@ fires "the trapped scratch dir beside it does not shield an untrapped one" "scri
 fires "the captured status beside it does not shield a swallowed one" "scripts/swallow.sh:4: [fail-open] git || true swallows exit 2"
 fires "the wired suites beside it, and the workflow path filter globbing everything, do not wire an unwired one" "tests/orphan.test.sh:0: [unwired-suite]"
 
+echo "=== mktemp assignments whose status the shell checks stay clean ==="
+seed mktempchecked
+mkdir -p "$R/scripts/lib"
+cat >"$R/scripts/lib/or-list.sh" <<'EOF'
+#!/usr/bin/env bash
+read_error_file="$(mktemp)" || { echo "could not create error file" >&2; return 1; }
+trap 'rm -f "${read_error_file:-}"' EXIT
+EOF
+cat >"$R/scripts/lib/condition.sh" <<'EOF'
+#!/usr/bin/env bash
+if false; then
+  :
+elif _elt_tmp="$(mktemp)"; then
+  rm -f "$_elt_tmp"
+else
+  return 1
+fi
+trap ':' EXIT
+EOF
+run_pf
+clean "an OR-list handler and an elif condition check mktemp status" 2
+
+echo "=== control: an operator inside mktemp does not check the assignment ==="
+cat >"$R/scripts/lib/or-list.sh" <<'EOF'
+#!/usr/bin/env bash
+read_error_file="$(mktemp || true)"
+trap 'rm -f "${read_error_file:-}"' EXIT
+EOF
+run_pf
+fires "an operator hidden inside the substitution leaves the assignment unchecked" "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp"
+
 echo "=== inert trap text arms nothing; quoted command text swallows nothing; an untracked runner wires ==="
 seed inert
 mkdir -p "$R/.github/workflows"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -732,6 +732,18 @@ has_exit_trap() { # FILE
 # opens with `$(`, and it runs no command and carries no status, so a loop
 # counter — the commonest line in this repo's own tooling — is not the shape.
 SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
+# A substitution assignment's status is checked when the assignment is the
+# condition, or when an operator follows the substitution's closing `)`.
+# Reading only the tail keeps an operator inside the substitution out.
+substitution_status_checked() { # LINE
+  if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1"; then
+    return 0
+  fi
+  case "${1##*)}" in
+    *'||'* | *'&&'*) return 0 ;;
+  esac
+  return 1
+}
 # The guard the assignment was written to reach: a test naming the assigned
 # variable on one of the lines just below. It is the whole finding — a
 # variable nothing below tests belongs to a command whose failure is MEANT to
@@ -1207,7 +1219,9 @@ while IFS= read -r f; do
     n="${rec%%"$TAB"*}"
     content="${rec#*"$TAB"}"
 
-    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] && printf '%s' "$content" | grep -Eq -- "$MKTEMP_ASSIGN"; then
+    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] \
+      && grep -Eq -- "$MKTEMP_ASSIGN" <<<"$content" \
+      && ! substitution_status_checked "$content"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
     fi
 
@@ -1222,22 +1236,13 @@ while IFS= read -r f; do
       && [ "$has_ee" = 1 ] && [ "$has_noee" = 0 ]; then
       case "$content" in
         *'$('*)
-          # The operator is a status capture only OUTSIDE the substitution, so
-          # the skip reads the tail past the last `)`: `VAR="$(cmd)" || VAR=""`
-          # is the fix shape and stays out, while `VAR="$(cd "$d" && cmd)"` —
-          # whose inner operator captures nothing — is judged like any other.
-          case "${content##*)}" in
-            *'||'* | *'&&'*) ;;
-            *)
-              if grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
-                assign_var="${content#"${content%%[![:space:]]*}"}"
-                assign_var="${assign_var%%=*}"
-                if guard_tests_var "$cpath" "$n" "$assign_var"; then
-                  emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
-                fi
-              fi
-              ;;
-          esac
+          if ! substitution_status_checked "$content" && grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
+            assign_var="${content#"${content%%[![:space:]]*}"}"
+            assign_var="${assign_var%%=*}"
+            if guard_tests_var "$cpath" "$n" "$assign_var"; then
+              emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
+            fi
+          fi
           ;;
       esac
     fi

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -733,15 +733,14 @@ has_exit_trap() { # FILE
 # counter — the commonest line in this repo's own tooling — is not the shape.
 SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
 # A substitution assignment's status is checked when the assignment is the
-# condition, or when an operator follows the substitution's closing `)`.
-# Reading only the tail keeps an operator inside the substitution out.
+# condition, or when an operator immediately follows the substitution.
+# Reading only the tail keeps an operator inside the substitution out, and
+# requiring the operator at the tail's start keeps a later command out.
 substitution_status_checked() { # LINE
   if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1"; then
     return 0
   fi
-  case "${1##*)}" in
-    *'||'* | *'&&'*) return 0 ;;
-  esac
+  grep -Eq -- '^"?[[:space:]]*(&&|\|\|)' <<<"${1##*)}" && return 0
   return 1
 }
 # The guard the assignment was written to reach: a test naming the assigned

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -737,7 +737,8 @@ SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
 # Reading only the tail keeps an operator inside the substitution out, and
 # requiring the operator at the tail's start keeps a later command out.
 substitution_status_checked() { # LINE
-  if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1"; then
+  if grep -Eq -- '^[[:space:]]*(if|elif)[[:space:]]+(![[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]' <<<"$1" \
+    && ! grep -Eq -- '(&&|\|\|)' <<<"${1%%)*}"; then
     return 0
   fi
   grep -Eq -- '^"?[[:space:]]*(&&|\|\|)' <<<"${1##*)}" && return 0

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -282,7 +282,7 @@ seed mktempchecked
 mkdir -p "$R/scripts/lib"
 cat >"$R/scripts/lib/or-list.sh" <<'EOF'
 #!/usr/bin/env bash
-read_error_file="$(mktemp)" || { echo "could not create error file" >&2; return 1; }
+read_error_file="$(mktemp)" || { echo "could not create error file" >&2; exit 1; }
 trap 'rm -f "${read_error_file:-}"' EXIT
 EOF
 cat >"$R/scripts/lib/condition.sh" <<'EOF'
@@ -292,24 +292,32 @@ if false; then
 elif _elt_tmp="$(mktemp)"; then
   rm -f "$_elt_tmp"
 else
-  return 1
+  exit 1
 fi
 trap ':' EXIT
 EOF
 run_pf
 clean "an OR-list handler and an elif condition check mktemp status" 2
 
-echo "=== control: inner and later operators do not check the assignment ==="
+echo "=== control: inner, later, and conditional-inner operators do not check the assignment ==="
 cat >"$R/scripts/lib/or-list.sh" <<'EOF'
 #!/usr/bin/env bash
 read_error_file="$(mktemp || true)"
 later_error_file="$(mktemp)"; false || true
 trap 'rm -f "${read_error_file:-}"' EXIT
 EOF
+cat >"$R/scripts/lib/condition.sh" <<'EOF'
+#!/usr/bin/env bash
+if conditional_tmp="$(mktemp || true)"; then
+  :
+fi
+trap 'rm -f "${conditional_tmp:-}"' EXIT
+EOF
 run_pf
-fires "inner and later operators leave both assignments unchecked" \
+fires "inner, later, and conditional-inner operators leave the assignments unchecked" \
   "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp" \
-  "scripts/lib/or-list.sh:3: [fail-open] unchecked mktemp"
+  "scripts/lib/or-list.sh:3: [fail-open] unchecked mktemp" \
+  "scripts/lib/condition.sh:2: [fail-open] unchecked mktemp"
 
 echo "=== inert trap text arms nothing; quoted command text swallows nothing; an untracked runner wires ==="
 seed inert

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -299,14 +299,17 @@ EOF
 run_pf
 clean "an OR-list handler and an elif condition check mktemp status" 2
 
-echo "=== control: an operator inside mktemp does not check the assignment ==="
+echo "=== control: inner and later operators do not check the assignment ==="
 cat >"$R/scripts/lib/or-list.sh" <<'EOF'
 #!/usr/bin/env bash
 read_error_file="$(mktemp || true)"
+later_error_file="$(mktemp)"; false || true
 trap 'rm -f "${read_error_file:-}"' EXIT
 EOF
 run_pf
-fires "an operator hidden inside the substitution leaves the assignment unchecked" "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp"
+fires "inner and later operators leave both assignments unchecked" \
+  "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp" \
+  "scripts/lib/or-list.sh:3: [fail-open] unchecked mktemp"
 
 echo "=== inert trap text arms nothing; quoted command text swallows nothing; an untracked runner wires ==="
 seed inert

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -277,6 +277,37 @@ fires "the trapped scratch dir beside it does not shield an untrapped one" "scri
 fires "the captured status beside it does not shield a swallowed one" "scripts/swallow.sh:4: [fail-open] git || true swallows exit 2"
 fires "the wired suites beside it, and the workflow path filter globbing everything, do not wire an unwired one" "tests/orphan.test.sh:0: [unwired-suite]"
 
+echo "=== mktemp assignments whose status the shell checks stay clean ==="
+seed mktempchecked
+mkdir -p "$R/scripts/lib"
+cat >"$R/scripts/lib/or-list.sh" <<'EOF'
+#!/usr/bin/env bash
+read_error_file="$(mktemp)" || { echo "could not create error file" >&2; return 1; }
+trap 'rm -f "${read_error_file:-}"' EXIT
+EOF
+cat >"$R/scripts/lib/condition.sh" <<'EOF'
+#!/usr/bin/env bash
+if false; then
+  :
+elif _elt_tmp="$(mktemp)"; then
+  rm -f "$_elt_tmp"
+else
+  return 1
+fi
+trap ':' EXIT
+EOF
+run_pf
+clean "an OR-list handler and an elif condition check mktemp status" 2
+
+echo "=== control: an operator inside mktemp does not check the assignment ==="
+cat >"$R/scripts/lib/or-list.sh" <<'EOF'
+#!/usr/bin/env bash
+read_error_file="$(mktemp || true)"
+trap 'rm -f "${read_error_file:-}"' EXIT
+EOF
+run_pf
+fires "an operator hidden inside the substitution leaves the assignment unchecked" "scripts/lib/or-list.sh:2: [fail-open] unchecked mktemp"
+
 echo "=== inert trap text arms nothing; quoted command text swallows nothing; an untracked runner wires ==="
 seed inert
 mkdir -p "$R/.github/workflows"


### PR DESCRIPTION
Preflight classified checked `mktemp` assignments as fail-open in files without errexit. This blocked review-gate even when an OR-list handler or `elif` condition checked the assignment status. The matcher now shares one status-handling test with the existing command-substitution rule and still rejects an operator hidden inside the substitution.

Validation:

- All preflight shell suites pass.
- Bash 3.2 lint passes for the source and render.
- Must-fail control: `read_error_file="$(mktemp || true)"` still reports unchecked `mktemp`.

Compliant test files left unchanged:

- `diff-parse.test.sh`
- `lanes-must-fail.test.sh`
- `modes.test.sh`
- `runner-wiring.test.sh`
- `unavailable-tools.test.sh`
