### PR TITLE
Give the doc-drift list to the agent, once per stale set (KEN-1313)

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -52,7 +52,7 @@ Review and QA-review belong to the reviewer skill: [`../reviewer/workflows/revie
 - Before adding a function, parser, stub or loop, grep the repo for the verb it performs; before stating a rule, grep for the rule.
   - A second copy of that verb, in any language, is a twin and never delegation, and so is a second statement of a rule another file owns, in prose, config or a table.
   - Call or cite the one that exists, or escalate in your return. An issue that orders a twin is escalated, not implemented.
-- Docs move with the code they describe; the `docs-writing` skill states the rule and the `doc-drift-check` hook shows the user docs that may need an update.
+- Docs move with the code they describe; the `docs-writing` skill states the rule and the `doc-drift-check` hook names the docs that may need an update.
 - Once a pushed head has been reviewed, later rounds add commits and never amend; before any review has run on a head, the kendex-issues fix cycle may amend only to refresh a required check that cannot be rerun.
 - A push that prints `rebase-map:` lines has rewritten the shas the PR's `Fixed in <sha>` replies name: before holding, re-reply each such thread with the new sha, or post the map as one PR comment naming old and new per line; a sha the map reports as `dropped` gets a reply that the fix commit no longer exists on the branch.
 

--- a/.agents/skills/docs-writing/SKILL.md
+++ b/.agents/skills/docs-writing/SKILL.md
@@ -147,7 +147,7 @@ The `changelog-entries` lane owns the shape. Follow the repository's `changelog.
 
 ## Format
 
-- Docs change in the same commit as the code they describe. The `doc-drift-check` hook shows unchanged covering docs to the user as a notice; it does not block a stop.
+- Docs change in the same commit as the code they describe. The `doc-drift-check` hook names the unchanged covering docs to the agent and blocks that stop once per set.
 - One paragraph per line, one list item per line, no hard wraps inside either. Blank lines separate paragraphs, list blocks, headings, and fences. Tables and fenced code stay as written. The commit-guards `md-format` lane enforces it and `md-reflow` converts a file once.
 - Every relative link, `<path>.md § Heading` or `<path>.md#anchor` citation, and decision ID resolves. The `md-refs` lane checks them.
 - Agent-loaded markdown carries no history. The `prose` lane checks it.

--- a/.claude/hooks/doc-drift-check.sh
+++ b/.claude/hooks/doc-drift-check.sh
@@ -4,7 +4,7 @@
 # event: Stop
 # matcher:
 # description: Blocks a stop once per set of stale documents — the documents covering changed code that did not change — so the agent, the only party that can update them, is the one given the list. The refusal opens with `doc-drift-check: stale=<count>` and `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each document under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a document is a different set and blocks once. `stop_hook_active` true passes. Uses the nearest tracked non-root AGENTS.md and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
-# safety: Reads the payload, git state and the topic files; the only write is the per-set marker under the repository's git common dir. Exit 2 names the documents and asks for each to be confirmed or updated, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before anything is judged, and a payload, git state or marker it cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, git state and the topic files; the only write is the per-set marker under the repository's git common dir. Exit 2 names the documents and asks for each to be confirmed or updated, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -88,32 +88,24 @@ refuse() { # KEY VALUE [DETAIL]
 # were not captured at the site.
 trap 'status=$?; if [ "$status" -ne 0 ] && [ "$REFUSED" -eq 0 ]; then refuse exit "$status"; fi' EXIT
 
-# Every external command this hook runs, checked before anything is judged: an
+# Every external command this hook runs is checked before it is called: an
 # absence the shell reports for itself writes "command not found" ahead of the
 # keyed line and leaves a status the harness reads as a plain error rather than
-# a refusal. The value names every one PATH is missing, in the order checked.
+# a refusal. Each value names every command PATH is missing, in the order
+# checked.
+#
+# The two commands that read the payload come first and alone. The flag that
+# ends a stop hook's retry is in that payload, so a refusal for any other
+# absence has to wait until the flag has been read; refusing ahead of it would
+# refuse the retry as well, which is the loop the flag exists to end. These two
+# refuse that retry because without them the flag cannot be read at all, and a
+# hook that passes what it cannot read is the defect this one is not allowed to
+# have.
 MISSING=""
-for dependency in jq git cat sed sort tr dirname grep mkdir; do
+for dependency in jq cat; do
   command -v "$dependency" >/dev/null 2>&1 || MISSING="$MISSING,$dependency"
 done
-# macOS ships shasum and no sha256sum; either one names the set.
-HASH_TOOL=""
-if command -v sha256sum >/dev/null 2>&1; then
-  HASH_TOOL=sha256sum
-elif command -v shasum >/dev/null 2>&1; then
-  HASH_TOOL=shasum
-else
-  MISSING="$MISSING,sha256sum"
-fi
 [ -z "$MISSING" ] || refuse missing-tools "${MISSING#,}"
-
-hash_set() { # the set on stdin; its digest and the reader's own trailing word
-  if [ "$HASH_TOOL" = sha256sum ]; then
-    sha256sum
-  else
-    shasum -a 256
-  fi
-}
 
 # cat's words are captured, not left to precede the refusal: on failure the
 # substitution holds what it wrote, and the refusal replays it under the keyed
@@ -139,6 +131,32 @@ ACTIVE=${FIELDS#*"$TAB"}
 if [ "$ACTIVE" = "true" ]; then
   exit 0
 fi
+
+# The rest of what the hook runs: the commands that read what changed and
+# record the set. An absence here refuses this stop, and the retry it costs
+# passes at the flag above.
+MISSING=""
+for dependency in git sed sort tr dirname grep mkdir; do
+  command -v "$dependency" >/dev/null 2>&1 || MISSING="$MISSING,$dependency"
+done
+# macOS ships shasum and no sha256sum; either one names the set.
+HASH_TOOL=""
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_TOOL=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+  HASH_TOOL=shasum
+else
+  MISSING="$MISSING,sha256sum"
+fi
+[ -z "$MISSING" ] || refuse missing-tools "${MISSING#,}"
+
+hash_set() { # the set on stdin; its digest and the reader's own trailing word
+  if [ "$HASH_TOOL" = sha256sum ]; then
+    sha256sum
+  else
+    shasum -a 256
+  fi
+}
 
 # Git cannot distinguish an absent repository from unreadable metadata here.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || refuse git 'rev-parse' "$REPO_ROOT"

--- a/.claude/hooks/doc-drift-check.sh
+++ b/.claude/hooks/doc-drift-check.sh
@@ -3,84 +3,153 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Shows the user a notice through stdout systemMessage JSON when unchanged documents may need an update after covered code changes. The notice opens with `doc-drift-check: stale=<count>` and `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and lists the documents under them; stdout carries that one object and nothing else. Uses the nearest tracked non-root AGENTS.md and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Every Stop reports independently. Claude Code only.
-# safety: Read-only notice. Always exits 0, including when discovery fails; failures report that the notice is unavailable. Does not parse session payloads or write session state. Every notice opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# description: Blocks a stop once per set of stale documents — the documents covering changed code that did not change — so the agent, the only party that can update them, is the one given the list. The refusal opens with `doc-drift-check: stale=<count>` and `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each document under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a document is a different set and blocks once. `stop_hook_active` true passes. Uses the nearest tracked non-root AGENTS.md and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# safety: Reads the payload, git state and the topic files; the only write is the per-set marker under the repository's git common dir. Exit 2 names the documents and asks for each to be confirmed or updated, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before anything is judged, and a payload, git state or marker it cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
 
 set -euo pipefail
 
-# Every line this hook writes, and the only place its text lives. Each begins
-# with the stable first line `doc-drift-check: <key>=<value>`: a stable key for
-# the condition and the value acted on — the git subcommand that failed, the
-# status a discovery command left, or how many documents the notice names. The
-# English explanation follows it.
-# The keyed line stands first, at position 1. What a command this hook runs
-# wrote is captured where the hook reads it and passed here as the cause, so
-# it is replayed under the key rather than ahead of it.
-#
-# The notice itself is a machine-read protocol Claude Code parses: one JSON
-# object on stdout, whose single `systemMessage` string key holds the text the
-# user is shown. The keyed first line opens that string; nothing else is
-# written to stdout, and a second object there is not the protocol.
-notice() { # KEY VALUE [DETAIL]
-  case "$1" in
-    stale)
-      # jq's stderr is captured and its stdout left alone: the notice is the
-      # protocol on stdout, and a jq that cannot build it reports under the
-      # keyed line rather than ahead of it. The swap is the standard one —
-      # stderr becomes this substitution's stdout, jq's stdout goes to fd 3.
-      exec 3>&1
-      JQ_STATUS=0
-      JQ_ERR=$(jq -n --arg systemMessage \
-        "$(printf 'doc-drift-check: stale=%s\ndoc-drift-check: base=%s\nThese unchanged documents may need an update:\n%sCompared %s\n' \
-          "$2" "$BASE_VALUE" "$STALE" "$JUDGED")" '{systemMessage: $systemMessage}' 2>&1 1>&3) || JQ_STATUS=$?
-      exec 3>&-
-      [ "$JQ_STATUS" -eq 0 ] || notice exit "$JQ_STATUS" "$JQ_ERR"
-      ;;
-    git)
-      {
-        printf 'doc-drift-check: git=%s\n' "$2"
-        printf 'notice unavailable: git %s failed, so what changed is unknown:\n' "$2"
-        printf '%s\n' "${3:-}"
-      } >&2
-      ;;
-    exit)
-      {
-        printf 'doc-drift-check: exit=%s\n' "$2"
-        printf 'notice unavailable: a discovery command exited %s\n' "$2"
-        [ -z "${3:-}" ] || printf '%s\n' "$3"
-      } >&2
-      ;;
-  esac
-}
-
-# A notice cannot hold a Stop event, including on a failed discovery command.
-# Every filter above captures its own words where the hook reads it; this trap
-# is the backstop for a command that has none captured, and its keyed line is
-# then the first this hook writes.
-trap 'status=$?; if [ "$status" -ne 0 ]; then notice exit "$status" || :; fi; exit 0' EXIT
-
-# Doc paths are matched by byte ranges below; a locale that
-# reads them as something else changes what a filename may hold.
+# Session ids and doc paths are matched by byte ranges below; a locale that
+# reads them as something else changes what a filename may hold. The sort that
+# feeds the digest reads them the same way, so the locale also decides which
+# set two runs agree on.
 export LC_ALL=C
 
