### PR TITLE
Explain the Shared files chip and its neighbours (KEN-1283)

### DIFF
--- a/changelog.d/changed/KEN-1283.md
+++ b/changelog.d/changed/KEN-1283.md
@@ -1,0 +1,1 @@
+- The Shared files chip now names the files several harnesses read and what changing one costs; Forked, Bundled with, and a harness row's folder, version and count badges say what they are too.

--- a/ui/src/components/harnesses/harness-row.test.tsx
+++ b/ui/src/components/harnesses/harness-row.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { harnessName } from "@/lib/labels";
+import {
+  HARNESS_VERSION_HELP,
+  harnessRootHelp,
+  showKindLabel,
+} from "@/lib/copy";
+import { harnessName, kindLabel } from "@/lib/labels";
 import { showEverythingLabel } from "@/lib/show-everything-label";
 import { useNavStore } from "@/stores/nav";
 import { mount as mountTree } from "@/test/dom";
@@ -16,13 +21,13 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const mount = (detectedRoot: string | null) => {
+const mount = (detectedRoot: string | null, version: string | null = null) => {
   useNavStore.setState(navHome);
   return mountTree(
     <HarnessRow
       place={{ harness: "claude" }}
       detectedRoot={detectedRoot}
-      version={null}
+      version={version}
       counts={[["skill", 3]]}
       folder=""
       onFolderChange={() => {}}
@@ -83,5 +88,43 @@ describe("the harness row's name", () => {
     );
     expect(named).toEqual([]);
     expect(useNavStore.getState().page).toBe("home");
+  });
+});
+
+// Three things on this row are shown without a word saying what they are: a
+// path, a version number, and a count badge whose press goes somewhere the
+// count does not name. Each says it where a pointer, a keyboard or a screen
+// reader can ask.
+describe("what a harness row's line and badges say they are", () => {
+  it("names the path, the version and where a count badge lands", () => {
+    const host = mount("/home/u/.claude", "2.4.0");
+    // The leaf that holds the words, not the wrapper around it and the
+    // pencil, which carries the same textContent and a title of its own.
+    const leaf = (text: string) =>
+      [...host.querySelectorAll<HTMLElement>("span")].find(
+        (el) => el.children.length === 0 && el.textContent === text,
+      );
+    const path = leaf("/home/u/.claude");
+    expect(path?.title).toBe(harnessRootHelp("Claude Code"));
+    const version = leaf("2.4.0");
+    expect(version?.title).toBe(HARNESS_VERSION_HELP);
+    const badge = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (b) => b.textContent === `3 ${kindLabel("skill", 3)}`,
+    );
+    expect(badge?.getAttribute("aria-label")).toBe(
+      showKindLabel(3, kindLabel("skill", 3), "Claude Code"),
+    );
+  });
+
+  // The must-fail half: a row that pinned one sentence to every line would
+  // pass the case above and call a missing harness's "Not installed" the
+  // place its files are kept.
+  it("claims no folder for a harness that has none", () => {
+    const host = mount(null);
+    const line = [...host.querySelectorAll<HTMLElement>("span")].find(
+      (el) => el.children.length === 0 && el.textContent === "Not installed",
+    );
+    if (!line) throw new Error("no not-installed line");
+    expect(line.title).toBe("");
   });
 });

--- a/ui/src/components/harnesses/harness-row.tsx
+++ b/ui/src/components/harnesses/harness-row.tsx
@@ -6,9 +6,15 @@ import { HarnessFolderDialog } from "@/components/harnesses/harness-folder-dialo
 import { ShowEverythingButton } from "@/components/harnesses/show-everything-button";
 import { KindCountBadges } from "@/components/kind-count-badges";
 import { Button } from "@/components/ui/button";
-import { HARNESS_FOLDER_HELP, NOT_INSTALLED_LABEL } from "@/lib/copy";
+import {
+  HARNESS_FOLDER_HELP,
+  HARNESS_VERSION_HELP,
+  harnessRootHelp,
+  NOT_INSTALLED_LABEL,
+  showKindLabel,
+} from "@/lib/copy";
 import type { ItemPlace } from "@/lib/derive";
-import { harnessName } from "@/lib/labels";
+import { harnessName, kindLabel } from "@/lib/labels";
 import { cn } from "@/lib/utils";
 import { useNavStore } from "@/stores/nav";
 
@@ -59,18 +65,27 @@ export function HarnessRow({
               {name}
             </span>
           )}