-git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty one
-  notice git "$1" "$2"
-  exit 0
+# What the refusals name, empty until each is known: which base the changed set
+# was read against, that same choice in English, the documents themselves and
+# how many, and the marker that records having named them.
+BASE_VALUE=""
+JUDGED=""
+STALE=""
+STALE_COUNT=0
+# A refusal has written its own keyed line; the EXIT trap writes one only for a
+# status no handler claimed.
+REFUSED=0
+
+# Every line this hook writes, and the only place its text lives. The first
+# line is the contract a reader parses, `doc-drift-check: <key>=<value>`: a
+# stable key for the condition and the value acted on — the missing commands,
+# why the payload could not be read, how many documents are named, the git
+# subcommand that failed, the marker path, or the status a discovery command
+# left. The English explanation follows it, and never a bypass.
+# The keyed line stands first, at position 1. What a command this hook runs
+# wrote is captured where the hook reads it and passed here as the cause, so it
+# is replayed under the key rather than ahead of it.
+#
+# The audience is the agent. The documents are work only the agent can do, and
+# most sessions in this repository run with nobody watching, so the list goes
+# to the channel the harness gives Claude — stderr with exit 2 — and stdout is
+# left empty rather than carrying a second copy for a user who cannot act on it.
+refuse() { # KEY VALUE [DETAIL]
+  {
+    printf 'doc-drift-check: %s=%s\n' "$1" "$2"
+    case "$1=$2" in
+      stale=*)
+        printf 'doc-drift-check: base=%s\n' "$BASE_VALUE"
+        printf 'code changed at paths these documents cover, and none of them changed:\n'
+        printf '%s' "$STALE"
+        printf 'Compared %s\n' "$JUDGED"
+        printf 'Confirm each document still holds or update it, then finish.\n'
+        ;;
+      missing-tools=*)
+        printf '%s\n' "the commands ${2//,/, } are required to read the payload, the git state and the documents and are not on PATH; refusing rather than skipping the check. sha256sum stands for it or shasum, either of which names the set"
+        ;;
+      payload=unreadable)
+        printf 'the hook payload could not be read from stdin\n'
+        ;;
+      payload=invalid-json)
+        printf 'the hook payload is not valid JSON, or a field it reads is not a string; refusing rather than skipping the check\n'
+        ;;
+      session-id=invalid)
+        printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
+        ;;
+      marker=*)
+        printf 'the marker %s could not be recorded, so a second stop could not be told from the first\n' "$2"
+        ;;
+      git=*)
+        printf 'git %s failed, so what changed is unknown:\n' "$2"
+        ;;
+      exit=*)
+        printf 'a discovery command exited %s\n' "$2"
+        ;;
+    esac
+    # The cause a command this hook ran wrote, captured at the site and
+    # replayed here: under the keyed line, never ahead of it.
+    [ -z "${3:-}" ] || printf '%s\n' "$3"
+  } >&2
+  REFUSED=1
+  exit 2
 }
 
+# A status no handler claimed still reports under a keyed line: errexit ends the
+# script where a helper died, and this is the backstop for one whose own words
+# were not captured at the site.
+trap 'status=$?; if [ "$status" -ne 0 ] && [ "$REFUSED" -eq 0 ]; then refuse exit "$status"; fi' EXIT
+
+# Every external command this hook runs, checked before anything is judged: an
+# absence the shell reports for itself writes "command not found" ahead of the
+# keyed line and leaves a status the harness reads as a plain error rather than
+# a refusal. The value names every one PATH is missing, in the order checked.
+MISSING=""
+for dependency in jq git cat sed sort tr dirname grep mkdir; do
+  command -v "$dependency" >/dev/null 2>&1 || MISSING="$MISSING,$dependency"
+done
+# macOS ships shasum and no sha256sum; either one names the set.
+HASH_TOOL=""
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_TOOL=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+  HASH_TOOL=shasum
+else
+  MISSING="$MISSING,sha256sum"
+fi
+[ -z "$MISSING" ] || refuse missing-tools "${MISSING#,}"
+
+hash_set() { # the set on stdin; its digest and the reader's own trailing word
+  if [ "$HASH_TOOL" = sha256sum ]; then
+    sha256sum
+  else
+    shasum -a 256
+  fi
+}
+
+# cat's words are captured, not left to precede the refusal: on failure the
+# substitution holds what it wrote, and the refusal replays it under the keyed
+# line. A cat that succeeds is silent, so the payload is not mixed with a
+# diagnostic on the passing side.
+INPUT=$(cat 2>&1) || refuse payload unreadable "$INPUT"
+
+# The session names the reader being told, and jq alone reads it: the keys are
+# top-level, and a text scan finds the same characters inside a transcript path
+# or a cwd. jq's own words are captured where a failure would otherwise write
+# them ahead of the keyed line; a jq that answers writes none.
+FIELDS=$(printf '%s' "$INPUT" | jq -r '
+  def str($v): if $v == null then "" elif ($v | type) == "string" then $v else error("not a string") end;
+  [str(.session_id), (.stop_hook_active == true | tostring)] | @tsv' 2>&1) ||
+  refuse payload invalid-json "$FIELDS"
+TAB=$'\t'
+SESSION=${FIELDS%%"$TAB"*}
+ACTIVE=${FIELDS#*"$TAB"}
+
+# The harness sets stop_hook_active on the turn it continued because a stop
+# hook blocked. Refusing that turn as well is the loop the flag exists to end,
+# and the harness caps a hook that does it anyway.
+if [ "$ACTIVE" = "true" ]; then
+  exit 0
+fi
+
 # Git cannot distinguish an absent repository from unreadable metadata here.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || git_failed 'rev-parse' "$REPO_ROOT"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || refuse git 'rev-parse' "$REPO_ROOT"
 
 # What counts as changed is everything the branch did: every path that
 # differs between the working tree and the branch's merge-base with the
 # default branch, committed or not, plus untracked non-ignored paths. The
 # workflow commits before it stops, so a set read off the working tree
-# alone is empty at the point this notice runs. On the default branch
+# alone is empty at the point this hook runs. On the default branch
 # itself, or where no merge-base resolves, the working tree alone is
-# judged, and the notice says so.
+# judged, and the refusal says so.
 #
 # The probes for the default branch exit 1 when the ref is absent and
 # otherwise on a repository git cannot read; only the first is an answer.
@@ -93,7 +162,7 @@ probe_ref() { # ARGS... — sets REF; returns 1 when the ref is absent
   case "$rc" in
     0) return 0 ;;
     1) return 1 ;;
-    *) git_failed "$1" "$REF" ;;
+    *) refuse git "$1" "$REF" ;;
   esac
 }
 DEFAULT=""
@@ -112,10 +181,9 @@ fi
 
 # BASE_VALUE is the arm this hook chose, as a value a reader parses: the ref
 # it compared against, or which of the three reasons left it the working tree
-# alone. The English below the notice describes the same choice for a person;
-# the value is what a consumer reads, so the choice is not carried by prose.
+# alone. The English below it describes the same choice for a person; the
+# value is what a consumer reads, so the choice is not carried by prose.
 BASE=""
-BASE_VALUE=""
 if [ -z "$DEFAULT" ]; then
   BASE_VALUE=none
   JUDGED="the working tree alone: no origin/HEAD, main or master to compare against"
@@ -135,7 +203,7 @@ else
       BASE_VALUE=unrelated
       JUDGED="the working tree alone: HEAD shares no history with $DEFAULT"
       ;;
-    *) git_failed 'merge-base' "$BASE" ;;
+    *) refuse git 'merge-base' "$BASE" ;;
   esac
 fi
 
@@ -144,24 +212,22 @@ fi
 # suffix. Against a base, one diff covers the worktree and the index both;
 # without one, the two are read separately. Untracked paths are read in
 # either case: without them a stop whose only work is an untracked file
-# presents an empty changed set and produces no notice.
+# presents an empty changed set and nothing is named.
 if [ -n "$BASE" ]; then
-  CHANGED=$(git diff --name-only -z "$BASE" 2>&1 | tr '\0' '\n' 2>&1) || git_failed 'diff' "$CHANGED"
+  CHANGED=$(git diff --name-only -z "$BASE" 2>&1 | tr '\0' '\n' 2>&1) || refuse git 'diff' "$CHANGED"
   STAGED=""
 else
-  CHANGED=$(git diff --name-only -z 2>&1 | tr '\0' '\n' 2>&1) || git_failed 'diff' "$CHANGED"
+  CHANGED=$(git diff --name-only -z 2>&1 | tr '\0' '\n' 2>&1) || refuse git 'diff' "$CHANGED"
   STAGED=$(git diff --cached --name-only -z 2>&1 | tr '\0' '\n' 2>&1) ||
-    git_failed 'diff --cached' "$STAGED"
+    refuse git 'diff --cached' "$STAGED"
 fi
 UNTRACKED=$(git ls-files --others --exclude-standard --full-name -z -- :/ 2>&1 | tr '\0' '\n' 2>&1) ||
-  git_failed 'ls-files' "$UNTRACKED"
+  refuse git 'ls-files' "$UNTRACKED"
 # Each filter's own words are captured where the hook reads it: a bare
 # assignment would let sort or sed write first and leave the trap's keyed line
 # second. Both are silent when they succeed.
-ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u 2>&1 | sed '/^$/d' 2>&1) || {
-  notice exit "$?" "$ALL_CHANGED"
-  exit 0
-}
+ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u 2>&1 | sed '/^$/d' 2>&1) ||
+  refuse exit "$?" "$ALL_CHANGED"
 
 if [ -z "$ALL_CHANGED" ]; then
   exit 0
@@ -170,10 +236,8 @@ fi
 # A markdown path is a doc, whatever directory it sits in. Neither filter may
 # stop reading early: under pipefail an early-exiting reader turns the
 # producer's SIGPIPE into status 141, read as no match.
-CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) || {
-  notice exit "$?" "$CODE_CHANGED"
-  exit 0
-}
+CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) ||
+  refuse exit "$?" "$CODE_CHANGED"
 if [ -z "$CODE_CHANGED" ]; then
   exit 0
 fi
@@ -182,7 +246,7 @@ fi
 # cwd, and `*` crosses `/`, so this is every AGENTS.md below the root and
 # not the root's own, which covers nothing.
 AGENTS_DOCS=$(git ls-files -z --full-name -- ':(top)*/AGENTS.md' 2>&1 | tr '\0' '\n' 2>&1) ||
-  git_failed 'ls-files' "$AGENTS_DOCS"
+  refuse git 'ls-files' "$AGENTS_DOCS"
 
 # Topic files are read from the working tree, so a file written this session
 # already covers what it says it covers; a tracked one deleted this session
@@ -195,12 +259,10 @@ for topic in "$REPO_ROOT"/docs/architecture/*.md; do
   [ -f "$topic" ] || continue
   rel="docs/architecture/${topic##*/}"
   # sed and tr write their own reason where their output would have gone, so
-  # a failed read reaches the notice under its keyed line rather than before
+  # a failed read reaches the refusal under its keyed line rather than before
   # it. Both are silent when they succeed.
-  entries=$(sed -n 's/^Covers:[[:space:]]*//p' "$topic" 2>&1 | tr ',' ' ' 2>&1) || {
-    notice exit "$?" "$entries"
-    exit 0
-  }
+  entries=$(sed -n 's/^Covers:[[:space:]]*//p' "$topic" 2>&1 | tr ',' ' ' 2>&1) ||
+    refuse exit "$?" "$entries"
   set -f
   for covered in $entries; do
     covered="${covered#./}"
@@ -255,8 +317,6 @@ EOF
 # Every doc left unchanged while code it covers changed, with the first such
 # path; a doc is named once however many paths reached it.
 STALE_DOCS=""
-STALE=""
-STALE_COUNT=0
 while IFS= read -r path; do
   docs=$(covering_docs "$path")
   [ -n "$docs" ] || continue
@@ -286,5 +346,37 @@ if [ -z "$STALE" ]; then
   exit 0
 fi
 