+          {/* A bare number beside a tool name could be anything it ships;
+              the one word that says which is on hover. */}
           {version ? (
-            <span className="font-mono text-xs text-muted-foreground">
+            <span
+              className="font-mono text-xs text-muted-foreground"
+              title={HARNESS_VERSION_HELP}
+            >
               {version}
             </span>
           ) : null}
         </span>
         <span className="flex min-w-0 items-center gap-1 pl-7">
+          {/* A path on its own line says nothing about whose it is or what
+              it is for; the pencil beside it already answers that, and the
+              line now answers it too. */}
           <span
             className={cn(
               "truncate text-[13px] text-muted-foreground",
               detectedRoot && "font-mono",
             )}
+            title={detectedRoot ? harnessRootHelp(name) : undefined}
           >
             {detectedRoot ?? NOT_INSTALLED_LABEL}
           </span>
@@ -101,6 +116,9 @@ export function HarnessRow({
         <div className="flex shrink-0 flex-wrap justify-end gap-1.5 pt-0.5">
           <KindCountBadges
             counts={counts}
+            describe={(kind, count) =>
+              showKindLabel(count, kindLabel(kind, count), name)
+            }
             onKindClick={(kind) => goToLibrary({ ...place, kind })}
           />
         </div>

--- a/ui/src/components/kind-count-badges.tsx
+++ b/ui/src/components/kind-count-badges.tsx
@@ -7,11 +7,16 @@ import { kindLabel } from "@/lib/labels";
 export function KindCountBadges({
   counts,
   onKindClick,
+  describe,
   emptyLabel = "Nothing yet",
   emptyClassName = "text-xs text-muted-foreground",
 }: {
   counts: [ItemKind, number][];
   onKindClick?: (kind: ItemKind) => void;
+  /** What pressing one of these badges does, in words. "3 skills" says what
+   *  the badge counts and nothing about where the press lands; a caller that
+   *  can name the place says it here and the pill announces it. */
+  describe?: (kind: ItemKind, count: number) => string;
   emptyLabel?: string;
   emptyClassName?: string;
 }) {
@@ -27,7 +32,11 @@ export function KindCountBadges({
             variant="outline"
             className="cursor-pointer hover:bg-accent"
             render={
-              <button type="button" onClick={() => onKindClick(kind)}>
+              <button
+                type="button"
+                aria-label={describe?.(kind, count)}
+                onClick={() => onKindClick(kind)}
+              >
                 {count} {kindLabel(kind, count)}
               </button>
             }

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -1,8 +1,14 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
+import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Scope } from "@/bindings";
-import { FORKED_BADGE_LABEL } from "@/lib/copy";
+import {
+  bundledWithLabel,
+  FORKED_BADGE_HELP,
+  FORKED_BADGE_LABEL,
+  vendorHelp,
+} from "@/lib/copy";
 import { groupItems } from "@/lib/derive";
 import { mount as mountTree } from "@/test/dom";
 import { InstalledRow } from "./installed-row";
@@ -108,6 +114,54 @@ describe("opening a package from its Library row", () => {
       if (entry.args !== undefined)
         expect(onOpen, entry.name).toHaveBeenCalledWith(...entry.args);
     }
+  });
+});
+
+// A word the app made up — Forked, Bundled with Anthropic — says nothing to
+// the person reading the row. Each one carries what it costs them, and it
+// arrives on focus, not only under a pointer.
+describe("the words a Library row's badges stand for", () => {
+  // The nothing-before-focus half of every case here: a helper that read a
+  // flyout already on screen would pass over a badge that explains itself
+  // only under a pointer, which is the state this change is fixing.
+  const openOn = (badge: HTMLElement): string | undefined => {
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+    act(() => badge.focus());
+    return (
+      document.querySelector('[data-slot="tooltip-content"]')?.textContent ??
+      undefined
+    );
+  };
+
+  it("opens the fork's meaning on focus", () => {
+    const { host } = mount([VG]);
+    const badge = [...host.querySelectorAll<HTMLElement>("button")].find((b) =>
+      b.textContent?.startsWith(FORKED_BADGE_LABEL),
+    );
+    if (!badge) throw new Error("no fork badge");
+    expect(openOn(badge)).toBe(FORKED_BADGE_HELP);
+  });
+
+  it("opens what a bundled package is on focus", () => {
+    const bundled = groupItems([
+      { ...item(VG), vendor: "Anthropic" },
+    ] as never)[0];
+    const host = mountTree(
+      <tbody>
+        <InstalledRow
+          group={bundled}
+          origin={null}
+          forkedIn={[]}
+          onOpen={() => {}}
+        />
+      </tbody>,
+      { host: "table" },
+    );
+    const badge = [
+      ...host.querySelectorAll<HTMLElement>('[data-slot="tooltip-trigger"]'),
+    ].find((b) => b.textContent?.startsWith(bundledWithLabel("claude")));
+    if (!badge) throw new Error("no bundled badge");
+    expect(openOn(badge)).toBe(vendorHelp("Anthropic"));
   });
 });
 

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -1,6 +1,7 @@
 import type { HarnessId, Origin, Scope } from "@/bindings";
 import { Ago } from "@/components/ago";
 import { HarnessBadge } from "@/components/harness-badge";
+import { SharedFilesBadge } from "@/components/shared-files-badge";
 import { StatusDot } from "@/components/status-dot";
 import { TagBadges } from "@/components/tag-badge";
 import { Badge } from "@/components/ui/badge";
@@ -11,7 +12,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { clickAsksToOpen } from "@/lib/click-asks-to-open";
-import { bundledWithLabel, FORKED_BADGE_LABEL, vendorHelp } from "@/lib/copy";
+import {
+  bundledWithLabel,
+  FORKED_BADGE_HELP,
+  FORKED_BADGE_LABEL,
+  vendorHelp,
+} from "@/lib/copy";
 import { STATUS_LABELS } from "@/lib/copy-customize";
 import {
   type GroupStatus,
@@ -19,6 +25,7 @@ import {
   groupStatus,
   groupVendor,
   type ItemGroup,
+  sharedFiles,
 } from "@/lib/derive";
 import { kindIcon } from "@/lib/kind-icon";
 import {
@@ -55,6 +62,7 @@ export function InstalledRow({
   const displayName =
     group.kind === "hook" ? hookDisplayName(group.name) : group.name;
   const vendor = groupVendor(group);
+  const shared = sharedFiles(group.installations);
   const scopes = groupScopes(group);
   const status = groupStatus(group);
   const whereLabel =
@@ -100,21 +108,45 @@ export function InstalledRow({
                   the reader it happened and not where, and leaves nothing
                   to open — a fork belongs to the place it was made in. */}
               {forkedIn.map((where) => (
-                <Badge
-                  key={scopeKey(where)}
-                  variant="outline"
-                  className="cursor-pointer"
-                  render={
-                    <button type="button" onClick={() => onOpen(where)}>
-                      {`${FORKED_BADGE_LABEL} in ${placeName(where, scopes)}`}
-                    </button>
-                  }
-                />
+                // "Forked" is the app's word, not the reader's: what it
+                // costs them is the paused updates, and that arrives on
+                // hover, on focus and through the button's own name.
+                <Tooltip key={scopeKey(where)}>
+                  <TooltipTrigger
+                    render={
+                      <Badge
+                        variant="outline"
+                        className="cursor-pointer"
+                        render={
+                          <button type="button" onClick={() => onOpen(where)}>
+                            {`${FORKED_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                            <span className="sr-only">{FORKED_BADGE_HELP}</span>
+                          </button>
+                        }
+                      />
+                    }
+                  />
+                  <TooltipContent className="max-w-80">
+                    {FORKED_BADGE_HELP}
+                  </TooltipContent>
+                </Tooltip>
               ))}
               {vendor ? (
-                <Badge variant="outline" title={vendorHelp(vendor)}>
-                  {bundledWithLabel(group.installations[0].harness)}
-                </Badge>
+                // A title alone answers a pointer and nothing else; the
+                // same words reach the keyboard and a screen reader here.
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Badge variant="outline" tabIndex={0}>
+                        {bundledWithLabel(group.installations[0].harness)}
+                        <span className="sr-only">{vendorHelp(vendor)}</span>
+                      </Badge>
+                    }
+                  />
+                  <TooltipContent className="max-w-80">
+                    {vendorHelp(vendor)}
+                  </TooltipContent>
+                </Tooltip>
               ) : null}
             </span>
             {group.description ? (
@@ -141,9 +173,7 @@ export function InstalledRow({
           {group.harnesses.map((h) => (
             <HarnessBadge key={h} harness={h as HarnessId} compact />
           ))}
-          {group.shared ? (
-            <Badge variant="secondary">Shared files</Badge>
-          ) : null}
+          <SharedFilesBadge files={shared} />
         </span>
       </TableCell>
       <TableCell title={whereTitle} className="text-muted-foreground">

--- a/ui/src/components/package/package-meta.tsx
+++ b/ui/src/components/package/package-meta.tsx
@@ -7,11 +7,11 @@ import type {
 import { Ago } from "@/components/ago";
 import { HarnessBadge } from "@/components/harness-badge";
 import { SectionHeading } from "@/components/section";
+import { SharedFilesBadge } from "@/components/shared-files-badge";
 import { StatusLine } from "@/components/status-note";
 import { TagBadges } from "@/components/tag-badge";
-import { Badge } from "@/components/ui/badge";
 import { TAGS_ROW_LABEL } from "@/lib/copy";
-import { groupScopes, type ItemGroup } from "@/lib/derive";
+import { groupScopes, type ItemGroup, sharedFiles } from "@/lib/derive";
 import { kindLabel, scopeName } from "@/lib/labels";
 import { versionLabel } from "@/lib/versions";
 import { subscription } from "@/stores/marketplaces";
@@ -73,9 +73,7 @@ export function PackageMetaBlock({
             {group.harnesses.map((h) => (
               <HarnessBadge key={h} harness={h as HarnessId} />
             ))}
-            {group.shared ? (
-              <Badge variant="secondary">Shared files</Badge>
-            ) : null}
+            <SharedFilesBadge files={sharedFiles(group.installations)} />
           </span>
         </Row>
         <Row label="Scope">{scopeName(primary.scope)}</Row>

--- a/ui/src/components/shared-files-badge.dom.test.tsx
+++ b/ui/src/components/shared-files-badge.dom.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+import type { ObservedItem } from "@/bindings";
+import { SharedFilesBadge } from "@/components/shared-files-badge";
+import { SHARED_FILES_CONSEQUENCE } from "@/lib/copy";
+import { sharedFiles } from "@/lib/derive";
+import { mount } from "@/test/dom";
+
+const DEPLOY = "/h/.agents/skills/deploy";
+const LINT = "/h/.agents/skills/lint";
+
+const install = (overrides: Partial<ObservedItem>): ObservedItem =>
+  ({
+    kind: "skill",
+    name: "deploy",
+    harness: "claude",
+    scope: { scope: "global" },
+    path: DEPLOY,
+    fileState: { state: "dir" },
+    enabled: true,
+    origin: null,
+    description: null,
+    tags: [],
+    modifiedAt: null,
+    vendor: null,
+    ...overrides,
+  }) as ObservedItem;
+
+/** One folder both tools read: Codex reaches it through a link of its own,
+ *  so the two paths differ and the bytes are one copy. */
+const linkedTo = (target: string): ObservedItem[] => [
+  install({ path: target }),
+  install({
+    harness: "codex",
+    path: "/h/.codex/skills/deploy",
+    fileState: { state: "symlink", target, broken: false },
+  }),
+];
+
+/** The chip itself. Wrapping it in a tooltip makes the element the
+ *  trigger, so that is what the chip is on screen. */
+const badge = (host: HTMLElement): HTMLElement => {
+  const found = host.querySelector<HTMLElement>(
+    '[data-slot="tooltip-trigger"]',
+  );
+  if (!found) throw new Error("no shared-files badge rendered");
+  return found;
+};
+
+/** The flyout's own words, opened the way a keyboard opens it. */
+const flyout = (host: HTMLElement): string => {
+  const trigger = badge(host);
+  expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+  act(() => trigger.focus());
+  const content = document.querySelector('[data-slot="tooltip-content"]');
+  if (!content) throw new Error("focus opened no flyout");
+  return content.textContent ?? "";
+};
+
+describe("the Shared files badge", () => {
+  it("names the shared file, its readers and what sharing costs", () => {
+    const host = mount(
+      <SharedFilesBadge files={sharedFiles(linkedTo(DEPLOY))} />,
+    );
+    expect(badge(host).textContent).toContain("Shared files");
+
+    const words = flyout(host);
+    // The real path, not the word "shared": a reader who cannot see which
+    // file is meant can neither check the claim nor act on it.
+    expect(words).toContain(DEPLOY);
+    expect(words).toContain("Claude Code and Codex read");
+    expect(words).toContain(SHARED_FILES_CONSEQUENCE);
+  });
+
+  // The must-fail half: a flyout that printed a fixed sentence would pass
+  // the case above while naming a file this package does not share.
+  it("names the path these installations actually share", () => {
+    const host = mount(
+      <SharedFilesBadge files={sharedFiles(linkedTo(LINT))} />,
+    );
+    const words = flyout(host);
+    expect(words).toContain(LINT);
+    expect(words).not.toContain(DEPLOY);
+  });
+
+  // Nothing shared is no chip at all: a badge explaining itself into saying
+  // nothing is worse than the two bare words it replaced.
+  it("renders nothing when no two harnesses read one file", () => {
+    const apart = [
+      install({}),
+      install({ harness: "codex", path: "/h/.codex/skills/deploy" }),
+    ];
+    expect(sharedFiles(apart)).toEqual([]);
+    const host = mount(<SharedFilesBadge files={sharedFiles(apart)} />);
+    expect(host.querySelector('[data-slot="tooltip-trigger"]')).toBeNull();
+    expect(host.textContent).toBe("");
+  });
+});

--- a/ui/src/components/shared-files-badge.tsx
+++ b/ui/src/components/shared-files-badge.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  SHARED_FILES_BADGE_LABEL,
+  SHARED_FILES_CONSEQUENCE,
+  sharedFileReaders,
+  sharedFilesHelp,
+} from "@/lib/copy";
+import type { SharedFile } from "@/lib/derive";
+
+/**
+ * "Shared files": one copy of this package that several harnesses read.
+ *
+ * The two words alone are a fact about the app's plumbing that a reader has
+ * no way to check or act on, so the badge carries its own explanation — the
+ * paths themselves, who reads each, and what that costs on the next edit —
+ * on hover, on focus, and to a screen reader. Nothing is shared, no badge:
+ * the empty list is the same answer as the absent one.
+ */
+export function SharedFilesBadge({ files }: { files: SharedFile[] }) {
+  if (files.length === 0) return null;
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Badge variant="secondary" tabIndex={0}>
+            {SHARED_FILES_BADGE_LABEL}
+            <span className="sr-only">{sharedFilesHelp(files)}</span>
+          </Badge>
+        }
+      />
+      <TooltipContent className="max-w-96">
+        <span className="flex flex-col gap-1">
+          {files.map((file) => (
+            <span key={file.path}>
+              {sharedFileReaders(file.harnesses)} read{" "}
+              <span className="font-mono break-all">{file.path}</span>
+            </span>
+          ))}
+          <span>{SHARED_FILES_CONSEQUENCE}</span>
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -41,6 +41,40 @@ export const bundledWithLabel = (harness: HarnessId): string =>
   `Bundled with ${harnessName(harness)}`;
 export const vendorHelp = (vendor: string): string =>
   `${vendor} ships and updates this with the harness. kendex lists it, but doesn't manage or check it.`;
+// The badges on a harness row and on a Library row, and what each one means
+// said in the words of the thing itself. A badge that only a person who
+// already knows the app can read is a badge that says nothing.
+export const SHARED_FILES_BADGE_LABEL = "Shared files";
+/** Which harnesses read one path, written out. Every shared path has at
+ *  least two readers, so this is always a list. */
+export const sharedFileReaders = (harnesses: string[]): string => {
+  const names = harnesses.map((h) => harnessName(h as HarnessId));
+  return names.length < 2
+    ? names.join("")
+    : `${names.slice(0, -1).join(", ")} and ${names.at(-1)}`;
+};
+export const sharedFileLine = (harnesses: string[], path: string): string =>
+  `${sharedFileReaders(harnesses)} read ${path}`;
+export const SHARED_FILES_CONSEQUENCE =
+  "There is one copy, so a change to it is a change for all of them.";
+/** The whole explanation as one sentence run, for a screen reader. */
+export const sharedFilesHelp = (
+  files: { path: string; harnesses: string[] }[],
+): string =>
+  [
+    ...files.map((file) => `${sharedFileLine(file.harnesses, file.path)}.`),
+    SHARED_FILES_CONSEQUENCE,
+  ].join(" ");
+/** What the path under a harness's name is. */
+export const harnessRootHelp = (harness: string): string =>
+  `Where ${harness} keeps its files`;
+export const HARNESS_VERSION_HELP = "The installed version";
+/** What a count badge on a harness row opens. */
+export const showKindLabel = (
+  count: number,
+  kind: string,
+  harness: string,
+): string => `Show the ${count} ${kind} in ${harness}`;
 export const BROWSE_LABEL = "Choose a folder…";
 export const HARNESS_FOLDER_HELP = "Change where this harness keeps its files";
 export const harnessFolderTitle = (harness: string): string =>
@@ -154,6 +188,8 @@ export const updatedToastLabel = (name: string): string => `Updated ${name}`;
 
 // Fork: what happens when the app finds files you edited by hand.
 export const FORKED_BADGE_LABEL = "Forked";
+export const FORKED_BADGE_HELP =
+  "You changed this package's files here. kendex keeps your copy and pauses its updates until you decide what to do with it.";
 /** A fork whose files you have since changed. One state, not a question:
  *  the edit is the fork's content and nothing is held back for it. */
 export const FORKED_EDITED_BADGE_LABEL = "Forked · edited";

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -75,6 +75,37 @@ export interface ItemGroup {
   modifiedAt: number | null;
 }
 
+/** One path several harnesses read, and which ones read it. */
+export interface SharedFile {
+  /** Where the bytes are. */
+  path: string;
+  /** The harness ids reading that path, in the order they were observed. */
+  harnesses: string[];
+}
+
+/** The paths more than one harness reads, out of one item's installations.
+ *
+ * Where the bytes actually are, not where the harness looks for them: two
+ * harnesses linking to one shared folder are sharing a file, even though each
+ * has a path of its own pointing at it. The badge that says a package is
+ * shared and the flyout that says which files reads this one answer, so the
+ * badge can never stand over a list that disagrees with it. */
+export function sharedFiles(installations: ObservedItem[]): SharedFile[] {
+  const byPath = new Map<string, string[]>();
+  for (const install of installations) {
+    const real =
+      install.fileState.state === "symlink" && !install.fileState.broken
+        ? install.fileState.target
+        : install.path;
+    const harnesses = byPath.get(real) ?? [];
+    if (!harnesses.includes(install.harness)) harnesses.push(install.harness);
+    byPath.set(real, harnesses);
+  }
+  return [...byPath.entries()]
+    .filter(([, harnesses]) => harnesses.length > 1)
+    .map(([path, harnesses]) => ({ path, harnesses }));
+}
+
 export function groupItems(items: ObservedItem[]): ItemGroup[] {
   const groups = new Map<string, ItemGroup>();
   for (const item of items) {
@@ -103,20 +134,7 @@ export function groupItems(items: ObservedItem[]): ItemGroup[] {
     }
   }
   for (const group of groups.values()) {
-    // Where the bytes actually are, not where the harness looks for them: two
-    // harnesses linking to one shared folder are sharing a file, even though
-    // each has a path of its own pointing at it.
-    const byPath = new Map<string, Set<string>>();
-    for (const install of group.installations) {
-      const real =
-        install.fileState.state === "symlink" && !install.fileState.broken
-          ? install.fileState.target
-          : install.path;
-      const set = byPath.get(real) ?? new Set();
-      set.add(install.harness);
-      byPath.set(real, set);
-    }
-    group.shared = [...byPath.values()].some((harnesses) => harnesses.size > 1);
+    group.shared = sharedFiles(group.installations).length > 0;
     const times = group.installations
       .map((i) => i.modifiedAt)
       .filter((t): t is number => t != null);


### PR DESCRIPTION
## What this changes

The harnesses column of My Library showed a "Shared files" chip that said a
true thing about the app's plumbing and nothing a reader could check or act
on. It now carries its own explanation, and every other unexplained badge or
term in the harness list and the harness detail behind it was swept the same
way.

Closes KEN-1283.

## The chip

It stays, because the fact behind it is the one that decides an edit: several
tools read one copy, so changing it changes them all. What was missing was
which files. On hover, on focus, and as screen-reader text it now reads:

> Claude Code and Codex read /home/u/.agents/skills/deploy
> There is one copy, so a change to it is a change for all of them.

One line per shared path, from `sharedFiles()` in `src/lib/derive.ts` — the
same selector that decides whether the chip renders at all, so the badge can
never stand over a list that disagrees with it. Where no two harnesses read
one file there is no chip, which is what the old flag already meant.

## Requirement → file

| Requirement | File |
|---|---|
| Chip says what it means on hover or focus | `ui/src/components/shared-files-badge.tsx` |
| Naming the real shared files | `ui/src/lib/derive.ts::sharedFiles` |
| The words | `ui/src/lib/copy.ts` |
| Chip on the Library row | `ui/src/components/library/installed-row.tsx` |
| Chip on the package page's Details | `ui/src/components/package/package-meta.tsx` |
| Sweep of the harness list | `ui/src/components/harnesses/harness-row.tsx`, `ui/src/components/kind-count-badges.tsx` |
| Vitest control plus must-fail | `ui/src/components/shared-files-badge.dom.test.tsx`, `installed-row.test.tsx`, `harness-row.test.tsx` |
| Changelog fragment | `changelog.d/changed/KEN-1283.md` |

## Every badge and term in these views, and its disposition

Harnesses list (`ui/src/components/harnesses/harness-row.tsx`):

| Thing on screen | Before | Disposition |
|---|---|---|
| Harness name | Button, "Show everything in Claude Code" | Already explained. No change. |
| Version, e.g. `2.4.0` | Bare mono string beside the name | `title` "The installed version" |
| Folder line, e.g. `/home/u/.claude` | Bare mono path | `title` "Where Claude Code keeps its files"; "Not installed" carries none, because it is not a folder |
| Pencil | `aria-label` + `title` | Already explained. No change. |
| Count badge "3 Skills" | Accessible name "3 Skills" — the count, never where the press lands | `aria-label` "Show the 3 Skills in Claude Code" |
| Empty state | Plain sentences | No change. |

Harness detail — the Library the harness row opens
(`ui/src/components/library/installed-row.tsx`):

| Thing on screen | Before | Disposition |
|---|---|---|
| **Shared files** | Two words, nothing on hover or focus | The flyout above, on hover and focus, plus screen-reader text |
| Harness marks | Tooltip names the tool | Already explained. No change. |
| "Forked in vg" | The app's own word, unexplained | Tooltip + screen-reader text: what changed and that updates are paused |
| "Bundled with Anthropic" | `title` only — a pointer, and nothing for a keyboard | Same words on hover, on focus, and to a screen reader |
| Tag chips under "For" | The column heading and the tag's own word | Already explained. No change. |
| "2 locations" (Where) | `title` lists them | Kept. A count is its own explanation, and the cell is not a badge. |
| From | `title` from provenance | Kept, same reason. |
| Status dot | Tooltip | Already explained. No change. |
| Updated | Relative time | No change. |

The package page's Details block reads the same chip, so it gains the same
flyout; nothing else on that page was touched (KEN-1284 owns it). Project
registration and project cards were left alone for KEN-1279 —
`KindCountBadges` took an optional prop and its project-card caller passes
nothing.

## Before / after

- **Shared files** — before: `Shared files`, no title, no flyout, nothing on
  focus. After: the two lines quoted above, naming the real paths.
- **Forked in vg** — before: badge text alone. After: adds "You changed this
  package's files here. kendex keeps your copy and pauses its updates until
  you decide what to do with it."
- **Bundled with Anthropic** — before: reachable by pointer only. After: the
  same sentence on hover, on focus and to a screen reader.
- **Harness folder line** — before: `/home/u/.claude`. After: same line,
  "Where Claude Code keeps its files" on hover.
- **Version** — before: `2.4.0`. After: same, "The installed version" on hover.
- **Count badge** — before: announced "3 Skills". After: "Show the 3 Skills in
  Claude Code".

## Validation

- `env -u TMPDIR tools/guard --full` on `0bbb64dd9`: exit 0.
- UI: 993 tests over 161 files pass.
- Controls: the flyout must name the path these installations actually share
  (a fixed sentence fails it); the badge explanations must be absent before
  focus and present after (a hover-only `title` fails it); a harness with no
  folder must claim none.

## Local review dispositions

The local review passed with no blockers. Three raised points were declined,
each on the code as it stands:

- **Declined**: the harness row's path span was already truncated and carried
  no full-path `title`. The added help explains what the line is and removes
  no path access.
- **Declined**: no assistive-technology run showed duplicate announcements
  from the tooltip's text and the badge's screen-reader span. Unobserved and
  low severity, so the repository's existing badge-help pattern is kept.
- **Declined**: the fork badge still names the place and still calls the same
  `onOpen(where)`. A different action label is nonblocking copy work, and
  KEN-1285 owns the final copy pass.

https://claude.ai/code/session_01EgAJzLD8E152MSnjqF8yJH