-notice stale "$STALE_COUNT"
-exit 0
+SESSION_SHAPE='^[A-Za-z0-9._-]+$'
+if ! [[ "$SESSION" =~ $SESSION_SHAPE ]]; then
+  refuse session-id invalid
+fi
+
+# The marker's name has to tell one stale set from another, and a doc path can
+# hold bytes a filename cannot, so the set is hashed. The sort is what makes
+# two runs that reached the same documents by different paths agree on one
+# name; without it the block would repeat for a set already named.
+DIGEST=$( { printf '%s' "$STALE_DOCS" | sort | hash_set; } 2>&1 ) || refuse exit "$?" "$DIGEST"
+
+# The marker lives under the git COMMON dir so every linked worktree of the
+# repository shares it. rev-parse answers relative to the cwd when the dir
+# is nearby.
+COMMON_DIR=$(git rev-parse --git-common-dir 2>&1) ||
+  refuse git 'rev-parse --git-common-dir' "$COMMON_DIR"
+case "$COMMON_DIR" in
+  /*) ;;
+  *) COMMON_DIR="$PWD/$COMMON_DIR" ;;
+esac
+MARKER_DIR="$COMMON_DIR/kendex/doc-drift"
+MARKER="$MARKER_DIR/$SESSION-${DIGEST%% *}"
+if [ -e "$MARKER" ]; then
+  exit 0
+fi
+# Both probes are captured rather than left to write first: the group runs the
+# redirection in a subshell so the shell's own "cannot create" reaches the same
+# variable mkdir's message would.
+if ! MARKER_ERR=$(mkdir -p -- "$MARKER_DIR" 2>&1) ||
+  ! MARKER_ERR=$( { : >"$MARKER"; } 2>&1 ); then
+  refuse marker "$MARKER" "$MARKER_ERR"
+fi
+
+refuse stale "$STALE_COUNT"

--- a/changelog.d/added/doc-drift-hook.md
+++ b/changelog.d/added/doc-drift-hook.md
@@ -1,1 +1,1 @@
-- `doc-drift-check` (Claude Code Stop) shows the user unchanged covering docs that may need an update. Every stop exits 0; repeated stops repeat the notice without session markers or retry requests.
+- `doc-drift-check` (Claude Code Stop) names the unchanged documents covering changed code to the agent and blocks that stop once per set; a stop whose set was already named passes.

--- a/hooks/doc-drift-check.sh
+++ b/hooks/doc-drift-check.sh
@@ -4,7 +4,7 @@
 # event: Stop
 # matcher:
 # description: Blocks a stop once per set of stale documents — the documents covering changed code that did not change — so the agent, the only party that can update them, is the one given the list. The refusal opens with `doc-drift-check: stale=<count>` and `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each document under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a document is a different set and blocks once. `stop_hook_active` true passes. Uses the nearest tracked non-root AGENTS.md and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
-# safety: Reads the payload, git state and the topic files; the only write is the per-set marker under the repository's git common dir. Exit 2 names the documents and asks for each to be confirmed or updated, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before anything is judged, and a payload, git state or marker it cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, git state and the topic files; the only write is the per-set marker under the repository's git common dir. Exit 2 names the documents and asks for each to be confirmed or updated, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -88,32 +88,24 @@ refuse() { # KEY VALUE [DETAIL]
 # were not captured at the site.
 trap 'status=$?; if [ "$status" -ne 0 ] && [ "$REFUSED" -eq 0 ]; then refuse exit "$status"; fi' EXIT
 
-# Every external command this hook runs, checked before anything is judged: an
+# Every external command this hook runs is checked before it is called: an
 # absence the shell reports for itself writes "command not found" ahead of the
 # keyed line and leaves a status the harness reads as a plain error rather than
-# a refusal. The value names every one PATH is missing, in the order checked.
+# a refusal. Each value names every command PATH is missing, in the order
+# checked.
+#
+# The two commands that read the payload come first and alone. The flag that
+# ends a stop hook's retry is in that payload, so a refusal for any other
+# absence has to wait until the flag has been read; refusing ahead of it would
+# refuse the retry as well, which is the loop the flag exists to end. These two
+# refuse that retry because without them the flag cannot be read at all, and a
+# hook that passes what it cannot read is the defect this one is not allowed to
+# have.
 MISSING=""
-for dependency in jq git cat sed sort tr dirname grep mkdir; do
+for dependency in jq cat; do
   command -v "$dependency" >/dev/null 2>&1 || MISSING="$MISSING,$dependency"
 done
-# macOS ships shasum and no sha256sum; either one names the set.
-HASH_TOOL=""
-if command -v sha256sum >/dev/null 2>&1; then
-  HASH_TOOL=sha256sum
-elif command -v shasum >/dev/null 2>&1; then
-  HASH_TOOL=shasum
-else
-  MISSING="$MISSING,sha256sum"
-fi
 [ -z "$MISSING" ] || refuse missing-tools "${MISSING#,}"
-
-hash_set() { # the set on stdin; its digest and the reader's own trailing word
-  if [ "$HASH_TOOL" = sha256sum ]; then
-    sha256sum
-  else
-    shasum -a 256
-  fi
-}
 
 # cat's words are captured, not left to precede the refusal: on failure the
 # substitution holds what it wrote, and the refusal replays it under the keyed
@@ -139,6 +131,32 @@ ACTIVE=${FIELDS#*"$TAB"}
 if [ "$ACTIVE" = "true" ]; then
   exit 0
 fi
+
+# The rest of what the hook runs: the commands that read what changed and
+# record the set. An absence here refuses this stop, and the retry it costs
+# passes at the flag above.
+MISSING=""
+for dependency in git sed sort tr dirname grep mkdir; do
+  command -v "$dependency" >/dev/null 2>&1 || MISSING="$MISSING,$dependency"
+done
+# macOS ships shasum and no sha256sum; either one names the set.
+HASH_TOOL=""
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_TOOL=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+  HASH_TOOL=shasum
+else
+  MISSING="$MISSING,sha256sum"
+fi
+[ -z "$MISSING" ] || refuse missing-tools "${MISSING#,}"
+
+hash_set() { # the set on stdin; its digest and the reader's own trailing word
+  if [ "$HASH_TOOL" = sha256sum ]; then
+    sha256sum
+  else
+    shasum -a 256
+  fi
+}
 
 # Git cannot distinguish an absent repository from unreadable metadata here.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || refuse git 'rev-parse' "$REPO_ROOT"

--- a/hooks/doc-drift-check.sh
+++ b/hooks/doc-drift-check.sh
@@ -3,84 +3,153 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Shows the user a notice through stdout systemMessage JSON when unchanged documents may need an update after covered code changes. The notice opens with `doc-drift-check: stale=<count>` and `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and lists the documents under them; stdout carries that one object and nothing else. Uses the nearest tracked non-root AGENTS.md and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Every Stop reports independently. Claude Code only.
-# safety: Read-only notice. Always exits 0, including when discovery fails; failures report that the notice is unavailable. Does not parse session payloads or write session state. Every notice opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# description: Blocks a stop once per set of stale documents — the documents covering changed code that did not change — so the agent, the only party that can update them, is the one given the list. The refusal opens with `doc-drift-check: stale=<count>` and `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each document under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a document is a different set and blocks once. `stop_hook_active` true passes. Uses the nearest tracked non-root AGENTS.md and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# safety: Reads the payload, git state and the topic files; the only write is the per-set marker under the repository's git common dir. Exit 2 names the documents and asks for each to be confirmed or updated, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before anything is judged, and a payload, git state or marker it cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
 
 set -euo pipefail
 
-# Every line this hook writes, and the only place its text lives. Each begins
-# with the stable first line `doc-drift-check: <key>=<value>`: a stable key for
-# the condition and the value acted on — the git subcommand that failed, the
-# status a discovery command left, or how many documents the notice names. The
-# English explanation follows it.
-# The keyed line stands first, at position 1. What a command this hook runs
-# wrote is captured where the hook reads it and passed here as the cause, so
-# it is replayed under the key rather than ahead of it.
-#
-# The notice itself is a machine-read protocol Claude Code parses: one JSON
-# object on stdout, whose single `systemMessage` string key holds the text the
-# user is shown. The keyed first line opens that string; nothing else is
-# written to stdout, and a second object there is not the protocol.
-notice() { # KEY VALUE [DETAIL]
-  case "$1" in
-    stale)
-      # jq's stderr is captured and its stdout left alone: the notice is the
-      # protocol on stdout, and a jq that cannot build it reports under the
-      # keyed line rather than ahead of it. The swap is the standard one —
-      # stderr becomes this substitution's stdout, jq's stdout goes to fd 3.
-      exec 3>&1
-      JQ_STATUS=0
-      JQ_ERR=$(jq -n --arg systemMessage \
-        "$(printf 'doc-drift-check: stale=%s\ndoc-drift-check: base=%s\nThese unchanged documents may need an update:\n%sCompared %s\n' \
-          "$2" "$BASE_VALUE" "$STALE" "$JUDGED")" '{systemMessage: $systemMessage}' 2>&1 1>&3) || JQ_STATUS=$?
-      exec 3>&-
-      [ "$JQ_STATUS" -eq 0 ] || notice exit "$JQ_STATUS" "$JQ_ERR"
-      ;;
-    git)
-      {
-        printf 'doc-drift-check: git=%s\n' "$2"
-        printf 'notice unavailable: git %s failed, so what changed is unknown:\n' "$2"
-        printf '%s\n' "${3:-}"
-      } >&2
-      ;;
-    exit)
-      {
-        printf 'doc-drift-check: exit=%s\n' "$2"
-        printf 'notice unavailable: a discovery command exited %s\n' "$2"
-        [ -z "${3:-}" ] || printf '%s\n' "$3"
-      } >&2
-      ;;
-  esac
-}
-
-# A notice cannot hold a Stop event, including on a failed discovery command.
-# Every filter above captures its own words where the hook reads it; this trap
-# is the backstop for a command that has none captured, and its keyed line is
-# then the first this hook writes.
-trap 'status=$?; if [ "$status" -ne 0 ]; then notice exit "$status" || :; fi; exit 0' EXIT
-
-# Doc paths are matched by byte ranges below; a locale that
-# reads them as something else changes what a filename may hold.
+# Session ids and doc paths are matched by byte ranges below; a locale that
+# reads them as something else changes what a filename may hold. The sort that
+# feeds the digest reads them the same way, so the locale also decides which
+# set two runs agree on.
 export LC_ALL=C
 
-git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty one
-  notice git "$1" "$2"
-  exit 0
+# What the refusals name, empty until each is known: which base the changed set
+# was read against, that same choice in English, the documents themselves and
+# how many, and the marker that records having named them.
+BASE_VALUE=""
+JUDGED=""
+STALE=""
+STALE_COUNT=0
+# A refusal has written its own keyed line; the EXIT trap writes one only for a
+# status no handler claimed.
+REFUSED=0
+
+# Every line this hook writes, and the only place its text lives. The first
+# line is the contract a reader parses, `doc-drift-check: <key>=<value>`: a
+# stable key for the condition and the value acted on — the missing commands,
+# why the payload could not be read, how many documents are named, the git
+# subcommand that failed, the marker path, or the status a discovery command
+# left. The English explanation follows it, and never a bypass.
+# The keyed line stands first, at position 1. What a command this hook runs
+# wrote is captured where the hook reads it and passed here as the cause, so it
+# is replayed under the key rather than ahead of it.
+#
+# The audience is the agent. The documents are work only the agent can do, and
+# most sessions in this repository run with nobody watching, so the list goes
+# to the channel the harness gives Claude — stderr with exit 2 — and stdout is
+# left empty rather than carrying a second copy for a user who cannot act on it.
+refuse() { # KEY VALUE [DETAIL]
+  {
+    printf 'doc-drift-check: %s=%s\n' "$1" "$2"
+    case "$1=$2" in
+      stale=*)
+        printf 'doc-drift-check: base=%s\n' "$BASE_VALUE"
+        printf 'code changed at paths these documents cover, and none of them changed:\n'
+        printf '%s' "$STALE"
+        printf 'Compared %s\n' "$JUDGED"
+        printf 'Confirm each document still holds or update it, then finish.\n'
+        ;;
+      missing-tools=*)
+        printf '%s\n' "the commands ${2//,/, } are required to read the payload, the git state and the documents and are not on PATH; refusing rather than skipping the check. sha256sum stands for it or shasum, either of which names the set"
+        ;;
+      payload=unreadable)
+        printf 'the hook payload could not be read from stdin\n'
+        ;;
+      payload=invalid-json)
+        printf 'the hook payload is not valid JSON, or a field it reads is not a string; refusing rather than skipping the check\n'
+        ;;
+      session-id=invalid)
+        printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
+        ;;
+      marker=*)
+        printf 'the marker %s could not be recorded, so a second stop could not be told from the first\n' "$2"
+        ;;
+      git=*)
+        printf 'git %s failed, so what changed is unknown:\n' "$2"
+        ;;
+      exit=*)
+        printf 'a discovery command exited %s\n' "$2"
+        ;;
+    esac
+    # The cause a command this hook ran wrote, captured at the site and
+    # replayed here: under the keyed line, never ahead of it.
+    [ -z "${3:-}" ] || printf '%s\n' "$3"
+  } >&2
+  REFUSED=1
+  exit 2
 }
 
+# A status no handler claimed still reports under a keyed line: errexit ends the
+# script where a helper died, and this is the backstop for one whose own words
+# were not captured at the site.
+trap 'status=$?; if [ "$status" -ne 0 ] && [ "$REFUSED" -eq 0 ]; then refuse exit "$status"; fi' EXIT
+
+# Every external command this hook runs, checked before anything is judged: an
+# absence the shell reports for itself writes "command not found" ahead of the
+# keyed line and leaves a status the harness reads as a plain error rather than
+# a refusal. The value names every one PATH is missing, in the order checked.
+MISSING=""
+for dependency in jq git cat sed sort tr dirname grep mkdir; do
+  command -v "$dependency" >/dev/null 2>&1 || MISSING="$MISSING,$dependency"
+done
+# macOS ships shasum and no sha256sum; either one names the set.
+HASH_TOOL=""
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_TOOL=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+  HASH_TOOL=shasum
+else
+  MISSING="$MISSING,sha256sum"
+fi
+[ -z "$MISSING" ] || refuse missing-tools "${MISSING#,}"
+
+hash_set() { # the set on stdin; its digest and the reader's own trailing word
+  if [ "$HASH_TOOL" = sha256sum ]; then
+    sha256sum
+  else
+    shasum -a 256
+  fi
+}
+
+# cat's words are captured, not left to precede the refusal: on failure the
+# substitution holds what it wrote, and the refusal replays it under the keyed
+# line. A cat that succeeds is silent, so the payload is not mixed with a
+# diagnostic on the passing side.
+INPUT=$(cat 2>&1) || refuse payload unreadable "$INPUT"
+
+# The session names the reader being told, and jq alone reads it: the keys are
+# top-level, and a text scan finds the same characters inside a transcript path
+# or a cwd. jq's own words are captured where a failure would otherwise write
+# them ahead of the keyed line; a jq that answers writes none.
+FIELDS=$(printf '%s' "$INPUT" | jq -r '
+  def str($v): if $v == null then "" elif ($v | type) == "string" then $v else error("not a string") end;
+  [str(.session_id), (.stop_hook_active == true | tostring)] | @tsv' 2>&1) ||
+  refuse payload invalid-json "$FIELDS"
+TAB=$'\t'
+SESSION=${FIELDS%%"$TAB"*}
+ACTIVE=${FIELDS#*"$TAB"}
+
+# The harness sets stop_hook_active on the turn it continued because a stop
+# hook blocked. Refusing that turn as well is the loop the flag exists to end,
+# and the harness caps a hook that does it anyway.
+if [ "$ACTIVE" = "true" ]; then
+  exit 0
+fi
+
 # Git cannot distinguish an absent repository from unreadable metadata here.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || git_failed 'rev-parse' "$REPO_ROOT"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || refuse git 'rev-parse' "$REPO_ROOT"
 
 # What counts as changed is everything the branch did: every path that
 # differs between the working tree and the branch's merge-base with the
 # default branch, committed or not, plus untracked non-ignored paths. The
 # workflow commits before it stops, so a set read off the working tree
-# alone is empty at the point this notice runs. On the default branch
+# alone is empty at the point this hook runs. On the default branch
 # itself, or where no merge-base resolves, the working tree alone is
-# judged, and the notice says so.
+# judged, and the refusal says so.
 #
 # The probes for the default branch exit 1 when the ref is absent and
 # otherwise on a repository git cannot read; only the first is an answer.
@@ -93,7 +162,7 @@ probe_ref() { # ARGS... — sets REF; returns 1 when the ref is absent
   case "$rc" in
     0) return 0 ;;
     1) return 1 ;;
-    *) git_failed "$1" "$REF" ;;
+    *) refuse git "$1" "$REF" ;;
   esac
 }
 DEFAULT=""
@@ -112,10 +181,9 @@ fi
 
 # BASE_VALUE is the arm this hook chose, as a value a reader parses: the ref
 # it compared against, or which of the three reasons left it the working tree
-# alone. The English below the notice describes the same choice for a person;
-# the value is what a consumer reads, so the choice is not carried by prose.
+# alone. The English below it describes the same choice for a person; the
+# value is what a consumer reads, so the choice is not carried by prose.
 BASE=""
-BASE_VALUE=""
 if [ -z "$DEFAULT" ]; then
   BASE_VALUE=none
   JUDGED="the working tree alone: no origin/HEAD, main or master to compare against"
@@ -135,7 +203,7 @@ else
       BASE_VALUE=unrelated
       JUDGED="the working tree alone: HEAD shares no history with $DEFAULT"
       ;;
-    *) git_failed 'merge-base' "$BASE" ;;
+    *) refuse git 'merge-base' "$BASE" ;;
   esac
 fi
 
@@ -144,24 +212,22 @@ fi
 # suffix. Against a base, one diff covers the worktree and the index both;
 # without one, the two are read separately. Untracked paths are read in
 # either case: without them a stop whose only work is an untracked file
-# presents an empty changed set and produces no notice.
+# presents an empty changed set and nothing is named.
 if [ -n "$BASE" ]; then
-  CHANGED=$(git diff --name-only -z "$BASE" 2>&1 | tr '\0' '\n' 2>&1) || git_failed 'diff' "$CHANGED"
+  CHANGED=$(git diff --name-only -z "$BASE" 2>&1 | tr '\0' '\n' 2>&1) || refuse git 'diff' "$CHANGED"
   STAGED=""
 else
-  CHANGED=$(git diff --name-only -z 2>&1 | tr '\0' '\n' 2>&1) || git_failed 'diff' "$CHANGED"
+  CHANGED=$(git diff --name-only -z 2>&1 | tr '\0' '\n' 2>&1) || refuse git 'diff' "$CHANGED"
   STAGED=$(git diff --cached --name-only -z 2>&1 | tr '\0' '\n' 2>&1) ||
-    git_failed 'diff --cached' "$STAGED"
+    refuse git 'diff --cached' "$STAGED"
 fi
 UNTRACKED=$(git ls-files --others --exclude-standard --full-name -z -- :/ 2>&1 | tr '\0' '\n' 2>&1) ||
-  git_failed 'ls-files' "$UNTRACKED"
+  refuse git 'ls-files' "$UNTRACKED"
 # Each filter's own words are captured where the hook reads it: a bare
 # assignment would let sort or sed write first and leave the trap's keyed line
 # second. Both are silent when they succeed.
-ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u 2>&1 | sed '/^$/d' 2>&1) || {
-  notice exit "$?" "$ALL_CHANGED"
-  exit 0
-}
+ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u 2>&1 | sed '/^$/d' 2>&1) ||
+  refuse exit "$?" "$ALL_CHANGED"
 
 if [ -z "$ALL_CHANGED" ]; then
   exit 0
@@ -170,10 +236,8 @@ fi
 # A markdown path is a doc, whatever directory it sits in. Neither filter may
 # stop reading early: under pipefail an early-exiting reader turns the
 # producer's SIGPIPE into status 141, read as no match.
-CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) || {
-  notice exit "$?" "$CODE_CHANGED"
-  exit 0
-}
+CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) ||
+  refuse exit "$?" "$CODE_CHANGED"
 if [ -z "$CODE_CHANGED" ]; then
   exit 0
 fi
@@ -182,7 +246,7 @@ fi
 # cwd, and `*` crosses `/`, so this is every AGENTS.md below the root and
 # not the root's own, which covers nothing.
 AGENTS_DOCS=$(git ls-files -z --full-name -- ':(top)*/AGENTS.md' 2>&1 | tr '\0' '\n' 2>&1) ||
-  git_failed 'ls-files' "$AGENTS_DOCS"
+  refuse git 'ls-files' "$AGENTS_DOCS"
 
 # Topic files are read from the working tree, so a file written this session
 # already covers what it says it covers; a tracked one deleted this session
@@ -195,12 +259,10 @@ for topic in "$REPO_ROOT"/docs/architecture/*.md; do
   [ -f "$topic" ] || continue
   rel="docs/architecture/${topic##*/}"
   # sed and tr write their own reason where their output would have gone, so
-  # a failed read reaches the notice under its keyed line rather than before
+  # a failed read reaches the refusal under its keyed line rather than before
   # it. Both are silent when they succeed.
-  entries=$(sed -n 's/^Covers:[[:space:]]*//p' "$topic" 2>&1 | tr ',' ' ' 2>&1) || {
-    notice exit "$?" "$entries"
-    exit 0
-  }
+  entries=$(sed -n 's/^Covers:[[:space:]]*//p' "$topic" 2>&1 | tr ',' ' ' 2>&1) ||
+    refuse exit "$?" "$entries"
   set -f
   for covered in $entries; do
     covered="${covered#./}"
@@ -255,8 +317,6 @@ EOF
 # Every doc left unchanged while code it covers changed, with the first such
 # path; a doc is named once however many paths reached it.
 STALE_DOCS=""
-STALE=""
-STALE_COUNT=0
 while IFS= read -r path; do
   docs=$(covering_docs "$path")
   [ -n "$docs" ] || continue
@@ -286,5 +346,37 @@ if [ -z "$STALE" ]; then
   exit 0
 fi
 
-notice stale "$STALE_COUNT"
-exit 0
+SESSION_SHAPE='^[A-Za-z0-9._-]+$'
+if ! [[ "$SESSION" =~ $SESSION_SHAPE ]]; then
+  refuse session-id invalid
+fi
+
+# The marker's name has to tell one stale set from another, and a doc path can
+# hold bytes a filename cannot, so the set is hashed. The sort is what makes
+# two runs that reached the same documents by different paths agree on one
+# name; without it the block would repeat for a set already named.
+DIGEST=$( { printf '%s' "$STALE_DOCS" | sort | hash_set; } 2>&1 ) || refuse exit "$?" "$DIGEST"
+
+# The marker lives under the git COMMON dir so every linked worktree of the
+# repository shares it. rev-parse answers relative to the cwd when the dir
+# is nearby.
+COMMON_DIR=$(git rev-parse --git-common-dir 2>&1) ||
+  refuse git 'rev-parse --git-common-dir' "$COMMON_DIR"
+case "$COMMON_DIR" in
+  /*) ;;
+  *) COMMON_DIR="$PWD/$COMMON_DIR" ;;
+esac
+MARKER_DIR="$COMMON_DIR/kendex/doc-drift"
+MARKER="$MARKER_DIR/$SESSION-${DIGEST%% *}"
+if [ -e "$MARKER" ]; then
+  exit 0
+fi
+# Both probes are captured rather than left to write first: the group runs the
+# redirection in a subshell so the shell's own "cannot create" reaches the same
+# variable mkdir's message would.
+if ! MARKER_ERR=$(mkdir -p -- "$MARKER_DIR" 2>&1) ||
+  ! MARKER_ERR=$( { : >"$MARKER"; } 2>&1 ); then
+  refuse marker "$MARKER" "$MARKER_ERR"
+fi
+
+refuse stale "$STALE_COUNT"

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# doc-drift-check: an advisory Stop hook. Every changed non-markdown path is
-# matched against the nearest tracked non-root AGENTS.md above it and every
-# topic file whose Covers entry reaches it; a covering doc left unchanged is
-# named once on stdout as a lone {systemMessage} object, the notice Claude
-# Code shows. The changed set is read against the branch's merge-base with
-# the default branch, or the working tree alone where no base applies. The
-# hook always exits 0; a failed discovery command says so on stderr instead
-# of judging what it could not read.
+# doc-drift-check: a Stop hook that blocks once per stale-document set. Every
+# changed non-markdown path is matched against the nearest tracked non-root
+# AGENTS.md above it and every topic file whose Covers entry reaches it; a
+# covering doc left unchanged is named once on stderr with exit 2, the channel
+# the harness gives Claude, and stdout stays empty. The set is recorded under
+# `<git common dir>/kendex/doc-drift/<session_id>-<digest>`, so a later stop
+# naming that same set passes and a set that differs blocks once more. The
+# changed set is read against the branch's merge-base with the default branch,
+# or the working tree alone where no base applies. A payload, git state or
+# marker the hook cannot read or write is refused, never passed.
 #
 # A row is `label|<columns>`; each table names its columns in order:
 #   world    the row's repository, built fresh by `build` from these words:
@@ -14,30 +16,37 @@
 #            feat, origin/HEAD -> origin/main) or `norepo` (a bare directory)
 #            first; then the sealed additions and branch moves `build` lists;
 #            `subdir` runs the hook from ui/; `break:<cmd>` puts a git whose
-#            <cmd> dies (or a dying sed) first on PATH
+#            <cmd> dies (or a dying sed, jq or cat) first on PATH; `nopath`
+#            runs with an empty PATH; `sealed-marker` leaves the marker's
+#            parent directory unwritable
 #   change   the row's edits in order, from the words `change` lists;
 #            `stage` and `commit` take everything; `stopped` runs one Stop
-#            first; `-` for none
-#   payload  the Stop payload: `stop`, `active` (stop_hook_active true) or
-#            `raw` (not JSON); tables without the column feed `stop`
+#            first and `stopped-active` one with stop_hook_active; `-` for none
+#   payload  the Stop payload: `stop`, `stop2` (a second session), `active`
+#            (stop_hook_active true), `noid` (no session_id) or `raw` (not
+#            JSON); tables without the column feed `stop`
 #   rc       the exit status
-#   out      stdout reduced: `-` when empty; otherwise the notice's docs, each
-#            as `<doc>(<changed path>)`, sorted and joined by `,`; a stdout
-#            that is not a lone {systemMessage} object renders as
-#            `malformed:` and the text
-#   base     the notice's `doc-drift-check: base=` value: the ref the hook
+#   out      the documents the refusal names, each as `<doc>(<changed path>)`,
+#            sorted and joined by `,`; `-` when it names none. Anything on
+#            stdout renders as `stdout:` and the text, since the hook writes
+#            there at no time
+#   base     the refusal's `doc-drift-check: base=` value: the ref the hook
 #            compared against, or `default-branch`, `none` or `unrelated` for
 #            the three ways it is left the working tree alone; `-` without a
-#            notice
-#   stale    the notice's own first line, `doc-drift-check: stale=<count>`;
-#            `-` without a notice
-#   err      every stderr line by kind, in order, joined by `;`: the keyed
-#            first line of each report (`git=<subcommand>` for a failed probe,
-#            `exit=<n>` for the trap's) with the hook's name removed, a
-#            `fixture:` line (the broken command's own stderr, passed through)
-#            verbatim, and `git` once for each run of git's own words, which
-#            are not pinned; `-` when empty. The English under a keyed line is
-#            not read
+#            refusal
+#   stale    the refusal's own first line, `doc-drift-check: stale=<count>`;
+#            `-` without a refusal
+#   err      the keyed first line of each report in order, joined by `;`, with
+#            the hook's name removed; a `marker=` value renders as
+#            `marker=<path>`, pinning that the marker is reported rather than
+#            which path it was; a `fixture:` line (the broken command's own
+#            stderr, replayed under the key) verbatim; `-` when stderr is
+#            empty. The English under a keyed line is not read, and neither is
+#            a cause no fixture pinned
+#
+# HOOK_UNDER_TEST overrides the script under test so the must-fail controls
+# (a hook that exits 0 where it refuses, one that skips the marker, one keyed
+# on the session alone) can be run against these same assertions.
 set -euo pipefail
 
 # A suite running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
@@ -46,9 +55,11 @@ set -euo pipefail
 unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HOOK="$(cd "$TEST_DIR/.." && pwd)/doc-drift-check.sh"
+HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/doc-drift-check.sh}"
 TMP_ROOT="$(mktemp -d)"
-trap 'rm -rf -- "${TMP_ROOT:?}"' EXIT
+# A row that leaves a directory unwritable is cleaned up by restoring the mode
+# first; rm cannot unlink what a read-only parent holds.
+trap 'chmod -R u+rwx -- "${TMP_ROOT:?}" 2>/dev/null || :; rm -rf -- "${TMP_ROOT:?}"' EXIT
 PASS=0
 FAIL=0
 ROW=0
@@ -96,17 +107,19 @@ seal() {
 }
 
 # A PATH directory whose git dies on subcommand $1 with `fixture: $1 failed`
-# the way a broken index or unreadable refs would, or whose sed dies on
-# every call.
+# the way a broken index or unreadable refs would, or whose sed, jq or cat
+# dies on every call.
 broken() { # COMMAND
   local dir="$REPO.bin" real
   mkdir -p "$dir"
-  if [[ "$1" == sed || "$1" == jq ]]; then
-    printf '#!/usr/bin/env bash\necho "fixture: %s failed" >&2\nexit 19\n' "$1" >"$dir/$1"
-    chmod +x "$dir/$1"
-  else
-    real="$(command -v git)"
-    cat >"$dir/git" <<EOF
+  case "$1" in
+    sed | jq | cat)
+      printf '#!/usr/bin/env bash\necho "fixture: %s failed" >&2\nexit 19\n' "$1" >"$dir/$1"
+      chmod +x "$dir/$1"
+      ;;
+    *)
+      real="$(command -v git)"
+      cat >"$dir/git" <<EOF
 #!/usr/bin/env bash
 for a in "\$@"; do
   if [ "\$a" = "$1" ]; then
@@ -116,8 +129,9 @@ for a in "\$@"; do
 done
 exec "$real" "\$@"
 EOF
-    chmod +x "$dir/git"
-  fi
+      chmod +x "$dir/git"
+      ;;
+  esac
   printf '%s' "$dir"
 }
 
@@ -138,7 +152,10 @@ build() { # WORLD — the row's repository, its run directory and PATH
         fgit -C "$REPO" checkout -q -b feat
         ;;
       norepo) mkdir -p "$REPO" ;;
-      nodocs) fgit -C "$REPO" rm -q crates/core/AGENTS.md docs/architecture/core.md; seal ;;
+      nodocs)
+        fgit -C "$REPO" rm -q crates/core/AGENTS.md docs/architecture/core.md
+        seal
+        ;;
       crates-agents) printf '# crates\n' >"$REPO/crates/AGENTS.md"; seal ;;
       ignore-target) printf 'target/\n' >"$REPO/.gitignore"; seal ;;
       ui-topic)
@@ -162,6 +179,8 @@ build() { # WORLD — the row's repository, its run directory and PATH
       orphan) fgit -C "$REPO" checkout -q --orphan lone ;;
       subdir) RUN_DIR="$REPO/ui" ;;
       badconfig) printf 'this is not a config line\n' >"$REPO/.git/config" ;;
+      sealed-marker) mkdir -p "$REPO/.git/kendex"; chmod 500 "$REPO/.git/kendex" ;;
+      nopath) mkdir -p "$REPO.empty"; RUN_PATH="$REPO.empty" ;;
       break:*) RUN_PATH="$(broken "${word#break:}"):$PATH" ;;
       *) printf 'an unknown world word builds nothing: %s\n' "$word" >&2; exit 1 ;;
     esac
@@ -174,6 +193,7 @@ change() { # WORDS — the row's edits, in order
     case "$word" in
       -) ;;
       code) printf 'pub fn more() {}\n' >>"$REPO/crates/core/src/lib.rs" ;;
+      revert-code) fgit -C "$REPO" checkout -q -- crates/core/src/lib.rs ;;
       agents) printf 'more\n' >>"$REPO/crates/core/AGENTS.md" ;;
       topic) printf 'more\n' >>"$REPO/docs/architecture/core.md" ;;
       md) printf 'more\n' >>"$REPO/crates/core/README.md"; printf 'note\n' >"$REPO/crates/core/NOTES.md" ;;
@@ -188,35 +208,32 @@ change() { # WORDS — the row's edits, in order
       stage) fgit -C "$REPO" add -A ;;
       commit) fgit -C "$REPO" add -A; fgit -C "$REPO" commit -q -m step ;;
       stopped) run stop ;;
+      stopped-active) run active ;;
       *) printf 'an unknown change word changes nothing: %s\n' "$word" >&2; exit 1 ;;
     esac
   done
 }
 
-run() { # PAYLOAD — sets RC and MESSAGE (the systemMessage, empty when stdout is not the notice object)
+run() { # PAYLOAD — sets RC and MESSAGE (the hook's stderr)
   local payload
   case "$1" in
     stop) payload='{"session_id":"s1","hook_event_name":"Stop","stop_hook_active":false}' ;;
+    stop2) payload='{"session_id":"s2","hook_event_name":"Stop","stop_hook_active":false}' ;;
     active) payload='{"session_id":"s1","hook_event_name":"Stop","stop_hook_active":true}' ;;
+    noid) payload='{"hook_event_name":"Stop","stop_hook_active":false}' ;;
     raw) payload='not json' ;;
     *) printf 'an unknown payload word runs nothing: %s\n' "$1" >&2; exit 1 ;;
   esac
   RC=0
-  (cd "$RUN_DIR" && env HOME="$TMP_ROOT" PATH="$RUN_PATH" bash "$HOOK" <<<"$payload" \
+  # $BASH, not the name: the `nopath` row leaves no PATH to resolve it on.
+  (cd "$RUN_DIR" && env HOME="$TMP_ROOT" PATH="$RUN_PATH" "$BASH" "$HOOK" <<<"$payload" \
     >"$TMP_ROOT/stdout" 2>"$TMP_ROOT/stderr") || RC=$?
-  MESSAGE=""
-  # Slurped, so a second JSON value on stdout (which jq -e alone would read
-  # through, answering for the last) leaves MESSAGE empty and the row malformed.
-  if [[ -s "$TMP_ROOT/stdout" ]] && jq -es 'length == 1 and (.[0] | type == "object" and keys == ["systemMessage"] and (.systemMessage | type == "string" and length > 0))' \
-    <"$TMP_ROOT/stdout" >/dev/null 2>&1; then
-    MESSAGE="$(jq -rs '.[0].systemMessage' <"$TMP_ROOT/stdout")"
-  fi
+  MESSAGE="$(cat "$TMP_ROOT/stderr")"
 }
 
 out_text() {
   local line doc path out=""
-  [[ -s "$TMP_ROOT/stdout" ]] || { printf -- '-'; return; }
-  [[ "$MESSAGE" != "" ]] || { printf 'malformed:%s' "$(paste -s -d ';' - <"$TMP_ROOT/stdout")"; return; }
+  [[ ! -s "$TMP_ROOT/stdout" ]] || { printf 'stdout:%s' "$(paste -s -d ';' - <"$TMP_ROOT/stdout")"; return; }
   while IFS= read -r line; do
     case "$line" in
       "  "*" changed)")
@@ -227,14 +244,18 @@ out_text() {
         ;;
     esac
   done <<<"$MESSAGE"
+  [[ "$out" != "" ]] || { printf -- '-'; return; }
   printf '%s' "$out" | LC_ALL=C sort | paste -s -d ',' -
 }
 
-# The notice opens with two keyed lines, `stale=` then `base=`, so this reads
+# The refusal opens with two keyed lines, `stale=` then `base=`, so this reads
 # line 2 rather than searching for the key: a base line further down would not
 # be the contract.
 base_text() {
-  [[ "$MESSAGE" != "" ]] || { printf -- '-'; return; }
+  case "$MESSAGE" in
+    "doc-drift-check: stale="*) ;;
+    *) printf -- '-'; return ;;
+  esac
   printf '%s\n' "$MESSAGE" | sed -n '2s/^doc-drift-check: base=//p'
 }
 
@@ -243,18 +264,19 @@ err_text() {
   [[ -s "$TMP_ROOT/stderr" ]] || { printf -- '-'; return; }
   while IFS= read -r line; do
     case "$line" in
+      "doc-drift-check: marker="*) out="$out;marker=<path>" ;;
       "doc-drift-check: "*) out="$out;${line#doc-drift-check: }" ;;
-      "notice unavailable"*) ;;
       fixture:*) out="$out;$line" ;;
-      *) [[ "$out" == *";git" ]] || out="$out;git" ;;
     esac
   done <"$TMP_ROOT/stderr"
   printf '%s' "${out#;}"
 }
 
 stale_text() {
-  [[ "$MESSAGE" != "" ]] || { printf -- '-'; return; }
-  printf '%s' "${MESSAGE%%$'\n'*}"
+  case "$MESSAGE" in
+    "doc-drift-check: stale="*) printf '%s' "${MESSAGE%%$'\n'*}" ;;
+    *) printf -- '-' ;;
+  esac
 }
 
 run_table() { # TITLE COLUMNS ROWS
@@ -307,6 +329,7 @@ run_table() { # TITLE COLUMNS ROWS
 }
 
 CORE_DOCS='crates/core/AGENTS.md(crates/core/src/lib.rs),docs/architecture/core.md(crates/core/src/lib.rs)'
+CORE_AND_UI="$CORE_DOCS,docs/architecture/ui.md(crates/core/src/lib.rs)"
 
 run_table "coverage: which unchanged docs a changed path names" "world change out" "\
 a clean tree names nothing|repo|-|-
@@ -325,7 +348,7 @@ an untracked new file from a subdirectory is named by its repository path|repo s
 an ignored path is not a change|repo ignore-target|target|-
 a trailing-slash entry covers the directory|repo ui-topic|ui|docs/architecture/ui.md(ui/src/app.ts)
 a comma-joined entry covers the directory|repo ui-topic|lib|docs/architecture/ui.md(ui/lib/c.ts)
-a second topic naming the same directory is named beside the first|repo ui-topic|code|$CORE_DOCS,docs/architecture/ui.md(crates/core/src/lib.rs)
+a second topic naming the same directory is named beside the first|repo ui-topic|code|$CORE_AND_UI
 an exact file entry reaches its topic|repo selected-topic|ui|docs/architecture/selected.md(ui/src/app.ts)
 a glob entry reaches its topic, * crossing /|repo selected-topic|eval|docs/architecture/selected.md(crates/eval/src/eval_score.rs)
 a topic two paths reach is named once, with the first path|repo selected-topic|ui eval|docs/architecture/selected.md(crates/eval/src/eval_score.rs)
@@ -334,41 +357,56 @@ root entries cover nothing|repo root-topic|ui|-
 a non-ASCII path is code and keeps its bytes|repo|unicode|crates/core/AGENTS.md(crates/core/src/über.rs),docs/architecture/core.md(crates/core/src/über.rs)
 "
 
-run_table "base selection: what the branch is compared against" "world change out base" "\
-a committed change on a branch is judged against origin/HEAD|clone|code commit|$CORE_DOCS|origin/main
-an uncommitted doc change beside the committed code passes|clone|code commit agents|-|-
-a doc committed beside the code passes|clone|code agents commit|-|-
-a doc committed earlier on the branch passes|clone|topic commit code commit|-|-
-a commit on the default branch is not a change|clone on-main|code commit|-|-
-a working-tree change on the default branch is judged alone|clone on-main|code commit code|$CORE_DOCS|default-branch
-without origin/HEAD a local main is the base|repo on-feat|code commit|$CORE_DOCS|main
-main outranks master|repo with-master on-feat|code commit|$CORE_DOCS|main
-without main a local master is the base|repo master on-feat|code commit|$CORE_DOCS|master
-with no default branch a commit is not a change|repo trunk on-feat|code commit|-|-
-with no default branch the working tree is judged alone|repo trunk on-feat|code commit code|$CORE_DOCS|none
-a commit sharing no history with the default is not a change|repo orphan|code commit|-|-
-a branch sharing no history is judged on its working tree|repo orphan|code commit code|$CORE_DOCS|unrelated
+run_table "base selection: what the branch is compared against" "world change rc out base" "\
+a committed change on a branch is judged against origin/HEAD|clone|code commit|2|$CORE_DOCS|origin/main
+an uncommitted doc change beside the committed code passes|clone|code commit agents|0|-|-
+a doc committed beside the code passes|clone|code agents commit|0|-|-
+a doc committed earlier on the branch passes|clone|topic commit code commit|0|-|-
+a commit on the default branch is not a change|clone on-main|code commit|0|-|-
+a working-tree change on the default branch is judged alone|clone on-main|code commit code|2|$CORE_DOCS|default-branch
+without origin/HEAD a local main is the base|repo on-feat|code commit|2|$CORE_DOCS|main
+main outranks master|repo with-master on-feat|code commit|2|$CORE_DOCS|main
+without main a local master is the base|repo master on-feat|code commit|2|$CORE_DOCS|master
+with no default branch a commit is not a change|repo trunk on-feat|code commit|0|-|-
+with no default branch the working tree is judged alone|repo trunk on-feat|code commit code|2|$CORE_DOCS|none
+a commit sharing no history with the default is not a change|repo orphan|code commit|0|-|-
+a branch sharing no history is judged on its working tree|repo orphan|code commit code|2|$CORE_DOCS|unrelated
 "
 
-run_table "every Stop reports independently" "world change payload rc out err" "\
-a repeated stop with stop_hook_active reports the same notice again|repo|code stopped|active|0|$CORE_DOCS|-
-a payload that is not JSON does not stop the notice|repo|code|raw|0|$CORE_DOCS|-
+run_table "a set is named once per session" "world change payload rc out" "\
+the same set on a later stop passes|repo|code stopped|stop|0|-
+stop_hook_active passes|repo|code|active|0|-
+an active stop records nothing, so the set still blocks|repo|code stopped-active|stop|2|$CORE_DOCS
+another session is told the same set|repo|code stopped|stop2|2|$CORE_DOCS
+a set that gained a document blocks again|repo ui-topic|ui stopped code|stop|2|$CORE_AND_UI
+a set named earlier passes after another set intervened|repo ui-topic|ui stopped code stopped revert-code|stop|0|-
 "
 
-run_table "a failed discovery command is advisory" "world change rc out err" "\
-a dying command cannot hold the stop, and its words follow the key|repo break:sed|code|0|-|exit=19;fixture: sed failed
-a directory that is not a repository|norepo|-|0|-|git=rev-parse;git
-unreadable repository metadata|repo badconfig|code|0|-|git=rev-parse;git
-an unreadable changed set is not an empty one|repo break:ls-files|code|0|-|git=ls-files;fixture: ls-files failed
-a merge-base git cannot answer is not judged as the working tree|clone break:merge-base|code commit|0|-|git=merge-base;fixture: merge-base failed
-a default-branch probe git cannot answer is not read as absent|clone break:symbolic-ref|code commit|0|-|git=symbolic-ref;fixture: symbolic-ref failed
-a jq that cannot build the notice reports under its key, with its own words below|repo break:jq|code|0|-|exit=19;fixture: jq failed
+run_table "a state the hook cannot read or a marker it cannot write is refused" "world change payload rc out err" "\
+a dying command cannot be read as an empty change set, and its words follow the key|repo break:sed|code|stop|2|-|exit=19;fixture: sed failed
+a directory that is not a repository|norepo|-|stop|2|-|git=rev-parse
+unreadable repository metadata|repo badconfig|code|stop|2|-|git=rev-parse
+an unreadable changed set is not an empty one|repo break:ls-files|code|stop|2|-|git=ls-files;fixture: ls-files failed
+a merge-base git cannot answer is not judged as the working tree|clone break:merge-base|code commit|stop|2|-|git=merge-base;fixture: merge-base failed
+a default-branch probe git cannot answer is not read as absent|clone break:symbolic-ref|code commit|stop|2|-|git=symbolic-ref;fixture: symbolic-ref failed
+a payload that cannot be read|repo break:cat|code|stop|2|-|payload=unreadable;fixture: cat failed
+a payload that is not JSON|repo|code|raw|2|-|payload=invalid-json
+a jq that cannot answer for the payload, with its own words below|repo break:jq|code|stop|2|-|payload=invalid-json;fixture: jq failed
+a payload carrying no session id|repo|code|noid|2|-|session-id=invalid
+a marker that cannot be recorded|repo sealed-marker|code|stop|2|-|marker=<path>
+no command the hook runs on PATH|repo nopath|code|stop|2|-|missing-tools=jq,git,cat,sed,sort,tr,dirname,grep,mkdir,sha256sum
 "
 
-run_table "the notice's own first line counts what it names" "world change stale" "\
-two covering docs are a count of two|repo|code|doc-drift-check: stale=2
-one covering doc is a count of one|repo ui-topic|ui|doc-drift-check: stale=1
-nothing unchanged and covered writes no notice at all|repo|-|-
+run_table "a state the hook cannot read is refused only where a set is named" "world change payload rc err" "\
+a clean tree with no session id in the payload passes|repo|-|noid|0|-
+a clean tree whose marker directory is unwritable passes|repo sealed-marker|-|stop|0|-
+a markdown-only change with no session id passes|repo|md|noid|0|-
+"
+
+run_table "the refusal's own first line counts what it names" "world change rc stale" "\
+two covering docs are a count of two|repo|code|2|doc-drift-check: stale=2
+one covering doc is a count of one|repo ui-topic|ui|2|doc-drift-check: stale=1
+nothing unchanged and covered is not refused|repo|-|0|-
 "
 
 printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -181,6 +181,14 @@ build() { # WORLD — the row's repository, its run directory and PATH
       badconfig) printf 'this is not a config line\n' >"$REPO/.git/config" ;;
       sealed-marker) mkdir -p "$REPO/.git/kendex"; chmod 500 "$REPO/.git/kendex" ;;
       nopath) mkdir -p "$REPO.empty"; RUN_PATH="$REPO.empty" ;;
+      payload-tools-only)
+        # The two commands the hook may call before it reads the payload, and
+        # nothing else: the row asks what a discovery-only absence does.
+        mkdir -p "$REPO.only"
+        ln -sf -- "$(command -v jq)" "$REPO.only/jq"
+        ln -sf -- "$(command -v cat)" "$REPO.only/cat"
+        RUN_PATH="$REPO.only"
+        ;;
       break:*) RUN_PATH="$(broken "${word#break:}"):$PATH" ;;
       *) printf 'an unknown world word builds nothing: %s\n' "$word" >&2; exit 1 ;;
     esac
@@ -394,7 +402,13 @@ a payload that is not JSON|repo|code|raw|2|-|payload=invalid-json
 a jq that cannot answer for the payload, with its own words below|repo break:jq|code|stop|2|-|payload=invalid-json;fixture: jq failed
 a payload carrying no session id|repo|code|noid|2|-|session-id=invalid
 a marker that cannot be recorded|repo sealed-marker|code|stop|2|-|marker=<path>
-no command the hook runs on PATH|repo nopath|code|stop|2|-|missing-tools=jq,git,cat,sed,sort,tr,dirname,grep,mkdir,sha256sum
+no command the hook runs on PATH names the payload readers alone|repo nopath|code|stop|2|-|missing-tools=jq,cat
+only the payload readers on PATH names the rest|repo payload-tools-only|code|stop|2|-|missing-tools=git,sed,sort,tr,dirname,grep,mkdir,sha256sum
+"
+
+run_table "which absence still refuses the retry stop_hook_active passes" "world change payload rc err" "\
+a discovery command missing on an active stop passes|repo payload-tools-only|code|active|0|-
+a payload reader missing refuses the active stop too, the flag being in the payload it cannot read|repo nopath|code|active|2|missing-tools=jq,cat
 "
 
 run_table "a state the hook cannot read is refused only where a set is named" "world change payload rc err" "\

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -17,8 +17,9 @@
 #            first; then the sealed additions and branch moves `build` lists;
 #            `subdir` runs the hook from ui/; `break:<cmd>` puts a git whose
 #            <cmd> dies (or a dying sed, jq or cat) first on PATH; `nopath`
-#            runs with an empty PATH; `sealed-marker` leaves the marker's
-#            parent directory unwritable
+#            runs with an empty PATH, `payload-tools-only` with jq and cat
+#            alone and `shasum-only` with every command but sha256sum;
+#            `sealed-marker` leaves the marker's parent directory unwritable
 #   change   the row's edits in order, from the words `change` lists;
 #            `stage` and `commit` take everything; `stopped` runs one Stop
 #            first and `stopped-active` one with stop_hook_active; `-` for none
@@ -135,6 +136,19 @@ EOF
   printf '%s' "$dir"
 }
 
+# A PATH directory holding the named commands and nothing else, so a row can
+# ask what the hook does without one it does not name. A command this machine
+# lacks links to nothing and the hook reports it missing, which fails the row
+# rather than quietly skipping it.
+only_tools() { # COMMAND... — prints the directory
+  local dir="$REPO.only" cmd
+  mkdir -p "$dir"
+  for cmd in "$@"; do
+    ln -sf -- "$(command -v "$cmd")" "$dir/$cmd"
+  done
+  printf '%s' "$dir"
+}
+
 build() { # WORLD — the row's repository, its run directory and PATH
   local word
   ROW=$((ROW + 1))
@@ -184,10 +198,15 @@ build() { # WORLD — the row's repository, its run directory and PATH
       payload-tools-only)
         # The two commands the hook may call before it reads the payload, and
         # nothing else: the row asks what a discovery-only absence does.
-        mkdir -p "$REPO.only"
-        ln -sf -- "$(command -v jq)" "$REPO.only/jq"
-        ln -sf -- "$(command -v cat)" "$REPO.only/cat"
-        RUN_PATH="$REPO.only"
+        RUN_PATH="$(only_tools jq cat)"
+        ;;
+      shasum-only)
+        # A stock macOS: shasum and no sha256sum. Both CI legs carry GNU
+        # sha256sum — the macOS leg links it onto PATH itself
+        # (.github/workflows/skill-tests.yml, the supplied-utilities step) — so
+        # a PATH holding every command but that one is the only place the
+        # fallback runs.
+        RUN_PATH="$(only_tools jq cat git sed sort tr dirname grep mkdir shasum)"
         ;;
       break:*) RUN_PATH="$(broken "${word#break:}"):$PATH" ;;
       *) printf 'an unknown world word builds nothing: %s\n' "$word" >&2; exit 1 ;;
@@ -409,6 +428,11 @@ only the payload readers on PATH names the rest|repo payload-tools-only|code|sto
 run_table "which absence still refuses the retry stop_hook_active passes" "world change payload rc err" "\
 a discovery command missing on an active stop passes|repo payload-tools-only|code|active|0|-
 a payload reader missing refuses the active stop too, the flag being in the payload it cannot read|repo nopath|code|active|2|missing-tools=jq,cat
+"
+
+run_table "shasum names the set where a stock macOS has no sha256sum" "world change payload rc out" "\
+a set is named with shasum alone|repo shasum-only|code|stop|2|$CORE_DOCS
+the same set on a later stop passes, so shasum names it the same way twice|repo shasum-only|code stopped|stop|0|-
 "
 
 run_table "a state the hook cannot read is refused only where a set is named" "world change payload rc err" "\

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -44,7 +44,7 @@ Review and QA-review belong to the reviewer skill: [`../reviewer/workflows/revie
 - Before adding a function, parser, stub or loop, grep the repo for the verb it performs; before stating a rule, grep for the rule.
   - A second copy of that verb, in any language, is a twin and never delegation, and so is a second statement of a rule another file owns, in prose, config or a table.
   - Call or cite the one that exists, or escalate in your return. An issue that orders a twin is escalated, not implemented.
-- Docs move with the code they describe; the `docs-writing` skill states the rule and the `doc-drift-check` hook shows the user docs that may need an update.
+- Docs move with the code they describe; the `docs-writing` skill states the rule and the `doc-drift-check` hook names the docs that may need an update.
 - Once a pushed head has been reviewed, later rounds add commits and never amend; before any review has run on a head, the kendex-issues fix cycle may amend only to refresh a required check that cannot be rerun.
 - A push that prints `rebase-map:` lines has rewritten the shas the PR's `Fixed in <sha>` replies name: before holding, re-reply each such thread with the new sha, or post the map as one PR comment naming old and new per line; a sha the map reports as `dropped` gets a reply that the fix commit no longer exists on the branch.
 

--- a/skills/docs-writing/SKILL.md
+++ b/skills/docs-writing/SKILL.md
@@ -139,7 +139,7 @@ The `changelog-entries` lane owns the shape. Follow the repository's `changelog.
 
 ## Format
 
-- Docs change in the same commit as the code they describe. The `doc-drift-check` hook shows unchanged covering docs to the user as a notice; it does not block a stop.
+- Docs change in the same commit as the code they describe. The `doc-drift-check` hook names the unchanged covering docs to the agent and blocks that stop once per set.
 - One paragraph per line, one list item per line, no hard wraps inside either. Blank lines separate paragraphs, list blocks, headings, and fences. Tables and fenced code stay as written. The commit-guards `md-format` lane enforces it and `md-reflow` converts a file once.
 - Every relative link, `<path>.md § Heading` or `<path>.md#anchor` citation, and decision ID resolves. The `md-refs` lane checks them.
 - Agent-loaded markdown carries no history. The `prose` lane checks it.


### PR DESCRIPTION
`doc-drift-check` named the documents that cover changed code and did not change, then sent them to a `{"systemMessage": ...}` object on stdout — the one channel the model never reads. In an unattended session the list was built, formatted and discarded. The reporter saw nine documents across several turns, one of them a real gap, reach the model only by hand.

The list now goes to the agent: stderr with exit 2, the channel the harness gives Claude and the one every other hook in this package refuses on. stdout carries nothing, and no user-facing notice is written alongside — the header states that audience decision. A stop blocks once per set of stale documents: the sorted set is hashed and recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest>`, so a stop naming a set already shown passes, and only a set that gained or lost a document blocks again. `stop_hook_active` true passes outright, as `reviewer-stop-check` does.

## Requirement to file

| Requirement | File |
| --- | --- |
| The stale-document list reaches the agent, not the user | `hooks/doc-drift-check.sh` (refusal on stderr with exit 2, nothing on stdout) |
| A set blocks once and then passes | `hooks/doc-drift-check.sh` (`<session_id>-<digest>` marker under the git common dir, `stop_hook_active` honoured) |
| The stable first lines survive the channel change | `hooks/doc-drift-check.sh` (`stale=<count>` then `base=<ref>`, positions 1 and 2) |
| The suite asserts key, value and exit status | `hooks/tests/doc-drift-check.test.sh` |
| The committed render lands with the source | `.claude/hooks/doc-drift-check.sh` |
| Prose that stated the old audience and the old exit | `skills/docs-writing/SKILL.md`, `skills/dev/SKILL.md`, and their `.agents/` renders |
| The unreleased fragment stated the notice-only behaviour | `changelog.d/added/doc-drift-hook.md` |
| A missing command must not refuse the retry the flag passes (review round 1) | `hooks/doc-drift-check.sh` (payload readers checked before the payload, the rest after `stop_hook_active`) |
| The shasum fallback a stock macOS uses runs in the suite (review round 2) | `hooks/tests/doc-drift-check.test.sh` (`shasum-only` world, two rows) |

## What the issue got wrong, and what it changes

The issue says a block "as it stands would wedge every turn that has pending drift" because the hook is stateless. The hook before #2133 was not stateless: `1ed1a4eb0^` keeps a marker per `session_id` under this same `kendex/doc-drift/` directory and blocks once per session. (One such bare `<session_id>` file is still sitting in this repository's own common dir, which is why the new names are `<session>-<digest>` and cannot collide with it.)

The actual reason #2133 removed blocking is the guards evaluation's doc-drift row: "The same unchanged documents block once and pass on the next stop. A notice can name relevant docs without pretending to enforce an update or costing a retry turn." Keying the marker on the set rather than the session is the answer to that finding: a block is no longer a repeat of something the session was already shown, so each retry turn it costs carries a list the agent has not seen. The hook still enforces nothing — an agent may read the list, decide every document holds, and finish.

## Failures refuse instead of passing

Every failure path — an unreadable payload, a payload carrying no `session_id`, a git state git cannot answer for, a marker that cannot be written, a command missing from PATH — now refuses with its keyed line rather than exiting 0. This is the same defect as the notice: at exit 0 the harness routes a hook's output to its debug log, so those reports reached nobody either, and `hooks/AGENTS.md` already requires that a payload a hook cannot read is a refusal and never a pass. `stop_hook_active` caps each at one retry. The commands the hook runs are checked before it calls them, as `reviewer-stop-check` checks its own: without that, a missing command lets the shell write `command not found` ahead of the keyed line and leaves a status the harness reads as a plain error rather than a refusal. The check is split at the payload read — jq and cat first, the discovery commands and the sha256 tool after `stop_hook_active` — so a discovery absence costs one retry instead of refusing the retry as well.

`sha256sum` names the set, falling back to `shasum -a 256` where macOS ships no `sha256sum` — the spelling `skills/linear/scripts/lib/common.sh` already uses. A document path can hold bytes a filename cannot, so the marker is named by a digest of the sorted set; sorting is what makes the name depend on the set alone rather than on the order the documents were discovered in.

## Validation

- `hooks/tests/doc-drift-check.test.sh`: 65 passed, 0 failed. Every other suite under `hooks/tests/` passes.
- Thirteen must-fail controls planted, thirteen caught: the stale block, the refusal exit status, the marker dismissal, per-set keying, `stop_hook_active`, the payload-reader check, the discovery-command check, the position of that check relative to the flag, the shasum selection, the shasum fallback itself, the marker-write refusal, the session-id refusal, and the empty stdout.
- preflight `clean=8`; doc-limits 780 documents OK; `tools/bash32-lint` clean=542; the armed pre-commit chain `result=0`, its repo-local `tools/guard` lane included.
- `env -u TMPDIR tools/guard --full` exits 0 on the final head, with no `guard:` failure line in its log.

This is a production hook change; consumers carrying `.claude/hooks/doc-drift-check.sh` need the refresh train after merge.

Closes KEN-1313
Closes #2497

https://claude.ai/code/session_01K4ji1PoRcBTpc4U9bhpoA3
